### PR TITLE
added update_cold_storage_purge_date to archive client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - `departure_date` is now an optional parameter for `sdk.detectionlists.departing_employee.add()`.
 
+- Added `sdk.archives.update_cold_storage_purge_date()`, allowing the changing of the date at which a cold storage archive will be purged.
+
 ## 1.0.0 - 2020-04-21
 
 ### Changed

--- a/src/py42/_internal/clients/archive.py
+++ b/src/py42/_internal/clients/archive.py
@@ -34,3 +34,9 @@ class ArchiveClient(BaseClient):
         uri = u"/api/WebRestoreInfo"
         params = {u"srcGuid": src_guid, u"destGuid": dest_guid}
         return self._session.get(uri, params=params)
+
+    def update_cold_storage_purge_date(self, archive_guid, purge_date):
+        uri = u"/api/coldStorage/{0}".format(archive_guid)
+        params = {u"idType": u"guid"}
+        data = {u"archiveHoldExpireDate": purge_date}
+        return self._session.put(uri, params=params, data=json.dumps(data))

--- a/src/py42/modules/archive.py
+++ b/src/py42/modules/archive.py
@@ -109,13 +109,13 @@ class ArchiveModule(object):
 
     def update_cold_storage_purge_date(self, archive_guid, purge_date):
         """Updates the cold storage purge date for a specified archive.
-        REST Documentation <https://www.crashplan.com/apidocviewer/#ColdStorage-put>
+        `REST Documentation <https://console.us.code42.com/apidocviewer/#ColdStorage-put>`__
 
         Args:
             archive_guid (str): The identification number of the archive that should be updated
             purge_date (str): The date on which the archive should be purged in yyyy-MM-dd format
 
         Returns:
-            :class: py42.response.Py42Response: the response from the ColdStorage API.
+            :class: `py42.response.Py42Response`: the response from the ColdStorage API.
         """
         return self._archive_client.update_cold_storage_purge_date(archive_guid, purge_date)

--- a/src/py42/modules/archive.py
+++ b/src/py42/modules/archive.py
@@ -106,3 +106,16 @@ class ArchiveModule(object):
             that each contain a page of restore history.
         """
         return self._archive_client.get_all_restore_history(days, u"computerId", device_id)
+
+    def update_cold_storage_purge_date(self, archive_guid, purge_date):
+        """Updates the cold storage purge date for a specified archive.
+        REST Documentation <https://www.crashplan.com/apidocviewer/#ColdStorage-put>
+
+        Args:
+            archive_guid (str): The identification number of the archive that should be updated
+            purge_date (str): The date on which the archive should be purged in yyyy-MM-dd format
+
+        Returns:
+            :class: py42.response.Py42Response: the response from the ColdStorage API.
+        """
+        return self._archive_client.update_cold_storage_purge_date(archive_guid, purge_date)

--- a/src/py42/modules/archive.py
+++ b/src/py42/modules/archive.py
@@ -116,6 +116,6 @@ class ArchiveModule(object):
             purge_date (str): The date on which the archive should be purged in yyyy-MM-dd format
 
         Returns:
-            :class: `py42.response.Py42Response`: the response from the ColdStorage API.
+            :class:`py42.response.Py42Response`: the response from the ColdStorage API.
         """
         return self._archive_client.update_cold_storage_purge_date(archive_guid, purge_date)

--- a/tests/_internal/clients/test_archive.py
+++ b/tests/_internal/clients/test_archive.py
@@ -1,5 +1,6 @@
 import pytest
 from requests import Response
+import json
 
 import py42.settings
 from py42._internal.clients.archive import ArchiveClient
@@ -43,3 +44,14 @@ class TestArchiveClient(object):
             pass
         py42.settings.items_per_page = 1000
         assert mock_session.get.call_count == 3
+
+    def test_update_cold_storage_purge_date_calls_coldstorage_with_expected_data(
+        self, mock_session
+    ):
+        client = ArchiveClient(mock_session)
+        client.update_cold_storage_purge_date(u"123", u"2020-04-24")
+        mock_session.put.assert_called_once_with(
+            u"/api/coldStorage/123",
+            params={u"idType": u"guid"},
+            data=json.dumps({u"archiveHoldExpireDate": u"2020-04-24"}),
+        )

--- a/tests/modules/test_archive.py
+++ b/tests/modules/test_archive.py
@@ -40,3 +40,12 @@ class TestArchiveModule(object):
         archive._archive_client.get_all_restore_history.assert_called_once_with(
             self._TEST_DAYS, "computerId", self._TEST_ID
         )
+
+    def test_update_cold_storage_purge_date_calls_update_cold_storage_with_expected_data(
+        self, mocker
+    ):
+        archive = _get_module(mocker)
+        archive.update_cold_storage_purge_date(u"123", u"2020-04-24")
+        archive._archive_client.update_cold_storage_purge_date.assert_called_once_with(
+            u"123", u"2020-04-24"
+        )


### PR DESCRIPTION
This request adds an update_cold_storage_purge_date to the archive client. This functionality is used by PS in our deactivate devices script, which we would like to re-implement using py42.

I'm pretty new to all of this and I'm not sure I did things right, so please let me know if I should make any changes, or if there's better ways to do things.