### PR TITLE
Feature/cold storage get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Added
+
+- `get_all_org_cold_storage_archives()` function to `ArchiveModule`, available at `sdk.archive.get_all_org_cold_storage_archives()`.
+
+
 ## 1.3.0 - 2020-06-02
 
 ### Added

--- a/src/py42/_internal/clients/archive.py
+++ b/src/py42/_internal/clients/archive.py
@@ -35,15 +35,38 @@ class ArchiveClient(BaseClient):
         params = {u"srcGuid": src_guid, u"destGuid": dest_guid}
         return self._session.get(uri, params=params)
 
-    def get_all_cold_storage_archives_by_org_id(
-        self, org_id, inc_child_orgs=True, sort_key="archiveHoldExpireDate", sort_dir="asc"
+    def _get_cold_storage_archives_page(
+        self,
+        org_id=None,
+        include_child_orgs=None,
+        sort_key="archiveHoldExpireDate",
+        sort_dir="asc",
+        page_size=None,
+        page_num=None,
     ):
-        pass
+        uri = u"/api/ColdStorage"
+        params = {
+            u"orgId": org_id,
+            u"incChildOrgs": include_child_orgs,
+            u"srtKey": sort_key,
+            u"srtDir": sort_dir,
+            u"pgSize": page_size,
+            u"pgNum": page_num,
+        }
 
-    def get_all_cold_storage_archives_by_destination_guid(
-        self, destination_guid, sort_key="archiveHoldExpireDate", sort_dir="asc"
+        return self._session.get(uri, params=params)
+
+    def get_all_org_cold_storage_archives(
+        self, org_id, include_child_orgs=True, sort_key="archiveHoldExpireDate", sort_dir="asc"
     ):
-        pass
+        return get_all_pages(
+            self._get_cold_storage_archives_page,
+            u"coldStorageRows",
+            org_id=org_id,
+            include_child_orgs=include_child_orgs,
+            sort_key=sort_key,
+            sort_dir=sort_dir,
+        )
 
     def update_cold_storage_purge_date(self, archive_guid, purge_date):
         uri = u"/api/coldStorage/{0}".format(archive_guid)

--- a/src/py42/_internal/clients/archive.py
+++ b/src/py42/_internal/clients/archive.py
@@ -36,12 +36,12 @@ class ArchiveClient(BaseClient):
         return self._session.get(uri, params=params)
 
     def get_all_cold_storage_archives_by_org_id(
-        self, org_id, inc_child_orgs=True, sort_key=None, sort_dir="asc"
+        self, org_id, inc_child_orgs=True, sort_key="archiveHoldExpireDate", sort_dir="asc"
     ):
         pass
 
     def get_all_cold_storage_archives_by_destination_guid(
-        self, destination_guid, sort_key=None, sort_dir="asc"
+        self, destination_guid, sort_key="archiveHoldExpireDate", sort_dir="asc"
     ):
         pass
 

--- a/src/py42/_internal/clients/archive.py
+++ b/src/py42/_internal/clients/archive.py
@@ -35,6 +35,16 @@ class ArchiveClient(BaseClient):
         params = {u"srcGuid": src_guid, u"destGuid": dest_guid}
         return self._session.get(uri, params=params)
 
+    def get_all_cold_storage_archives_by_org_id(
+        self, org_id, inc_child_orgs=True, sort_key=None, sort_dir="asc"
+    ):
+        pass
+
+    def get_all_cold_storage_archives_by_destination_guid(
+        self, destination_guid, sort_key=None, sort_dir="asc"
+    ):
+        pass
+
     def update_cold_storage_purge_date(self, archive_guid, purge_date):
         uri = u"/api/coldStorage/{0}".format(archive_guid)
         params = {u"idType": u"guid"}

--- a/src/py42/modules/archive.py
+++ b/src/py42/modules/archive.py
@@ -123,31 +123,33 @@ class ArchiveModule(object):
     def get_all_cold_storage_archives_by_org_id(
         self, org_id, include_child_orgs=True, sort_key=None, sort_dir="asc"
     ):
-        """[summary]
+        """Returns a detailed list of cold storage archive information for a given org ID.
 
         Args:
-            org_id ([type]): [description]
-            include_child_orgs (bool, optional): [description]. Defaults to True.
-            sort_key ([type], optional): [description]. Defaults to None.
-            sort_dir (str, optional): [description]. Defaults to "asc".
+            org_id (str): The ID of a Code42 organization.
+            include_child_orgs (bool, optional): Determines whether cold storage information from the Org's children is also returned. Defaults to True.
+            sort_key (str, optional): Sets the property by which the returned results will be sorted. Choose from orgName, mountPointName, archiveBytes, and archiveType. Defaults to None.
+            sort_dir (str, optional): Sets the order by which sort_key should be sorted. Choose from asc or desc. Defaults to "asc".
 
         Returns:
-            [type]: [description]
+            generator: An object that iterates over :class:`py42.response.Py42Response` objects
+            that each contain a page of cold storage archive information.
         """
         return self.get_all_cold_storage_archives_by_org_id(org_id)
 
     def get_all_cold_storage_archives_by_destination_guid(
         self, destination_guid, sort_key=None, sort_dir="asc"
     ):
-        """[summary]
+        """Returns a detailed list of cold storage archive information for a given destination guid.
 
         Args:
-            destination_guid ([type]): [description]
-            sort_key ([type], optional): [description]. Defaults to None.
-            sort_dir (str, optional): [description]. Defaults to "asc".
+            destination_guid (str): The GUID of the destination on which the returned archives are stored.
+            sort_key (str, optional): Sets the property by which the returned results will be sorted. Choose from orgName, mountPointName, archiveBytes, and archiveType. Defaults to None.
+            sort_dir (str, optional): Sets the order by which sort_key should be sorted. Choose from asc or desc. Defaults to "asc".
 
         Returns:
-            [type]: [description]
+            generator: An object that iterates over :class:`py42.response.Py42Response` objects
+            that each contain a page of cold storage archive information.
         """
         return self._archive_client.get_all_cold_storage_archives_by_destination_guid(
             destination_guid

--- a/src/py42/modules/archive.py
+++ b/src/py42/modules/archive.py
@@ -119,3 +119,36 @@ class ArchiveModule(object):
             :class:`py42.response.Py42Response`: the response from the ColdStorage API.
         """
         return self._archive_client.update_cold_storage_purge_date(archive_guid, purge_date)
+
+    def get_all_cold_storage_archives_by_org_id(
+        self, org_id, include_child_orgs=True, sort_key=None, sort_dir="asc"
+    ):
+        """[summary]
+
+        Args:
+            org_id ([type]): [description]
+            include_child_orgs (bool, optional): [description]. Defaults to True.
+            sort_key ([type], optional): [description]. Defaults to None.
+            sort_dir (str, optional): [description]. Defaults to "asc".
+
+        Returns:
+            [type]: [description]
+        """
+        return self.get_all_cold_storage_archives_by_org_id(org_id)
+
+    def get_all_cold_storage_archives_by_destination_guid(
+        self, destination_guid, sort_key=None, sort_dir="asc"
+    ):
+        """[summary]
+
+        Args:
+            destination_guid ([type]): [description]
+            sort_key ([type], optional): [description]. Defaults to None.
+            sort_dir (str, optional): [description]. Defaults to "asc".
+
+        Returns:
+            [type]: [description]
+        """
+        return self._archive_client.get_all_cold_storage_archives_by_destination_guid(
+            destination_guid
+        )

--- a/src/py42/modules/archive.py
+++ b/src/py42/modules/archive.py
@@ -132,7 +132,7 @@ class ArchiveModule(object):
             sort_key (str, optional): Sets the property by which the returned results will be sorted.
              Choose from archiveHoldExpireDate, orgName, mountPointName, archiveBytes, and archiveType. Defaults to archiveHoldExpireDate.
             sort_dir (str, optional): Sets the order by which sort_key should be sorted. Choose from
-             asc or desc. Defaults to "asc".
+             asc or desc. Defaults to asc.
 
         Returns:
             generator: An object that iterates over :class:`py42.response.Py42Response` objects

--- a/src/py42/modules/archive.py
+++ b/src/py42/modules/archive.py
@@ -121,15 +121,18 @@ class ArchiveModule(object):
         return self._archive_client.update_cold_storage_purge_date(archive_guid, purge_date)
 
     def get_all_cold_storage_archives_by_org_id(
-        self, org_id, include_child_orgs=True, sort_key=None, sort_dir="asc"
+        self, org_id, include_child_orgs=True, sort_key="archiveHoldExpireDate", sort_dir="asc"
     ):
         """Returns a detailed list of cold storage archive information for a given org ID.
 
         Args:
             org_id (str): The ID of a Code42 organization.
-            include_child_orgs (bool, optional): Determines whether cold storage information from the Org's children is also returned. Defaults to True.
-            sort_key (str, optional): Sets the property by which the returned results will be sorted. Choose from orgName, mountPointName, archiveBytes, and archiveType. Defaults to None.
-            sort_dir (str, optional): Sets the order by which sort_key should be sorted. Choose from asc or desc. Defaults to "asc".
+            include_child_orgs (bool, optional): Determines whether cold storage information from
+             the Org's children is also returned. Defaults to True.
+            sort_key (str, optional): Sets the property by which the returned results will be sorted.
+             Choose from archiveHoldExpireDate, orgName, mountPointName, archiveBytes, and archiveType. Defaults to archiveHoldExpireDate.
+            sort_dir (str, optional): Sets the order by which sort_key should be sorted. Choose from
+             asc or desc. Defaults to "asc".
 
         Returns:
             generator: An object that iterates over :class:`py42.response.Py42Response` objects
@@ -138,14 +141,18 @@ class ArchiveModule(object):
         return self.get_all_cold_storage_archives_by_org_id(org_id)
 
     def get_all_cold_storage_archives_by_destination_guid(
-        self, destination_guid, sort_key=None, sort_dir="asc"
+        self, destination_guid, sort_key="archiveHoldExpireDate", sort_dir="asc"
     ):
         """Returns a detailed list of cold storage archive information for a given destination guid.
 
         Args:
-            destination_guid (str): The GUID of the destination on which the returned archives are stored.
-            sort_key (str, optional): Sets the property by which the returned results will be sorted. Choose from orgName, mountPointName, archiveBytes, and archiveType. Defaults to None.
-            sort_dir (str, optional): Sets the order by which sort_key should be sorted. Choose from asc or desc. Defaults to "asc".
+            destination_guid (str): The GUID of the destination on which the returned archives
+             are stored.
+            sort_key (str, optional): Sets the property by which the returned results
+             will be sorted. Choose from archiveHoldExpireDate, orgName, mountPointName,
+              archiveBytes, and archiveType. Defaults to archiveHoldExpireDate.
+            sort_dir (str, optional): Sets the order by which sort_key should be sorted. Choose
+             from asc or desc. Defaults to "asc".
 
         Returns:
             generator: An object that iterates over :class:`py42.response.Py42Response` objects

--- a/src/py42/modules/archive.py
+++ b/src/py42/modules/archive.py
@@ -120,7 +120,7 @@ class ArchiveModule(object):
         """
         return self._archive_client.update_cold_storage_purge_date(archive_guid, purge_date)
 
-    def get_all_cold_storage_archives_by_org_id(
+    def get_all_org_cold_storage_archives(
         self, org_id, include_child_orgs=True, sort_key="archiveHoldExpireDate", sort_dir="asc"
     ):
         """Returns a detailed list of cold storage archive information for a given org ID.
@@ -138,26 +138,4 @@ class ArchiveModule(object):
             generator: An object that iterates over :class:`py42.response.Py42Response` objects
             that each contain a page of cold storage archive information.
         """
-        return self.get_all_cold_storage_archives_by_org_id(org_id)
-
-    def get_all_cold_storage_archives_by_destination_guid(
-        self, destination_guid, sort_key="archiveHoldExpireDate", sort_dir="asc"
-    ):
-        """Returns a detailed list of cold storage archive information for a given destination guid.
-
-        Args:
-            destination_guid (str): The GUID of the destination on which the returned archives
-             are stored.
-            sort_key (str, optional): Sets the property by which the returned results
-             will be sorted. Choose from archiveHoldExpireDate, orgName, mountPointName,
-              archiveBytes, and archiveType. Defaults to archiveHoldExpireDate.
-            sort_dir (str, optional): Sets the order by which sort_key should be sorted. Choose
-             from asc or desc. Defaults to "asc".
-
-        Returns:
-            generator: An object that iterates over :class:`py42.response.Py42Response` objects
-            that each contain a page of cold storage archive information.
-        """
-        return self._archive_client.get_all_cold_storage_archives_by_destination_guid(
-            destination_guid
-        )
+        return self._archive_client.get_all_org_cold_storage_archives(org_id)

--- a/tests/_internal/clients/test_archive.py
+++ b/tests/_internal/clients/test_archive.py
@@ -13,10 +13,14 @@ MOCK_GET_ORG_RESTORE_HISTORY_RESPONSE = (
 
 MOCK_EMPTY_GET_ORG_RESTORE_HISTORY_RESPONSE = """{"totalCount": 3000, "restoreEvents": []}"""
 
+MOCK_GET_ORG_COLD_STORAGE_RESPONSE = """{"coldStorageRows": [{"archiveGuid": "fakeguid"}]}"""
+
+MOCK_EMPTY_GET_ORG_COLD_STORAGE_RESPONSE = """{"coldStorageRows": []}"""
+
 
 class TestArchiveClient(object):
     @pytest.fixture
-    def mock_get_all_response(self, mocker):
+    def mock_get_all_restore_history_response(self, mocker):
         response = mocker.MagicMock(spec=Response)
         response.status_code = 200
         response.encoding = "utf-8"
@@ -24,22 +28,41 @@ class TestArchiveClient(object):
         return Py42Response(response)
 
     @pytest.fixture
-    def mock_get_all_empty_response(self, mocker):
+    def mock_get_all_restore_history_empty_response(self, mocker):
         response = mocker.MagicMock(spec=Response)
         response.status_code = 200
         response.encoding = "utf-8"
         response.text = MOCK_EMPTY_GET_ORG_RESTORE_HISTORY_RESPONSE
         return Py42Response(response)
 
+    @pytest.fixture
+    def mock_get_all_org_cold_storage_response(self, mocker):
+        response = mocker.MagicMock(spec=Response)
+        response.status_code = 200
+        response.encoding = "utf-8"
+        response.text = MOCK_GET_ORG_COLD_STORAGE_RESPONSE
+        return Py42Response(response)
+
+    @pytest.fixture
+    def mock_get_all_org_cold_storage_empty_response(self, mocker):
+        response = mocker.MagicMock(spec=Response)
+        response.status_code = 200
+        response.encoding = "utf-8"
+        response.text = MOCK_EMPTY_GET_ORG_COLD_STORAGE_RESPONSE
+        return Py42Response(response)
+
     def test_get_all_restore_history_calls_get_expected_number_of_times(
-        self, mock_session, mock_get_all_response, mock_get_all_empty_response
+        self,
+        mock_session,
+        mock_get_all_restore_history_response,
+        mock_get_all_restore_history_empty_response,
     ):
         py42.settings.items_per_page = 1
         client = ArchiveClient(mock_session)
         mock_session.get.side_effect = [
-            mock_get_all_response,
-            mock_get_all_response,
-            mock_get_all_empty_response,
+            mock_get_all_restore_history_response,
+            mock_get_all_restore_history_response,
+            mock_get_all_restore_history_empty_response,
         ]
         for _ in client.get_all_restore_history(10, "orgId", "123"):
             pass
@@ -58,6 +81,37 @@ class TestArchiveClient(object):
         )
 
     def test_get_all_org_cold_storage_archives_calls_get_expected_number_of_times(
-        self, mock_session
+        self,
+        mock_session,
+        mock_get_all_org_cold_storage_response,
+        mock_get_all_org_cold_storage_empty_response,
     ):
-        pass
+        py42.settings.items_per_page = 1
+        client = ArchiveClient(mock_session)
+        mock_session.get.side_effect = [
+            mock_get_all_org_cold_storage_response,
+            mock_get_all_org_cold_storage_response,
+            mock_get_all_org_cold_storage_empty_response,
+        ]
+        for _ in client.get_all_org_cold_storage_archives("orgId"):
+            pass
+        py42.settings.items_per_page = 1000
+        assert mock_session.get.call_count == 3
+
+    def test_get_all_org_cold_storage_archives_calls_get_with_expected_uri_and_params(
+        self, mock_session, mock_get_all_org_cold_storage_empty_response
+    ):
+        client = ArchiveClient(mock_session)
+        mock_session.get.side_effect = [mock_get_all_org_cold_storage_empty_response]
+        for _ in client.get_all_org_cold_storage_archives("orgId"):
+            break
+
+        params = {
+            "orgId": "orgId",
+            "incChildOrgs": True,
+            "pgNum": 1,
+            "pgSize": 1000,
+            "srtDir": "asc",
+            "srtKey": "archiveHoldExpireDate",
+        }
+        mock_session.get.assert_called_once_with("/api/ColdStorage", params=params)

--- a/tests/_internal/clients/test_archive.py
+++ b/tests/_internal/clients/test_archive.py
@@ -16,7 +16,7 @@ MOCK_EMPTY_GET_ORG_RESTORE_HISTORY_RESPONSE = """{"totalCount": 3000, "restoreEv
 
 class TestArchiveClient(object):
     @pytest.fixture
-    def mock_get_all_restore_history_response(self, mocker):
+    def mock_get_all_response(self, mocker):
         response = mocker.MagicMock(spec=Response)
         response.status_code = 200
         response.encoding = "utf-8"
@@ -24,11 +24,11 @@ class TestArchiveClient(object):
         return Py42Response(response)
 
     @pytest.fixture
-    def mock_get_all_restore_history_empty_response(self, mocker):
+    def mock_get_all_empty_response(self, mocker):
         response = mocker.MagicMock(spec=Response)
         response.status_code = 200
         response.encoding = "utf-8"
-        response.text = MOCK_GET_ORG_RESTORE_HISTORY_RESPONSE
+        response.text = MOCK_EMPTY_GET_ORG_RESTORE_HISTORY_RESPONSE
         return Py42Response(response)
 
     def test_get_all_restore_history_calls_get_expected_number_of_times(

--- a/tests/_internal/clients/test_archive.py
+++ b/tests/_internal/clients/test_archive.py
@@ -7,31 +7,31 @@ import py42.settings
 from py42._internal.clients.archive import ArchiveClient
 from py42.response import Py42Response
 
-MOCK_GET_ORG_RESPONSE = (
+MOCK_GET_ORG_RESTORE_HISTORY_RESPONSE = (
     """{"totalCount": 3000, "restoreEvents": [{"eventName": "foo", "eventUid": "123"}]}"""
 )
 
-MOCK_EMPTY_GET_ORGS_RESPONSE = """{"totalCount": 3000, "restoreEvents": []}"""
+MOCK_EMPTY_GET_ORG_RESTORE_HISTORY_RESPONSE = """{"totalCount": 3000, "restoreEvents": []}"""
 
 
 class TestArchiveClient(object):
     @pytest.fixture
-    def mock_get_all_response(self, mocker):
+    def mock_get_all_restore_history_response(self, mocker):
         response = mocker.MagicMock(spec=Response)
         response.status_code = 200
         response.encoding = "utf-8"
-        response.text = MOCK_GET_ORG_RESPONSE
+        response.text = MOCK_GET_ORG_RESTORE_HISTORY_RESPONSE
         return Py42Response(response)
 
     @pytest.fixture
-    def mock_get_all_empty_response(self, mocker):
+    def mock_get_all_restore_history_empty_response(self, mocker):
         response = mocker.MagicMock(spec=Response)
         response.status_code = 200
         response.encoding = "utf-8"
-        response.text = MOCK_EMPTY_GET_ORGS_RESPONSE
+        response.text = MOCK_GET_ORG_RESTORE_HISTORY_RESPONSE
         return Py42Response(response)
 
-    def test_get_all_calls_get_expected_number_of_times(
+    def test_get_all_restore_history_calls_get_expected_number_of_times(
         self, mock_session, mock_get_all_response, mock_get_all_empty_response
     ):
         py42.settings.items_per_page = 1
@@ -56,3 +56,8 @@ class TestArchiveClient(object):
             params={u"idType": u"guid"},
             data=json.dumps({u"archiveHoldExpireDate": u"2020-04-24"}),
         )
+
+    def test_get_all_org_cold_storage_archives_calls_get_expected_number_of_times(
+        self, mock_session
+    ):
+        pass

--- a/tests/modules/test_archive.py
+++ b/tests/modules/test_archive.py
@@ -70,6 +70,6 @@ class TestArchiveModule(object):
     def test_get_all_org_cold_storage_archives_calls_client_with_expected_data(self, mocker):
         archive = _get_module(mocker)
         archive.get_all_org_cold_storage_archives("TEST ORG ID")
-        archive._archive_client.update_cold_storage_purge_date.assert_called_once_with(
+        archive._archive_client.get_all_org_cold_storage_archives.assert_called_once_with(
             "TEST ORG ID"
         )

--- a/tests/modules/test_archive.py
+++ b/tests/modules/test_archive.py
@@ -66,3 +66,10 @@ class TestArchiveModule(object):
         archive._archive_client.update_cold_storage_purge_date.assert_called_once_with(
             u"123", u"2020-04-24"
         )
+
+    def test_get_all_org_cold_storage_archives_calls_client_with_expected_data(self, mocker):
+        archive = _get_module(mocker)
+        archive.get_all_org_cold_storage_archives("TEST ORG ID")
+        archive._archive_client.update_cold_storage_purge_date.assert_called_once_with(
+            "TEST ORG ID"
+        )


### PR DESCRIPTION
Adds the ability to get the list of cold storage archives for a given org Id.

This was originally also supposed to contain a method to get cold storage by destination guid, but I ended up excluding that for a couple reasons:
- I found that that api required a `destinationId` rather than a `destinationGuid` (confusing for users, I didn't even know there was such a thing).
- Even when I tried the API with that knowledge, a customer cloud admin still returned 403s for valid ids -- I think this feature may have been on-prem specific, which kind of makes sense since most of the concept of managing destinations is hidden in the cloud.
- There is no functionality in the UI for getting this info by destination, so I don't think it will be missed.