### PR TITLE
Refactor - added method to get query of a saved search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 ### Added
 
 - `get_all_org_cold_storage_archives()` function to `ArchiveModule`, available at `sdk.archive.get_all_org_cold_storage_archives()`.
-
+- `get_query()` function to `sdk.securitydata.savedsearches` to get query against a saved search id.
 
 ## 1.3.0 - 2020-06-02
 

--- a/src/py42/clients/savedsearch.py
+++ b/src/py42/clients/savedsearch.py
@@ -32,6 +32,11 @@ class SavedSearchClient(BaseClient):
         uri = u"{}/{}".format(self._resource, search_id)
         return self._session.get(uri)
 
+    def get_query(self, search_id):
+        response = self.get_by_id(search_id)
+        search = response[u"searches"][0]
+        return FileEventQuery.from_dict(search)
+
     def execute(self, search_id, pg_num=1, pg_size=10000):
         """
         Execute a saved search for given search Id and return its results.
@@ -43,7 +48,5 @@ class SavedSearchClient(BaseClient):
         Returns:
             :class:`py42.response.Py42Response`
         """
-        response = self.get_by_id(search_id)
-        search = response[u"searches"][0]
-        query = FileEventQuery.from_dict(search)
+        query = self.get_query(search_id)
         return self._file_event_client.search(query)

--- a/src/py42/clients/savedsearch.py
+++ b/src/py42/clients/savedsearch.py
@@ -33,6 +33,13 @@ class SavedSearchClient(BaseClient):
         return self._session.get(uri)
 
     def get_query(self, search_id):
+        """Get the saved search in form of a query(`py42.sdk.queries.fileevents.file_event_query`).
+        
+        Args:
+            search_id (str): Unique search Id of the saved search.
+        Returns:
+            :class:`py42.sdk.queries.fileevents.file_event_query.FileEventQuery`
+        """
         response = self.get_by_id(search_id)
         search = response[u"searches"][0]
         return FileEventQuery.from_dict(search)

--- a/tests/clients/test_savedsearch.py
+++ b/tests/clients/test_savedsearch.py
@@ -32,9 +32,6 @@ class TestSavedSearchClient(object):
         file_event_client = FileEventClient(mock_session)
         saved_search_client = SavedSearchClient(mock_session, file_event_client)
         saved_search_client.execute(u"test-id")
-        assert (
-            mock_session.get.call_args[0][0] == "/forensic-search/queryservice/api/v1/saved/test-id"
-        )
         assert mock_session.post.call_args[0][0] == "/forensic-search/queryservice/api/v1/fileevent"
 
     def test_execute_calls_post_with_expected_query(self, mock_session, py42_response):
@@ -49,4 +46,14 @@ class TestSavedSearchClient(object):
             posted_data["pgSize"] == 10000
             and posted_data[u"pgNum"] == 1
             and posted_data[u"groups"] == []
+        )
+
+    def test_get_query_calls_get_with_expected_uri(self, mock_session, py42_response):
+        py42_response.text = '{u"searches": [{u"groups": []}]}'
+        mock_session.post.return_value = py42_response
+        file_event_client = FileEventClient(mock_session)
+        saved_search_client = SavedSearchClient(mock_session, file_event_client)
+        saved_search_client.get_query(u"test-id")
+        assert (
+            mock_session.get.call_args[0][0] == "/forensic-search/queryservice/api/v1/saved/test-id"
         )


### PR DESCRIPTION
Scope: Saved Search.

Refactored `execute` to get `query`, I needed this for extractor to work.

Kept the method as public, as its needed in CLI, moreover it would be helpful for a user to see the underline query created against the search-id.
