### PR TITLE
Bugfix/alert rules page size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Fixed
 
-- An issue that caused requests to `sdk.alerts.rules.get_all()`, `sdk.alerts.rules.get_all_by_name()`, and `sdk.alerts.rules.get_by_observerid()` to fail due to a change made to their backing api.
+- An issue that caused requests to `sdk.alerts.rules.get_all()`, `sdk.alerts.rules.get_all_by_name()`, and `sdk.alerts.rules.get_by_observer_id()` to fail due to a change made to their backing api.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,13 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - Ability for users to provide their own logger for debug logging
 
+### Fixed
+
+- An issue that caused requests to `sdk.alerts.rules.get_all()`, `sdk.alerts.rules.get_all_by_name()`, and `sdk.alerts.rules.get_by_observerid()` to fail due to a change made to their backing api.
+
 ### Changed
 
+- The default value of `py42.settings.items_per_page` has been changed to 500 (was 1000).
 - Default debug logging moved from print statements to a logger writing to `sys.stderr`
 - Debug logging levels now use standard levels from the `logging` module (old levels still work but are now
     automatically mapped to appropriate `logging` module level, with both `debug.DEBUG` and `debug.TRACE` being mapped

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ There are a few default settings that affect the behavior of the client.
 | proxies | Dictionary mapping protocol or protocol and hostname to the URL of the proxy.<br>See [the Requests library's documentation on proxies](http://docs.python-requests.org/en/master/user/advanced/?highlight=proxies#proxies) for more info.| `None`
 | debug.level | Controls log level | `logging.NOTSET`
 | debug.logger | Controls logger used | `logging.Logger` with `StreamHandler` sending to `sys.stderr`
-| items_per_page | Controls how many items are retrieved per request for methods that loops over several "pages" of items in order to collect them all. | 1000
+| items_per_page | Controls how many items are retrieved per request for methods that loops over several "pages" of items in order to collect them all. | 500
 
 To override these settings, import `py42.settings` and override values as necessary before creating the client.
  For example, to disable certificate validation in a dev environment:

--- a/src/py42/settings/__init__.py
+++ b/src/py42/settings/__init__.py
@@ -9,7 +9,7 @@ proxies = None
 # True, False, or a path to a CA bundle to use.
 verify_ssl_certs = True
 
-items_per_page = 1000
+items_per_page = 500
 
 _custom_user_suffix = u""
 _python_version = u"{0}.{1}.{2}".format(
@@ -43,5 +43,6 @@ class DebugSettings(object):
     @level.setter
     def level(self, level):
         self.logger.setLevel(level)
+
 
 debug = DebugSettings()

--- a/tests/_internal/clients/test_archive.py
+++ b/tests/_internal/clients/test_archive.py
@@ -66,7 +66,7 @@ class TestArchiveClient(object):
         ]
         for _ in client.get_all_restore_history(10, "orgId", "123"):
             pass
-        py42.settings.items_per_page = 1000
+        py42.settings.items_per_page = 500
         assert mock_session.get.call_count == 3
 
     def test_update_cold_storage_purge_date_calls_coldstorage_with_expected_data(
@@ -95,7 +95,7 @@ class TestArchiveClient(object):
         ]
         for _ in client.get_all_org_cold_storage_archives("orgId"):
             pass
-        py42.settings.items_per_page = 1000
+        py42.settings.items_per_page = 500
         assert mock_session.get.call_count == 3
 
     def test_get_all_org_cold_storage_archives_calls_get_with_expected_uri_and_params(
@@ -110,7 +110,7 @@ class TestArchiveClient(object):
             "orgId": "orgId",
             "incChildOrgs": True,
             "pgNum": 1,
-            "pgSize": 1000,
+            "pgSize": 500,
             "srtDir": "asc",
             "srtKey": "archiveHoldExpireDate",
         }

--- a/tests/clients/test_alerts.py
+++ b/tests/clients/test_alerts.py
@@ -279,7 +279,7 @@ class TestAlertClient(object):
             and posted_data["groups"] == []
             and posted_data["groupClause"] == "AND"
             and posted_data["pgNum"] == 0
-            and posted_data["pgSize"] == 1000
+            and posted_data["pgSize"] == 500
             and posted_data["srtKey"] == "key"
             and posted_data["srtDirection"] == "ASC"
         )
@@ -305,7 +305,7 @@ class TestAlertClient(object):
             posted_data["tenantId"] == user_context.get_current_tenant_id()
             and posted_data["groupClause"] == "AND"
             and posted_data["pgNum"] == 0
-            and posted_data["pgSize"] == 1000
+            and posted_data["pgSize"] == 500
             and posted_data["srtKey"] == "key"
             and posted_data["srtDirection"] == "ASC"
         )
@@ -329,7 +329,7 @@ class TestAlertClient(object):
             posted_data["tenantId"] == user_context.get_current_tenant_id()
             and posted_data["groupClause"] == "AND"
             and posted_data["pgNum"] == 0
-            and posted_data["pgSize"] == 1000
+            and posted_data["pgSize"] == 500
             and posted_data["srtKey"] == "CreatedAt"
             and posted_data["srtDirection"] == "DESC"
         )

--- a/tests/clients/test_devices.py
+++ b/tests/clients/test_devices.py
@@ -18,7 +18,7 @@ DEFAULT_GET_DEVICES_PARAMS = {
     "incBackupUsage": None,
     "incCounts": True,
     "pgNum": 1,
-    "pgSize": 1000,
+    "pgSize": 500,
     "q": None,
 }
 
@@ -89,5 +89,5 @@ class TestDeviceClient(object):
         ]
         for _ in client.get_all():
             pass
-        py42.settings.items_per_page = 1000
+        py42.settings.items_per_page = 500
         assert mock_session.get.call_count == 3

--- a/tests/clients/test_legalhold.py
+++ b/tests/clients/test_legalhold.py
@@ -16,7 +16,7 @@ DEFAULT_GET_LEGAL_HOLDS_PARAMS = {
     "incBackupUsage": None,
     "incCounts": True,
     "pgNum": 1,
-    "pgSize": 1000,
+    "pgSize": 500,
     "q": None,
 }
 
@@ -83,7 +83,7 @@ class TestLegalHoldClient(object):
         ]
         for _ in client.get_all_matters():
             pass
-        py42.settings.items_per_page = 1000
+        py42.settings.items_per_page = 500
         assert mock_session.get.call_count == 3
 
     def test_get_all_matter_custodians_calls_get_expected_number_of_times(
@@ -101,5 +101,5 @@ class TestLegalHoldClient(object):
         ]
         for _ in client.get_all_matter_custodians():
             pass
-        py42.settings.items_per_page = 1000
+        py42.settings.items_per_page = 500
         assert mock_session.get.call_count == 3

--- a/tests/clients/test_orgs.py
+++ b/tests/clients/test_orgs.py
@@ -51,7 +51,7 @@ class TestOrgClient(object):
         ]
         for _ in client.get_all():
             pass
-        py42.settings.items_per_page = 1000
+        py42.settings.items_per_page = 500
         assert mock_session.get.call_count == 3
 
     def test_get_org_by_name_returns_expected_org(
@@ -65,7 +65,7 @@ class TestOrgClient(object):
             mock_get_all_empty_response,
         ]
         actual = client.get_by_name("foo")[0]
-        py42.settings.items_per_page = 1000
+        py42.settings.items_per_page = 500
         assert actual["orgUid"] == "123"
 
     def test_get_org_by_name_returns_expected_number_of_orgs(
@@ -79,7 +79,7 @@ class TestOrgClient(object):
             mock_get_all_empty_response,
         ]
         actual = len(client.get_by_name("foo"))
-        py42.settings.items_per_page = 1000
+        py42.settings.items_per_page = 500
         assert actual == 2
 
     def test_get_org_by_name_when_not_found_returns_empty_list(

--- a/tests/clients/test_users.py
+++ b/tests/clients/test_users.py
@@ -18,7 +18,7 @@ DEFAULT_GET_ALL_PARAMS = {
     "orgUid": None,
     "roleId": None,
     "pgNum": 1,
-    "pgSize": 1000,
+    "pgSize": 500,
     "q": None,
 }
 
@@ -113,7 +113,7 @@ class TestUserClient(object):
         ]
         for _ in client.get_all():
             pass
-        py42.settings.items_per_page = 1000
+        py42.settings.items_per_page = 500
         assert mock_session.get.call_count == 3
 
     def test_get_scim_data_by_uid_calls_get_with_expected_uri_and_params(self, mock_session):


### PR DESCRIPTION
Fixes a newly added size limit on paging for alert rules that cause failures under the old defaults. After discussing with @timabrmsn, we decided to simply lower the default of `settings.items_per_page`. 