### PR TITLE
added detectionlists.refresh_user_scim_attributes method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 ### Added
 
 - Ability for users to provide their own logger for debug logging
+- adds `sdk.detectionlists.refresh_user_scim_attributes()` to update user SCIM attributes in detection lists.
 
 ### Fixed
 

--- a/src/py42/_internal/clients/detection_list_user.py
+++ b/src/py42/_internal/clients/detection_list_user.py
@@ -185,3 +185,19 @@ class DetectionListUserClient(BaseClient):
         }
         uri = self._make_uri(u"/removecloudusernames")
         return self._session.post(uri, data=json.dumps(data))
+
+    def refresh(self, user_id):
+        """Refresh SCIM attributes for the user.
+
+        Args:
+            user_id (str or int): The user_id whose attributes need to be refreshed.
+
+        Returns:
+            :class:`py42.response.Py42Response`
+        """
+        data = {
+            u"tenantId": self._user_context.get_current_tenant_id(),
+            u"userId": user_id,
+        }
+        uri = self._make_uri(u"/refresh")
+        return self._session.post(uri, data=json.dumps(data))

--- a/src/py42/_internal/clients/detection_list_user.py
+++ b/src/py42/_internal/clients/detection_list_user.py
@@ -187,10 +187,10 @@ class DetectionListUserClient(BaseClient):
         return self._session.post(uri, data=json.dumps(data))
 
     def refresh(self, user_id):
-        """Refresh SCIM attributes for the user.
+        """Refresh SCIM attributes of a user.
 
         Args:
-            user_id (str or int): The user_id whose attributes need to be refreshed.
+            user_id (str or int): The user_id of the user whose attributes need to be refreshed.
 
         Returns:
             :class:`py42.response.Py42Response`

--- a/src/py42/modules/detectionlists.py
+++ b/src/py42/modules/detectionlists.py
@@ -125,10 +125,11 @@ class DetectionListsModule(object):
         self._detection_list_user_client.remove_cloud_alias(user_id, alias)
 
     def refresh_user_scim_attributes(self, user_id):
-        """Refresh SCIM attributes for the user.
+        """Refresh SCIM attributes of a user.
+        `REST documentation <https://ecm-default.prod.ffs.us2.code42.com/svc/swagger/index.html?urls.primaryName=v2#/User/UserControllerV2_RefreshUser>`__
 
         Args:
-            user_id (str or int): The Code42 userUid whose attributes you wish to refresh.
+            user_id (str or int): The Code42 userUid of the user whose attributes you wish to refresh.
 
         Returns:
             :class:`py42.response.Py42Response`

--- a/src/py42/modules/detectionlists.py
+++ b/src/py42/modules/detectionlists.py
@@ -123,3 +123,16 @@ class DetectionListsModule(object):
         factory = self._microservice_client_factory
         self._detection_list_user_client = factory.get_detection_list_user_client()
         self._detection_list_user_client.remove_cloud_alias(user_id, alias)
+
+    def refresh_user_scim_attributes(self, user_id):
+        """Refresh SCIM attributes for the user.
+
+        Args:
+            user_id (str or int): The Code42 userUid whose attributes you wish to refresh.
+
+        Returns:
+            :class:`py42.response.Py42Response`
+        """
+        factory = self._microservice_client_factory
+        self._detection_list_user_client = factory.get_detection_list_user_client()
+        return self._detection_list_user_client.refresh(user_id)

--- a/tests/_internal/clients/test_detection_list_user.py
+++ b/tests/_internal/clients/test_detection_list_user.py
@@ -204,3 +204,17 @@ class TestDetectionListUserClient(object):
         assert mock_get_by_id_fails.post.call_count == 2
         assert mock_user_client._session.get.call_count == 1
         assert mock_user_client._session.get.call_args[0][0] == "/api/User/942897397520289999"
+
+    def test_refresh_posts_expected_data(self, mock_session, user_context, mock_user_client):
+        detection_list_user_client = DetectionListUserClient(
+            mock_session, user_context, mock_user_client
+        )
+        detection_list_user_client.refresh("942897397520289999")
+
+        posted_data = json.loads(mock_session.post.call_args[1]["data"])
+        assert mock_session.post.call_count == 1
+        assert mock_session.post.call_args[0][0] == "/svc/api/v2/user/refresh"
+        assert (
+            posted_data["tenantId"] == user_context.get_current_tenant_id()
+            and posted_data["userId"] == "942897397520289999"
+        )

--- a/tests/modules/test_detectionlists.py
+++ b/tests/modules/test_detectionlists.py
@@ -123,3 +123,13 @@ class TestDetectionListModule(object):
         mock_detection_list_user_client.remove_cloud_alias.assert_called_once_with(
             TEST_USER_ID, "oldalias"
         )
+
+    def test_refresh_user_scim_attributes_calls_user_client_with_expected_values(
+        self, mock_microservice_client_factory, mock_detection_list_user_client
+    ):
+        mock_microservice_client_factory.get_detection_list_user_client.return_value = (
+            mock_detection_list_user_client
+        )
+        module = DetectionListsModule(mock_microservice_client_factory)
+        module.refresh_user_scim_attributes(TEST_USER_ID)
+        mock_detection_list_user_client.refresh.assert_called_once_with(TEST_USER_ID)


### PR DESCRIPTION
This request adds a method to refresh user SCIM data. This won't be necessary once DES can do this automatically, but for now it's useful as there isn't an intuitive way to do this.

REST documentation here: https://ecm-default.prod.ffs.us2.code42.com/svc/swagger/index.html?urls.primaryName=v2#/User/UserControllerV2_RefreshUser

Let me know if you'd like me to change or add anything else.