### PR TITLE
Feature/expose getting single page methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ## Unreleased
 
+### Added
 - Make `ExposureType.OUTSIDE_TRUSTED_DOMAINS` constant available.
+- Exposed methods `get_high_risk_employee_page()` and `get_departing_employee_page()` that accepts `pg_num` and
+    `pg_size` for getting individual pages.
 
 ## 1.5.1 - 2020-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Added
 - Make `ExposureType.OUTSIDE_TRUSTED_DOMAINS` constant available.
-- Exposed methods `get_high_risk_employee_page()` and `get_departing_employee_page()` that accepts `pg_num` and
+- Exposed methods `get_high_risk_employees_page()` and `get_departing_employees_page()` that accepts `pg_num` and
     `pg_size` for getting individual pages.
 
 ## 1.5.1 - 2020-06-17

--- a/src/py42/clients/detectionlists/departing_employee.py
+++ b/src/py42/clients/detectionlists/departing_employee.py
@@ -68,20 +68,20 @@ class DepartingEmployeeClient(BaseClient):
         data = {u"userId": user_id, u"tenantId": tenant_id}
         return self._session.post(uri, data=json.dumps(data))
 
-    def _get_departing_employees_page(
+    def get_departing_employees_page(
         self,
         tenant_id=None,
         filter_type=None,
         sort_key=u"CREATED_AT",
         sort_direction=u"DESC",
         page_num=None,
-        page_size=None,
+        page_size=100,
     ):
 
         uri = self._uri_prefix.format(u"search")
         data = {
             u"tenantId": tenant_id,
-            u"pgSize": 100,
+            u"pgSize": page_size,
             u"pgNum": page_num,
             u"filterType": filter_type,
             u"srtKey": sort_key,
@@ -105,12 +105,13 @@ class DepartingEmployeeClient(BaseClient):
             that each contain a page of departing employees.
         """
         return get_all_pages(
-            self._get_departing_employees_page,
+            self.get_departing_employees_page,
             u"items",
             tenant_id=self._user_context.get_current_tenant_id(),
             filter_type=filter_type,
             sort_key=sort_key,
             sort_direction=sort_direction,
+            page_size=100,
         )
 
     def set_alerts_enabled(self, alerts_enabled=True):

--- a/src/py42/clients/detectionlists/departing_employee.py
+++ b/src/py42/clients/detectionlists/departing_employee.py
@@ -80,8 +80,8 @@ class DepartingEmployeeClient(BaseClient):
 
         Args:
             filter_type (str, optional): Valid filter types. Defaults to None.
-            sort_key (str, optional): Sort results based by field. Defaults to None.
-            sort_direction (str. optional): ``ASC`` or ``DESC``. Defaults to None.
+            sort_key (str, optional): Sort results based by field. Defaults to "CREATED_AT".
+            sort_direction (str. optional): ``ASC`` or ``DESC``. Defaults to "DESC".
             page_num (str or int, optional): The page number to request. Defaults to None.
             page_size (str or int, optional): The items to have per page. Defaults to None.
 
@@ -102,8 +102,8 @@ class DepartingEmployeeClient(BaseClient):
 
         Args:
             filter_type (str, optional): Valid filter types. Defaults to None.
-            sort_key (str, optional): Sort results based by field. Defaults to None.
-            sort_direction (str. optional): ``ASC`` or ``DESC``. Defaults to None.
+            sort_key (str, optional): Sort results based by field. Defaults to "CREATED_AT".
+            sort_direction (str. optional): ``ASC`` or ``DESC``. Defaults to "DESC".
 
         Returns:
             generator: An object that iterates over :class:`py42.response.Py42Response` objects

--- a/src/py42/clients/detectionlists/departing_employee.py
+++ b/src/py42/clients/detectionlists/departing_employee.py
@@ -74,7 +74,7 @@ class DepartingEmployeeClient(BaseClient):
         sort_key=u"CREATED_AT",
         sort_direction=u"DESC",
         page_num=None,
-        page_size=100,
+        page_size=None,
     ):
         """Get a single page of Departing Employees.
 
@@ -83,7 +83,7 @@ class DepartingEmployeeClient(BaseClient):
             sort_key (str, optional): Sort results based by field. Defaults to None.
             sort_direction (str. optional): ``ASC`` or ``DESC``. Defaults to None.
             page_num (str or int, optional): The page number to request. Defaults to None.
-            page_size (str or int, optional): The items to have per page. Defaults to 100.
+            page_size (str or int, optional): The items to have per page. Defaults to None.
 
         Returns:
             :class:`py42.response.Py42Response`
@@ -126,7 +126,7 @@ class DepartingEmployeeClient(BaseClient):
         sort_key=u"CREATED_AT",
         sort_direction=u"DESC",
         page_num=None,
-        page_size=100,
+        page_size=None,
     ):
         uri = self._uri_prefix.format(u"search")
         data = {

--- a/src/py42/clients/detectionlists/departing_employee.py
+++ b/src/py42/clients/detectionlists/departing_employee.py
@@ -76,6 +76,18 @@ class DepartingEmployeeClient(BaseClient):
         page_num=None,
         page_size=100,
     ):
+        """Get a single page of Departing Employees.
+
+        Args:
+            filter_type (str, optional): Valid filter types. Defaults to None.
+            sort_key (str, optional): Sort results based by field. Defaults to None.
+            sort_direction (str. optional): ``ASC`` or ``DESC``. Defaults to None.
+            page_num (str or int, optional): The page number to request. Defaults to None.
+            page_size (str or int, optional): The items to have per page. Defaults to 100.
+
+        Returns:
+            :class:`py42.response.Py42Response`
+        """
         return self._get_departing_employees_page(
             tenant_id=self._user_context.get_current_tenant_id(),
             filter_type=filter_type,
@@ -89,12 +101,9 @@ class DepartingEmployeeClient(BaseClient):
         """Gets all Departing Employees.
 
         Args:
-            filter_type (str, optional): Filter results by status. Defaults to "OPEN".
-            sort_key (str, optional): Key to sort results on. Options: (``CREATED_AT``,
-                ``DEPARTURE_DATE``, ``DISPLAY_NAME``, ``NUM_EVENTS``, ``TOTAL_BYTES``). Defaults to
-                ``CREATED_AT``.
-            sort_direction (str, optional): Sort direction. Options: (``ASC``, ``DESC``). Defaults
-                to ``DESC``.
+            filter_type (str, optional): Valid filter types. Defaults to None.
+            sort_key (str, optional): Sort results based by field. Defaults to None.
+            sort_direction (str. optional): ``ASC`` or ``DESC``. Defaults to None.
 
         Returns:
             generator: An object that iterates over :class:`py42.response.Py42Response` objects

--- a/src/py42/clients/detectionlists/departing_employee.py
+++ b/src/py42/clients/detectionlists/departing_employee.py
@@ -70,24 +70,20 @@ class DepartingEmployeeClient(BaseClient):
 
     def get_departing_employees_page(
         self,
-        tenant_id=None,
         filter_type=None,
         sort_key=u"CREATED_AT",
         sort_direction=u"DESC",
         page_num=None,
         page_size=100,
     ):
-
-        uri = self._uri_prefix.format(u"search")
-        data = {
-            u"tenantId": tenant_id,
-            u"pgSize": page_size,
-            u"pgNum": page_num,
-            u"filterType": filter_type,
-            u"srtKey": sort_key,
-            u"srtDirection": sort_direction,
-        }
-        return self._session.post(uri, data=json.dumps(data))
+        return self._get_departing_employees_page(
+            tenant_id=self._user_context.get_current_tenant_id(),
+            filter_type=filter_type,
+            sort_key=sort_key,
+            sort_direction=sort_direction,
+            page_num=page_num,
+            page_size=page_size,
+        )
 
     def get_all(self, filter_type=u"OPEN", sort_key=u"CREATED_AT", sort_direction=u"DESC"):
         """Gets all Departing Employees.
@@ -105,7 +101,7 @@ class DepartingEmployeeClient(BaseClient):
             that each contain a page of departing employees.
         """
         return get_all_pages(
-            self.get_departing_employees_page,
+            self._get_departing_employees_page,
             u"items",
             tenant_id=self._user_context.get_current_tenant_id(),
             filter_type=filter_type,
@@ -113,6 +109,26 @@ class DepartingEmployeeClient(BaseClient):
             sort_direction=sort_direction,
             page_size=100,
         )
+
+    def _get_departing_employees_page(
+        self,
+        tenant_id=None,
+        filter_type=None,
+        sort_key=u"CREATED_AT",
+        sort_direction=u"DESC",
+        page_num=None,
+        page_size=100,
+    ):
+        uri = self._uri_prefix.format(u"search")
+        data = {
+            u"tenantId": tenant_id,
+            u"pgSize": page_size,
+            u"pgNum": page_num,
+            u"filterType": filter_type,
+            u"srtKey": sort_key,
+            u"srtDirection": sort_direction,
+        }
+        return self._session.post(uri, data=json.dumps(data))
 
     def set_alerts_enabled(self, alerts_enabled=True):
         """Enable or disable email alerting on Departing Employee exposure events.

--- a/src/py42/clients/detectionlists/high_risk_employee.py
+++ b/src/py42/clients/detectionlists/high_risk_employee.py
@@ -86,6 +86,45 @@ class HighRiskEmployeeClient(BaseClient):
 
     def get_high_risk_employees_page(
         self,
+        filter_type=None,
+        sort_key=None,
+        sort_direction=None,
+        page_num=None,
+        page_size=100,
+    ):
+        return self._get_high_risk_employees_page(
+            tenant_id=self._user_context.get_current_tenant_id(),
+            filter_type=filter_type,
+            sort_key=sort_key,
+            sort_direction=sort_direction,
+            page_num=page_num,
+            page_size=page_size,
+        )
+
+    def get_all(self, filter_type=u"OPEN", sort_key=None, sort_direction=None):
+        """Search High Risk Employee list. Filter results by filter_type.
+
+        Args:
+            filter_type (str): Valid filter types.
+            sort_key (str): Sort results based by field.
+            sort_direction (str): ``ASC`` or ``DESC``
+
+        Returns:
+            generator: An object that iterates over :class:`py42.response.Py42Response` objects
+            that each contain a page of users.
+        """
+
+        return get_all_pages(
+            self._get_high_risk_employees_page,
+            u"items",
+            tenant_id=self._user_context.get_current_tenant_id(),
+            filter_type=filter_type,
+            sort_key=sort_key,
+            sort_direction=sort_direction,
+        )
+
+    def _get_high_risk_employees_page(
+        self,
         tenant_id,
         filter_type=None,
         sort_key=None,
@@ -105,25 +144,3 @@ class HighRiskEmployeeClient(BaseClient):
 
         uri = self._make_uri(u"/search")
         return self._session.post(uri, data=json.dumps(data))
-
-    def get_all(self, filter_type=u"OPEN", sort_key=None, sort_direction=None):
-        """Search High Risk Employee list. Filter results by filter_type.
-
-        Args:
-            filter_type (str): Valid filter types.
-            sort_key (str): Sort results based by field.
-            sort_direction (str): ``ASC`` or ``DESC``
-
-        Returns:
-            generator: An object that iterates over :class:`py42.response.Py42Response` objects
-            that each contain a page of users.
-        """
-
-        return get_all_pages(
-            self.get_high_risk_employees_page,
-            u"items",
-            tenant_id=self._user_context.get_current_tenant_id(),
-            filter_type=filter_type,
-            sort_key=sort_key,
-            sort_direction=sort_direction,
-        )

--- a/src/py42/clients/detectionlists/high_risk_employee.py
+++ b/src/py42/clients/detectionlists/high_risk_employee.py
@@ -84,17 +84,16 @@ class HighRiskEmployeeClient(BaseClient):
         uri = self._make_uri(u"/get")
         return self._session.post(uri, data=json.dumps(data))
 
-    def _get_high_risk_employees_page(
+    def get_high_risk_employees_page(
         self,
         tenant_id,
         filter_type=None,
         sort_key=None,
         sort_direction=None,
         page_num=None,
-        page_size=None,
+        page_size=100,
     ):
         # Overwriting page_size since default value 1000 returns error
-        page_size = 100
         data = {
             u"tenantId": tenant_id,
             u"filterType": filter_type,
@@ -121,7 +120,7 @@ class HighRiskEmployeeClient(BaseClient):
         """
 
         return get_all_pages(
-            self._get_high_risk_employees_page,
+            self.get_high_risk_employees_page,
             u"items",
             tenant_id=self._user_context.get_current_tenant_id(),
             filter_type=filter_type,

--- a/src/py42/clients/detectionlists/high_risk_employee.py
+++ b/src/py42/clients/detectionlists/high_risk_employee.py
@@ -92,6 +92,18 @@ class HighRiskEmployeeClient(BaseClient):
         page_num=None,
         page_size=100,
     ):
+        """Get a single page of High Risk Employees.
+
+        Args:
+            filter_type (str, optional): Valid filter types. Defaults to None.
+            sort_key (str, optional): Sort results based by field. Defaults to None.
+            sort_direction (str. optional): ``ASC`` or ``DESC``. Defaults to None.
+            page_num (str or int, optional): The page number to request. Defaults to None.
+            page_size (str or int, optional): The items to have per page. Defaults to 100.
+
+        Returns:
+            :class:`py42.response.Py42Response`
+        """
         return self._get_high_risk_employees_page(
             tenant_id=self._user_context.get_current_tenant_id(),
             filter_type=filter_type,
@@ -107,7 +119,7 @@ class HighRiskEmployeeClient(BaseClient):
         Args:
             filter_type (str): Valid filter types.
             sort_key (str): Sort results based by field.
-            sort_direction (str): ``ASC`` or ``DESC``
+            sort_direction (str): ``ASC`` or ``DESC``.
 
         Returns:
             generator: An object that iterates over :class:`py42.response.Py42Response` objects
@@ -121,6 +133,7 @@ class HighRiskEmployeeClient(BaseClient):
             filter_type=filter_type,
             sort_key=sort_key,
             sort_direction=sort_direction,
+            page_size=100,
         )
 
     def _get_high_risk_employees_page(

--- a/src/py42/clients/detectionlists/high_risk_employee.py
+++ b/src/py42/clients/detectionlists/high_risk_employee.py
@@ -117,9 +117,9 @@ class HighRiskEmployeeClient(BaseClient):
         """Search High Risk Employee list. Filter results by filter_type.
 
         Args:
-            filter_type (str): Valid filter types.
-            sort_key (str): Sort results based by field.
-            sort_direction (str): ``ASC`` or ``DESC``.
+            filter_type (str, optional): Valid filter types. Defaults to "OPEN".
+            sort_key (str, optional): Sort results based by field. Defaults to None.
+            sort_direction (str, optional): ``ASC`` or ``DESC``. Defaults to None.
 
         Returns:
             generator: An object that iterates over :class:`py42.response.Py42Response` objects

--- a/src/py42/clients/detectionlists/high_risk_employee.py
+++ b/src/py42/clients/detectionlists/high_risk_employee.py
@@ -90,7 +90,7 @@ class HighRiskEmployeeClient(BaseClient):
         sort_key=None,
         sort_direction=None,
         page_num=None,
-        page_size=100,
+        page_size=None,
     ):
         """Get a single page of High Risk Employees.
 
@@ -99,7 +99,7 @@ class HighRiskEmployeeClient(BaseClient):
             sort_key (str, optional): Sort results based by field. Defaults to None.
             sort_direction (str. optional): ``ASC`` or ``DESC``. Defaults to None.
             page_num (str or int, optional): The page number to request. Defaults to None.
-            page_size (str or int, optional): The items to have per page. Defaults to 100.
+            page_size (str or int, optional): The items to have per page. Defaults to None.
 
         Returns:
             :class:`py42.response.Py42Response`
@@ -143,7 +143,7 @@ class HighRiskEmployeeClient(BaseClient):
         sort_key=None,
         sort_direction=None,
         page_num=None,
-        page_size=100,
+        page_size=None,
     ):
         # Overwriting page_size since default value 1000 returns error
         data = {

--- a/src/py42/clients/util.py
+++ b/src/py42/clients/util.py
@@ -2,12 +2,13 @@ import py42.settings as settings
 
 
 def get_all_pages(func, key, *args, **kwargs):
-
-    item_count = settings.items_per_page
     page_num = 0
-    while item_count >= settings.items_per_page:
+    if kwargs.get("page_size") is None:
+        kwargs["page_size"] = settings.items_per_page
+    item_count = kwargs["page_size"]
+    while item_count >= kwargs["page_size"]:
         page_num += 1
-        response = func(*args, page_num=page_num, page_size=settings.items_per_page, **kwargs)
+        response = func(*args, page_num=page_num, **kwargs)
         yield response
         page_items = response[key]
         item_count = len(page_items)

--- a/src/py42/clients/util.py
+++ b/src/py42/clients/util.py
@@ -3,12 +3,11 @@ import py42.settings as settings
 
 def get_all_pages(func, key, *args, **kwargs):
     page_num = 0
-    if kwargs.get("page_size") is None:
-        kwargs["page_size"] = settings.items_per_page
-    item_count = kwargs["page_size"]
-    while item_count >= kwargs["page_size"]:
+    page_size = kwargs.get("page_size") or settings.items_per_page
+    item_count = page_size
+    while item_count >= page_size:
         page_num += 1
-        response = func(*args, page_num=page_num, **kwargs)
+        response = func(*args, page_num=page_num, page_size=page_size, **kwargs)
         yield response
         page_items = response[key]
         item_count = len(page_items)

--- a/src/py42/clients/util.py
+++ b/src/py42/clients/util.py
@@ -3,11 +3,12 @@ import py42.settings as settings
 
 def get_all_pages(func, key, *args, **kwargs):
     page_num = 0
-    page_size = kwargs.get("page_size") or settings.items_per_page
-    item_count = page_size
-    while item_count >= page_size:
+    if kwargs.get("page_size") is None:
+        kwargs["page_size"] = settings.items_per_page
+    item_count = kwargs["page_size"]
+    while item_count >= kwargs["page_size"]:
         page_num += 1
-        response = func(*args, page_num=page_num, page_size=page_size, **kwargs)
+        response = func(*args, page_num=page_num, **kwargs)
         yield response
         page_items = response[key]
         item_count = len(page_items)

--- a/tests/clients/detectionlists/test_departing_employee.py
+++ b/tests/clients/detectionlists/test_departing_employee.py
@@ -161,6 +161,38 @@ class TestDepartingEmployeeClient(object):
         assert mock_session.post.call_args[0][0] == "/svc/api/v2/departingemployee/search"
         assert mock_session.post.call_count == 1
 
+    def test_get_departing_employee_page_posts_data_to_expected_url(
+        self,
+        mock_session,
+        user_context,
+        mock_get_all_cases_response,
+        mock_detection_list_user_client,
+    ):
+        client = DepartingEmployeeClient(
+            mock_session, user_context, mock_detection_list_user_client
+        )
+        client.get_departing_employees_page(
+            TENANT_ID_FROM_RESPONSE,
+            filter_type="OPEN",
+            sort_key="CREATED_AT",
+            sort_direction="DESC",
+            page_num=1,
+            page_size=100,
+        )
+        mock_session.post.return_value = mock_get_all_cases_response
+        first_call = mock_session.post.call_args_list[0]
+        posted_data = json.loads(first_call[1]["data"])
+        assert (
+            posted_data["tenantId"] == TENANT_ID_FROM_RESPONSE
+            and posted_data["pgSize"] == 100
+            and posted_data["pgNum"] == 1
+            and posted_data["filterType"] == "OPEN"
+            and posted_data["srtKey"] == "CREATED_AT"
+            and posted_data["srtDirection"] == "DESC"
+        )
+        assert mock_session.post.call_args[0][0] == "/svc/api/v2/departingemployee/search"
+        assert mock_session.post.call_count == 1
+
     def test_set_alerts_enabled_posts_expected_data(
         self,
         mock_session,

--- a/tests/clients/detectionlists/test_departing_employee.py
+++ b/tests/clients/detectionlists/test_departing_employee.py
@@ -172,7 +172,6 @@ class TestDepartingEmployeeClient(object):
             mock_session, user_context, mock_detection_list_user_client
         )
         client.get_departing_employees_page(
-            TENANT_ID_FROM_RESPONSE,
             filter_type="OPEN",
             sort_key="CREATED_AT",
             sort_direction="DESC",

--- a/tests/clients/detectionlists/test_high_risk_employee.py
+++ b/tests/clients/detectionlists/test_high_risk_employee.py
@@ -159,3 +159,30 @@ class TestHighRiskEmployeeClient(object):
             and posted_data["srtKey"] == "DISPLAY_NAME"
             and posted_data["srtDirection"] == "DESC"
         )
+
+    def test_get_high_risk_employee_page(
+        self, user_context, mock_session, mock_detection_list_user_client
+    ):
+        tenant_id = user_context.get_current_tenant_id()
+        high_risk_employee_client = HighRiskEmployeeClient(
+            mock_session, user_context, mock_detection_list_user_client
+        )
+        high_risk_employee_client.get_high_risk_employees_page(
+            tenant_id,
+            filter_type="NEW_FILTER",
+            page_num=3,
+            page_size=10,
+            sort_direction="DESC",
+            sort_key="DISPLAY_NAME",
+        )
+        posted_data = json.loads(mock_session.post.call_args[1]["data"])
+        assert mock_session.post.call_count == 1
+        assert mock_session.post.call_args[0][0] == "/svc/api/v2/highriskemployee/search"
+        assert (
+            posted_data["tenantId"] == user_context.get_current_tenant_id()
+            and posted_data["filterType"] == "NEW_FILTER"
+            and posted_data["pgNum"] == 3
+            and posted_data["pgSize"] == 10
+            and posted_data["srtKey"] == "DISPLAY_NAME"
+            and posted_data["srtDirection"] == "DESC"
+        )

--- a/tests/clients/detectionlists/test_high_risk_employee.py
+++ b/tests/clients/detectionlists/test_high_risk_employee.py
@@ -168,7 +168,6 @@ class TestHighRiskEmployeeClient(object):
             mock_session, user_context, mock_detection_list_user_client
         )
         high_risk_employee_client.get_high_risk_employees_page(
-            tenant_id,
             filter_type="NEW_FILTER",
             page_num=3,
             page_size=10,


### PR DESCRIPTION
I need methods for exposing get detection list pages using page size and page nuns for Demisto.

I want the investigator to be able load in data slowly at a time, observe it, load more in, do something else, come back, load more in, etc.  This is coming from feedback from PAN.

Two new methods:
* get_high_risk_employees_page()
* get_departing_employees_page()

Also fixed an issue with get_all_pages which allows you to specify a page size there instead of it always using the global one no matter what.