### PR TITLE
Make email param required for `create_user()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ## Unreleased
 
+### Added
 - Make `ExposureType.OUTSIDE_TRUSTED_DOMAINS` constant available.
+
+### Changed
+- `email` is now a required param on `py42.users.create_user()`.
 
 ## 1.5.1 - 2020-06-17
 

--- a/src/py42/clients/users.py
+++ b/src/py42/clients/users.py
@@ -38,6 +38,8 @@ class UserClient(BaseClient):
         """
 
         uri = u"/api/User"
+        if email is None:
+            email = username
         data = {
             u"orgUid": org_uid,
             u"username": username,

--- a/src/py42/clients/users.py
+++ b/src/py42/clients/users.py
@@ -27,7 +27,7 @@ class UserClient(BaseClient):
         Args:
             org_uid (str): The org UID for the organization the new user belongs to.
             username (str): The username for the new user.
-            email (str, optional): The email for the new user. Defaults to None.
+            email (str): The email for the new user.
             password (str, optional): The password for the new user. Defaults to None.
             first_name (str, optional): The first name for the new user. Defaults to None.
             last_name (str, optional): The last name for the new user. Defaults to None.
@@ -38,8 +38,6 @@ class UserClient(BaseClient):
         """
 
         uri = u"/api/User"
-        if email is None:
-            email = username
         data = {
             u"orgUid": org_uid,
             u"username": username,

--- a/src/py42/clients/users.py
+++ b/src/py42/clients/users.py
@@ -13,7 +13,7 @@ class UserClient(BaseClient):
         self,
         org_uid,
         username,
-        email=None,
+        email,
         password=None,
         first_name=None,
         last_name=None,


### PR DESCRIPTION
I get 400 responses when leaving off this parameter, so it must be required.