### PR TITLE
Bugfix/fix errored pds download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - An issue where `sdk.securitydata.stream_file_by_md5()` and `sdk.securitydata.stream_file_by_sha256()` would return streams containing an error message instead of properly failing.
 
+- An issue where streaming methods would load the stream completely into memory instead of retrieving it one chunk at a time.
+
 ## 1.6.0 - 2020-06-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Fixed
+
+- An issue where `sdk.securitydata.stream_file_by_md5()` and `sdk.securitydata.stream_file_by_sha256()` would return streams containing an error message instead of properly failing.
+
 ## 1.6.0 - 2020-06-30
 
 ### Added

--- a/src/py42/_internal/client_factories.py
+++ b/src/py42/_internal/client_factories.py
@@ -124,8 +124,9 @@ class MicroserviceClientFactory(object):
         return self._pds_client
 
     def create_storage_preservation_client(self, host_address):
-        session = self._session_factory.create_jwt_session(host_address, self._root_session)
-        return StoragePreservationDataClient(session)
+        main_session = self._session_factory.create_jwt_session(host_address, self._root_session)
+        streaming_session = self._session_factory.create_anonymous_session(host_address)
+        return StoragePreservationDataClient(main_session, streaming_session)
 
     def _get_jwt_session(self, key):
         url = self._get_stored_value(key)

--- a/src/py42/_internal/clients/storage/storagenode.py
+++ b/src/py42/_internal/clients/storage/storagenode.py
@@ -10,6 +10,10 @@ class StoragePreservationDataClient(BaseClient):
 
     _base_uri = u"c42api/v3/"
 
+    def __init__(self, main_session, streaming_session):
+        super(StoragePreservationDataClient, self).__init__(main_session)
+        self._streaming_session = streaming_session
+
     def get_download_token(self, archive_guid, file_id, timestamp):
         """Get PDS download token for a file.
 
@@ -42,6 +46,4 @@ class StoragePreservationDataClient(BaseClient):
         else:
             replaced_token = token
         params = {u"PDSDownloadToken": replaced_token}
-        debug.logger.info(u"{0}{1}".format(str("GET").ljust(8), uri))
-        debug.logger.debug(format_dict(params, u"  params"))
-        return requests.get(uri, params=params, stream=True)
+        return self._streaming_session.get(uri, params=params, stream=True)

--- a/src/py42/_internal/clients/storage/storagenode.py
+++ b/src/py42/_internal/clients/storage/storagenode.py
@@ -46,4 +46,5 @@ class StoragePreservationDataClient(BaseClient):
         else:
             replaced_token = token
         params = {u"PDSDownloadToken": replaced_token}
-        return self._streaming_session.get(uri, params=params, stream=True)
+        headers = {u"Accept": "*/*"}
+        return self._streaming_session.get(uri, params=params, headers=headers, stream=True)

--- a/src/py42/modules/securitydata.py
+++ b/src/py42/modules/securitydata.py
@@ -211,10 +211,9 @@ class SecurityModule(object):
         for response in file_generator:
             if response.status_code == 204:
                 continue
-            url = response[u"storageNodeURL"]
             try:
                 storage_node_client = self._microservices_client_factory.create_storage_preservation_client(
-                    url
+                    response[u"storageNodeURL"]
                 )
                 token = storage_node_client.get_download_token(
                     response[u"archiveGuid"], response[u"fileId"], response[u"versionTimestamp"]
@@ -225,7 +224,9 @@ class SecurityModule(object):
                 # 'get_file_location_detail_by_sha256', hence we keep looking until we find a stream
                 # to return
                 debug.logger.warning(
-                    u"Failed to stream file with hash {0} from {1}.".format(checksum, url)
+                    u"Failed to stream file with hash {0}, info: {1}.".format(
+                        checksum, response.text
+                    )
                 )
         raise Py42Error(
             u"No file with hash {0} available for download on any storage node.".format(checksum)

--- a/src/py42/modules/securitydata.py
+++ b/src/py42/modules/securitydata.py
@@ -209,9 +209,9 @@ class SecurityModule(object):
 
     def _stream_file(self, file_generator, checksum):
         for response in file_generator:
-            url = response[u"storageNodeURL"]
             if response.status_code == 204:
                 continue
+            url = response[u"storageNodeURL"]
             try:
                 storage_node_client = self._microservices_client_factory.create_storage_preservation_client(
                     url

--- a/src/py42/modules/securitydata.py
+++ b/src/py42/modules/securitydata.py
@@ -217,10 +217,10 @@ class SecurityModule(object):
                     response[u"storageNodeURL"]
                 )
                 token = storage_node_client.get_download_token(
-                    response[u"archiveGuid"], response[u"fileId"], response[u"versionTimestamp"],
+                    response[u"archiveGuid"], response[u"fileId"], response[u"versionTimestamp"]
                 )
                 return storage_node_client.get_file(str(token))
-            except HTTPError as err:
+            except Py42HTTPError as err:
                 # API searches multiple paths to find the file to be streamed, as returned by
                 # 'get_file_location_detail_by_sha256', hence we keep looking until we find a stream
                 # to return

--- a/src/py42/modules/securitydata.py
+++ b/src/py42/modules/securitydata.py
@@ -202,19 +202,19 @@ class SecurityModule(object):
                 # 'get_file_location_detail_by_sha256', hence we keep looking until we find a stream
                 # to return
                 debug.logger.warning(
-                    u"PDS fetch file version API failed for md5 hash {0} and sha256 hash {1}. "
+                    u"Failed to find any file version for md5 hash {0} / sha256 hash {1}. "
                     u"Error: ".format(md5_hash, sha256_hash),
                     err,
                 )
-                pass
 
     def _stream_file(self, file_generator, checksum):
         for response in file_generator:
+            url = response[u"storageNodeURL"]
             if response.status_code == 204:
                 continue
             try:
                 storage_node_client = self._microservices_client_factory.create_storage_preservation_client(
-                    response[u"storageNodeURL"]
+                    url
                 )
                 token = storage_node_client.get_download_token(
                     response[u"archiveGuid"], response[u"fileId"], response[u"versionTimestamp"]
@@ -225,9 +225,8 @@ class SecurityModule(object):
                 # 'get_file_location_detail_by_sha256', hence we keep looking until we find a stream
                 # to return
                 debug.logger.warning(
-                    u"PDS stream file token API failed for hash {0}, Error:".format(checksum), err
+                    u"Failed to stream file with hash {0} from {1}.".format(checksum, url)
                 )
-                pass
         raise Py42Error(
             u"No file with hash {0} available for download on any storage node.".format(checksum)
         )

--- a/tests/_internal/clients/storage/test_storagenode.py
+++ b/tests/_internal/clients/storage/test_storagenode.py
@@ -11,12 +11,12 @@ class TestStoragePreservationDataClient(object):
         return request
 
     def test_get_download_token_calls_get_with_valid_params(self, mock_successful_session):
-        client = StoragePreservationDataClient(mock_successful_session)
+        client = StoragePreservationDataClient(mock_successful_session, mock_successful_session)
         client.get_download_token("abc", "fabc", 1223)
 
         mock_successful_session.get.assert_called_once_with(
             u"c42api/v3/FileDownloadToken",
-            params={u"archiveGuid": "abc", u"fileId": "fabc", u"versionTimestamp": 1223,},
+            params={u"archiveGuid": "abc", u"fileId": "fabc", u"versionTimestamp": 1223},
         )
 
     def test_get_file_calls_get_with_valid_params_with_substitution(
@@ -24,16 +24,16 @@ class TestStoragePreservationDataClient(object):
     ):
         mock_successful_session.host_address = "https://host.com"
 
-        client = StoragePreservationDataClient(mock_successful_session)
+        client = StoragePreservationDataClient(mock_successful_session, mock_successful_session)
         client.get_file("token")
-        mock_request.assert_called_once_with(
+        mock_successful_session.get.assert_called_once_with(
             "https://host.com/c42api/v3/GetFile", params={"PDSDownloadToken": "token"}, stream=True
         )
 
     def test_get_file_calls_get_with_valid_params(self, mock_successful_session, mock_request):
         mock_successful_session.host_address = "https://host.com"
-        client = StoragePreservationDataClient(mock_successful_session)
+        client = StoragePreservationDataClient(mock_successful_session, mock_successful_session)
         client.get_file("PDSDownloadToken=token")
-        mock_request.assert_called_once_with(
+        mock_successful_session.get.assert_called_once_with(
             "https://host.com/c42api/v3/GetFile", params={"PDSDownloadToken": "token"}, stream=True
         )

--- a/tests/_internal/clients/storage/test_storagenode.py
+++ b/tests/_internal/clients/storage/test_storagenode.py
@@ -27,7 +27,10 @@ class TestStoragePreservationDataClient(object):
         client = StoragePreservationDataClient(mock_successful_session, mock_successful_session)
         client.get_file("token")
         mock_successful_session.get.assert_called_once_with(
-            "https://host.com/c42api/v3/GetFile", params={"PDSDownloadToken": "token"}, stream=True
+            "https://host.com/c42api/v3/GetFile",
+            headers={"Accept": "*/*"},
+            params={"PDSDownloadToken": "token"},
+            stream=True,
         )
 
     def test_get_file_calls_get_with_valid_params(self, mock_successful_session, mock_request):
@@ -35,5 +38,8 @@ class TestStoragePreservationDataClient(object):
         client = StoragePreservationDataClient(mock_successful_session, mock_successful_session)
         client.get_file("PDSDownloadToken=token")
         mock_successful_session.get.assert_called_once_with(
-            "https://host.com/c42api/v3/GetFile", params={"PDSDownloadToken": "token"}, stream=True
+            "https://host.com/c42api/v3/GetFile",
+            headers={"Accept": "*/*"},
+            params={"PDSDownloadToken": "token"},
+            stream=True,
         )

--- a/tests/_internal/test_client_factories.py
+++ b/tests/_internal/test_client_factories.py
@@ -271,3 +271,4 @@ class TestMicroserviceClientFactory(object):
         )
         factory.create_storage_preservation_client("https://host.com")
         session_factory.create_jwt_session.assert_called_once_with("https://host.com", mock_session)
+        session_factory.create_anonymous_session.assert_called_once_with("https://host.com")

--- a/tests/modules/test_securitydata.py
+++ b/tests/modules/test_securitydata.py
@@ -1,6 +1,8 @@
 import pytest
 import json
 
+from requests.exceptions import HTTPError
+
 from py42._internal.client_factories import MicroserviceClientFactory
 from py42._internal.clients.securitydata import SecurityClient
 from py42._internal.clients.storage import (
@@ -13,7 +15,7 @@ from py42._internal.clients.storage.storagenode import StoragePreservationDataCl
 from py42.clients.file_event import FileEventClient
 from py42.modules.securitydata import PlanStorageInfo, SecurityModule
 from py42.response import Py42Response
-from py42.exceptions import Py42Error
+from py42.exceptions import Py42Error, Py42HTTPError
 
 RAW_QUERY = "RAW JSON QUERY"
 
@@ -760,7 +762,6 @@ class TestSecurityModule(object):
         file_location,
         find_file_version,
         file_download,
-        error_response,
     ):
         security_module = SecurityModule(
             security_client, storage_client_factory, microservice_client_factory
@@ -776,7 +777,7 @@ class TestSecurityModule(object):
 
         storage_node_client = mocker.MagicMock(spec=StoragePreservationDataClient)
         storage_node_client.get_download_token.return_value = file_download
-        storage_node_client.get_file.side_effect = error_response
+        storage_node_client.get_file.side_effect = Py42HTTPError(HTTPError())
         microservice_client_factory.create_storage_preservation_client.return_value = (
             storage_node_client
         )
@@ -894,7 +895,6 @@ class TestSecurityModule(object):
         file_location,
         find_file_version,
         file_download,
-        error_response,
     ):
         security_module = SecurityModule(
             security_client, storage_client_factory, microservice_client_factory
@@ -910,7 +910,7 @@ class TestSecurityModule(object):
 
         storage_node_client = mocker.MagicMock(spec=StoragePreservationDataClient)
         storage_node_client.get_download_token.return_value = file_download
-        storage_node_client.get_file.side_effect = error_response
+        storage_node_client.get_file.side_effect = Py42HTTPError(HTTPError())
         microservice_client_factory.create_storage_preservation_client.return_value = (
             storage_node_client
         )


### PR DESCRIPTION
See internal detail at https://jira.corp.code42.com/browse/INTEG-1124.

If the `GetFile` request to the storage node fails, today this is resulting a stream that contains an error message from the server being returned instead of properly failing. This appears to have been caused by some differences in http headers.

Also fixes an issue that @timabrmsn found where streams were being loaded completely into memory due to `.text` being called in the `Py42Response` constructor.

To test:
```python
# this hash produces the error in our "partner" account, should result in a raised`Py42Error`.
sdk.securitydata.stream_file_by_sha256("8dc4e9ac5355cb2a87447cdaa9a15badefa027af70c3c8200a2e776b37f993ea")

# also ensure that the normal use case still works.
# Inspect the contents of written file to verify it does not simply contain an error message.
# from the "demo" account
stream = sdk.securitydata.stream_file_by_sha256("098db7aff65b03a60eb784d4005f08325243d8e747f52a98244ff6116171f56d")
with open("testfile.txt", "wb") as test:
    for chunk in stream.iter_content():
        test.write(chunk)
```