### PR TITLE
adjust changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,22 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
-## 1.7.1 - 2020-07-24
-
-### Changed
-
-- `sdk.securitydata.stream_file_by_md5()` now raises `Py42ChecksumNotFoundError` when no matching md5 is found (previously was `Py42ArchiveFileNotFoundError`).
-- `sdk.securitydata.stream_file_by_sha256()` now raises `Py42ChecksumNotFoundError` when no matching md5 is found (previously was `Py42Error`).
-
-### Fixed
-
-- functions now return `Py42Response` objects as expected:
-    - `sdk.detectionlists.update_user_notes()`
-    - `sdk.detectionlists.add_user_risk_tags()`
-    - `sdk.detectionlists.remove_user_risk_tags()`
-    - `sdk.detectionlists.add_user_cloud_alias()`
-    - `sdk.detectionlists.remove_user_cloud_alias()`
-- `sdk.archive.get_all_org_cold_storage_archives()` now actually uses parameters `include_child_orgs`, `sort_key` and `sort_dir`.
+## Unreleased
 
 ### Added
 
@@ -42,6 +27,23 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
     - EventTimestamp
     - EventType
     - SharingTypeAdded
+
+## 1.7.1 - 2020-07-24
+
+### Changed
+
+- `sdk.securitydata.stream_file_by_md5()` now raises `Py42ChecksumNotFoundError` when no matching md5 is found (previously was `Py42ArchiveFileNotFoundError`).
+- `sdk.securitydata.stream_file_by_sha256()` now raises `Py42ChecksumNotFoundError` when no matching md5 is found (previously was `Py42Error`).
+
+### Fixed
+
+- functions now return `Py42Response` objects as expected:
+    - `sdk.detectionlists.update_user_notes()`
+    - `sdk.detectionlists.add_user_risk_tags()`
+    - `sdk.detectionlists.remove_user_risk_tags()`
+    - `sdk.detectionlists.add_user_cloud_alias()`
+    - `sdk.detectionlists.remove_user_cloud_alias()`
+- `sdk.archive.get_all_org_cold_storage_archives()` now actually uses parameters `include_child_orgs`, `sort_key` and `sort_dir`.
 
 ## 1.7.0 - 2020-07-21
 


### PR DESCRIPTION
### Description of Change ###

Some changes that were made _after_ 1.7.1 was released were mistakenly included in the 1.7.1 section of the changelog (the release notes are correct).

