### PR TITLE
Risk tag constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
     - `sdk.legalhold.get_custodians_page()`
     - `sdk.alerts.get_rules_page()`
 
+- Added enum object `py42.modules.detectionlists.RiskTags` with constants:
+    - `FLIGHT_RISK`
+    - `HIGH_IMPACT_EMPLOYEE`
+    - `ELEVATED_ACCESS_PRIVILEGES`
+    - `PERFORMANCE_CONCERNS`
+    - `SUSPICIOUS_SYSTEM_ACTIVITY`
+    - `POOR_SECURITY_PRACTICES`
+    - `CONTRACT_EMPLOYEE`
+
 - Added below event filter support
     - TrustedActivity
     - RemoteActivity

--- a/src/py42/modules/detectionlists.py
+++ b/src/py42/modules/detectionlists.py
@@ -2,6 +2,9 @@ from py42.sdk.queries.query_filter import filter_attributes
 
 
 class RiskTags(object):
+    """The available RiskTags for :meth:`~py42.modules.detectionlists.DetectionListsModule.add_user_risk_tags()`
+    and :meth:`~py42.modules.detectionlists.DetectionListsModule.remove_user_risk_tags()`"""
+
     FLIGHT_RISK = u"FLIGHT_RISK"
     HIGH_IMPACT_EMPLOYEE = u"HIGH_IMPACT_EMPLOYEE"
     ELEVATED_ACCESS_PRIVILEGES = u"ELEVATED_ACCESS_PRIVILEGES"

--- a/src/py42/modules/detectionlists.py
+++ b/src/py42/modules/detectionlists.py
@@ -1,3 +1,20 @@
+from py42.sdk.queries.query_filter import filter_attributes
+
+
+class RiskTags(object):
+    FLIGHT_RISK = u"FLIGHT_RISK"
+    HIGH_IMPACT_EMPLOYEE = u"HIGH_IMPACT_EMPLOYEE"
+    ELEVATED_ACCESS_PRIVILEGES = u"ELEVATED_ACCESS_PRIVILEGES"
+    PERFORMANCE_CONCERNS = u"PERFORMANCE_CONCERNS"
+    SUSPICIOUS_SYSTEM_ACTIVITY = u"SUSPICIOUS_SYSTEM_ACTIVITY"
+    POOR_SECURITY_PRACTICES = u"POOR_SECURITY_PRACTICES"
+    CONTRACT_EMPLOYEE = u"CONTRACT_EMPLOYEE"
+
+    @staticmethod
+    def choices():
+        return filter_attributes(RiskTags)
+
+
 class DetectionListsModule(object):
     def __init__(self, microservice_client_factory):
         self._microservice_client_factory = microservice_client_factory

--- a/tests/modules/test_detectionlists.py
+++ b/tests/modules/test_detectionlists.py
@@ -19,7 +19,6 @@ def mock_detection_list_user_client(mocker):
 TEST_USER_ID = "12345"
 
 
-
 class TestRiskTags(object):
     def test_choices_returns_expected_set(self):
         choices = RiskTags.choices()

--- a/tests/modules/test_detectionlists.py
+++ b/tests/modules/test_detectionlists.py
@@ -3,6 +3,7 @@ import pytest
 from py42._internal.client_factories import MicroserviceClientFactory
 from py42._internal.clients.detection_list_user import DetectionListUserClient
 from py42.modules.detectionlists import DetectionListsModule
+from py42.modules.detectionlists import RiskTags
 
 
 @pytest.fixture
@@ -16,6 +17,22 @@ def mock_detection_list_user_client(mocker):
 
 
 TEST_USER_ID = "12345"
+
+
+
+class TestRiskTags(object):
+    def test_choices_returns_expected_set(self):
+        choices = RiskTags.choices()
+        valid_set = {
+            "FLIGHT_RISK",
+            "HIGH_IMPACT_EMPLOYEE",
+            "ELEVATED_ACCESS_PRIVILEGES",
+            "PERFORMANCE_CONCERNS",
+            "SUSPICIOUS_SYSTEM_ACTIVITY",
+            "POOR_SECURITY_PRACTICES",
+            "CONTRACT_EMPLOYEE",
+        }
+        assert set(choices) == valid_set
 
 
 class TestDetectionListModule(object):


### PR DESCRIPTION
### Description of Change ###

Adds the risk tag constants

### Issues Resolved ###

INTEG-1037

### Testing Procedure ###
Make sure you can import the constants `py42.modules.detectionlists.RiskTags` and call `choices()` and you get the tags

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
