### PR TITLE
Feature/more exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
     - `Py42ResponseError`
     - `Py42UserAlreadyAddedError`
     - `Py42UserNotInLegalHoldError`
-    - `Py42LegalHoldNotFoundError`
-    - `Py42PermissionDeniedError`
+    - `Py42LegalHoldNotFoundOrPermissionDeniedError`
     - `Py42UserDoesNotExistError`
     - `Py42InvalidRuleOperationError`
 
@@ -71,8 +70,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 - `py42.detectionlists.departing_employee.add()` now raises `Py42UserAlreadyAddedError` when the user is already on the list.
 - `py42.detectionlists.high_risk_employee.add()` now raises `Py42UserAlreadyAddedError` when the user already on the list.
 - `py42.legalhold.add_to_matter()` now raises `Py42UserAlreadyAddedError` when the user is already on the matter.
-- `py42.legalhold.get_matter_by_uid()` now raises `Py42LegalHoldNotFoundError` on bad requests.
-- `py42.legalhold.get_matter_by_uid()` now raises `Py42LegalHoldPermissionDeniedError` when the user does not have access.
+- `py42.legalhold.get_matter_by_uid()` now raises `Py42LegalHoldNotFoundOrPermissionDeniedError` when the user does not have
+    access or the ID does not exist.
 - `py42.users.get_by_username()` now raises `Py42UserDoesNotExistError` when the user is not found.
 - `py42.alerts.rules.add_user()` now raises `Py42InvalidRuleTypeError` when trying to add a user to a system rule.
 - `py42.alerts.rules.remove_user()` now raises `Py42InvalidRuleTypeError` when trying to remove user from a system rule.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ## Unreleased
 
+### Added
+
 - Methods for calling the agent-state APIs:
     - `sdk.devices.get_agent_state()`
     - `sdk.devices.get_agent_full_disk_access_state()`
     - `sdk.orgs.get_agent_state()`
     - `sdk.orgs.get_agent_full_disk_access_states()`
-
-### Added
 
 - Exception classes (`py42.execeptions`
     - `Py42ResponseError`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
     - `sdk.orgs.get_agent_state()`
     - `sdk.orgs.get_agent_full_disk_access_states()`
 
-- Exception classes (`py42.execeptions`
+- Exception classes (`py42.execeptions`)
     - `Py42ResponseError`
     - `Py42UserAlreadyAddedError`
     - `Py42UserNotInLegalHoldError`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
     - `Py42UserNotInLegalHoldError`
     - `Py42LegalHoldNotFoundOrPermissionDeniedError`
     - `Py42UserDoesNotExistError`
+    - `Py42InvalidRuleTypeError`
 
 - Methods for getting individual response pages:
     - `sdk.detectionlists.departing_employee.get_page()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - `py42.detectionlists.departing_employee.add()` now raises `Py42UserAlreadyAddedError` when user already present on list.
 - `py42.detectionlists.high_risk_employee.add()` now raises `Py42UserAlreadyAddedError` when user already present on list.
-- `py42.legalhold.add_to_matter()` now raises `Py42UserAlreadyAddedError` when use already on matter.
+- `py42.legalhold.add_to_matter()` now raises `Py42UserAlreadyAddedError` when user already on matter.
 - `py42.legalhold.get_matter_by_uid()` now raises `Py42LegalHoldNotFoundOrPermissionDeniedError` when matter unavailable.
 - `py42.users.get_by_username()` now raises `Py42UserDoesNotExistError`
 - `py42.alerts.rules.add_user()` now raises `Py42InvalidRuleTypeError` when trying to add a user to a system rule.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,13 +60,13 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Changed
 
-- `py42.detectionlists.departing_employee.add()` now raises `Py42UserAlreadyAddedError` when user already present on list.
-- `py42.detectionlists.high_risk_employee.add()` now raises `Py42UserAlreadyAddedError` when user already present on list.
-- `py42.legalhold.add_to_matter()` now raises `Py42UserAlreadyAddedError` when user already on matter.
-- `py42.legalhold.get_matter_by_uid()` now raises `Py42LegalHoldNotFoundOrPermissionDeniedError` when matter unavailable.
+- `py42.detectionlists.departing_employee.add()` now raises `Py42UserAlreadyAddedError` when the user is already on the list.
+- `py42.detectionlists.high_risk_employee.add()` now raises `Py42UserAlreadyAddedError` when the user already on the list.
+- `py42.legalhold.add_to_matter()` now raises `Py42UserAlreadyAddedError` when the user is already on the matter.
+- `py42.legalhold.get_matter_by_uid()` now raises `Py42LegalHoldNotFoundOrPermissionDeniedError` when the matter is unavailable.
 - `py42.users.get_by_username()` now raises `Py42UserDoesNotExistError`.
 - `py42.alerts.rules.add_user()` now raises `Py42InvalidRuleTypeError` when trying to add a user to a system rule.
-- `py42.alerts.rules.remove_user()` now raises `Py42InvalidRuleTypeError` when trying to remove a user from a system rule.
+- `py42.alerts.rules.remove_user()` now raises `Py42InvalidRuleTypeError` when trying to a remove user from a system rule.
 
 ## 1.7.1 - 2020-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,16 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
     - AlertState
     - Severity
 
+### Changed
+
+- `py42.detectionlists.departing_employee.add()` now raises `Py42UserAlreadyAddedError` when user already present on list.
+- `py42.detectionlists.high_risk_employee.add()` now raises `Py42UserAlreadyAddedError` when user already present on list.
+- `py42.legalhold.add_to_matter()` now raises `Py42UserAlreadyAddedError` when use already on matter.
+- `py42.legalhold.get_matter_by_uid()` now raises `Py42LegalHoldNotFoundOrPermissionDeniedError` when matter unavailable.
+- `py42.users.get_by_username()` now raises `Py42UserDoesNotExistError`
+- `py42.alerts.rules.add_user()` now raises `Py42InvalidRuleTypeError` when trying to add a user to a system rule.
+- `py42.alerts.rules.remove_user()` now raises `Py42InvalidRuleTypeError` when trying to remove a user from a system rule.
+
 ## 1.7.1 - 2020-07-24
 
 ### Changed
@@ -74,14 +84,6 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
     - `sdk.detectionlists.add_user_cloud_alias()`
     - `sdk.detectionlists.remove_user_cloud_alias()`
 - `sdk.archive.get_all_org_cold_storage_archives()` now actually uses parameters `include_child_orgs`, `sort_key` and `sort_dir`.
-
-### Changed
-
-- `py42.detectionlists.departing_employee.add()` now raises `Py42UserAlreadyAddedError` when user already present on list.
-- `py42.detectionlists.high_risk_employee.add()` now raises `Py42UserAlreadyAddedError` when user already present on list.
-- `py42.legalhold.add_to_matter()` now raises `Py42UserAlreadyAddedError` when use already on matter.
-- `py42.legalhold.get_matter_by_uid()` now raises `Py42LegalHoldNotFoundOrPermissionDeniedError` when matter unavailable.
-- `py42.users.get_by_username()` now raises `Py42UserDoesNotExistError`
 
 ## 1.7.0 - 2020-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
     - `Py42UserAlreadyAddedError`
     - `Py42UserNotInLegalHoldError`
     - `Py42LegalHoldNotFoundOrPermissionDeniedError`
+    - `Py42UserDoesNotExistError`
 
 - Methods for getting individual response pages:
     - `sdk.detectionlists.departing_employee.get_page()`
@@ -79,6 +80,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 - `py42.detectionlists.high_risk_employee.add()` now raises `Py42UserAlreadyAddedError` when user already present on list.
 - `py42.legalhold.add_to_matter()` now raises `Py42UserAlreadyAddedError` when use already on matter.
 - `py42.legalhold.get_matter_by_uid()` now raises `Py42LegalHoldNotFoundOrPermissionDeniedError` when matter unavailable.
+- `py42.users.get_by_username()` now raises `Py42UserDoesNotExistError`
 
 ## 1.7.0 - 2020-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 - `py42.detectionlists.high_risk_employee.add()` now raises `Py42UserAlreadyAddedError` when the user already on the list.
 - `py42.legalhold.add_to_matter()` now raises `Py42UserAlreadyAddedError` when the user is already on the matter.
 - `py42.legalhold.get_matter_by_uid()` now raises `Py42LegalHoldNotFoundOrPermissionDeniedError` when the matter is unavailable.
-- `py42.users.get_by_username()` now raises `Py42UserDoesNotExistError`.
+- `py42.users.get_by_username()` now raises `Py42UserDoesNotExistError` when the user is not found.
 - `py42.alerts.rules.add_user()` now raises `Py42InvalidRuleTypeError` when trying to add a user to a system rule.
 - `py42.alerts.rules.remove_user()` now raises `Py42InvalidRuleTypeError` when trying to a remove user from a system rule.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
     - `Py42ResponseError`
     - `Py42UserAlreadyAddedError`
     - `Py42UserNotInLegalHoldError`
-    - `Py42LegalHoldNotFoundOrPermissionDeniedError`
+    - `Py42LegalHoldNotFoundError`
+    - `Py42PermissionDeniedError`
     - `Py42UserDoesNotExistError`
     - `Py42InvalidRuleTypeError`
 
@@ -70,7 +71,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 - `py42.detectionlists.departing_employee.add()` now raises `Py42UserAlreadyAddedError` when the user is already on the list.
 - `py42.detectionlists.high_risk_employee.add()` now raises `Py42UserAlreadyAddedError` when the user already on the list.
 - `py42.legalhold.add_to_matter()` now raises `Py42UserAlreadyAddedError` when the user is already on the matter.
-- `py42.legalhold.get_matter_by_uid()` now raises `Py42LegalHoldNotFoundOrPermissionDeniedError` when the matter is unavailable.
+- `py42.legalhold.get_matter_by_uid()` now raises `Py42LegalHoldNotFoundError` on bad requests.
+- `py42.legalhold.get_matter_by_uid()` now raises `Py42LegalHoldPermissionDeniedError` when the user does not have access.
 - `py42.users.get_by_username()` now raises `Py42UserDoesNotExistError` when the user is not found.
 - `py42.alerts.rules.add_user()` now raises `Py42InvalidRuleTypeError` when trying to add a user to a system rule.
 - `py42.alerts.rules.remove_user()` now raises `Py42InvalidRuleTypeError` when trying to remove user from a system rule.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
     - `Py42LegalHoldNotFoundError`
     - `Py42PermissionDeniedError`
     - `Py42UserDoesNotExistError`
-    - `Py42InvalidRuleTypeError`
+    - `Py42InvalidRuleOperationError`
 
 - Methods for getting individual response pages:
     - `sdk.detectionlists.departing_employee.get_page()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Added
 
-- Exception classes (`py42.execeptions`)
+- Exception classes (`py42.execeptions`
+    - `Py42ResponseError`
     - `Py42UserAlreadyAddedError`
     - `Py42UserNotInLegalHoldError`
     - `Py42LegalHoldNotFoundOrPermissionDeniedError`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,11 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 - `py42.users.get_by_username()` now raises `Py42UserDoesNotExistError` when the user is not found.
 - `py42.alerts.rules.add_user()` now raises `Py42InvalidRuleTypeError` when trying to add a user to a system rule.
 - `py42.alerts.rules.remove_user()` now raises `Py42InvalidRuleTypeError` when trying to a remove user from a system rule.
+- `Py42ArchiveFileNotFoundError` now includes the response.
+- `Py42ChecksumNotFoundError` now includes the response.
+- `Py42FeatureUnavailableError` now includes the response.
+- `Py42UserDoesNotExistError` now includes the response.
+- `Py42StorageSessionInitializationError` now includes the response.
 
 ## 1.7.1 - 2020-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 - `py42.detectionlists.high_risk_employee.add()` now raises `Py42UserAlreadyAddedError` when user already present on list.
 - `py42.legalhold.add_to_matter()` now raises `Py42UserAlreadyAddedError` when user already on matter.
 - `py42.legalhold.get_matter_by_uid()` now raises `Py42LegalHoldNotFoundOrPermissionDeniedError` when matter unavailable.
-- `py42.users.get_by_username()` now raises `Py42UserDoesNotExistError`
+- `py42.users.get_by_username()` now raises `Py42UserDoesNotExistError`.
 - `py42.alerts.rules.add_user()` now raises `Py42InvalidRuleTypeError` when trying to add a user to a system rule.
 - `py42.alerts.rules.remove_user()` now raises `Py42InvalidRuleTypeError` when trying to remove a user from a system rule.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 - `py42.legalhold.get_matter_by_uid()` now raises `Py42LegalHoldNotFoundOrPermissionDeniedError` when the matter is unavailable.
 - `py42.users.get_by_username()` now raises `Py42UserDoesNotExistError` when the user is not found.
 - `py42.alerts.rules.add_user()` now raises `Py42InvalidRuleTypeError` when trying to add a user to a system rule.
-- `py42.alerts.rules.remove_user()` now raises `Py42InvalidRuleTypeError` when trying to a remove user from a system rule.
+- `py42.alerts.rules.remove_user()` now raises `Py42InvalidRuleTypeError` when trying to remove user from a system rule.
 - `Py42ArchiveFileNotFoundError` now includes the response.
 - `Py42ChecksumNotFoundError` now includes the response.
 - `Py42FeatureUnavailableError` now includes the response.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Added
 
+- Exception classes (`py42.execeptions`)
+    - `Py42UserAlreadyAddedError`
+    - `Py42UserNotInLegalHoldError`
+    - `Py42LegalHoldNotFoundOrPermissionDeniedError`
+
 - Methods for getting individual response pages:
     - `sdk.detectionlists.departing_employee.get_page()`
     - `sdk.detectionlists.high_risk.get_page()`
@@ -67,6 +72,13 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
     - `sdk.detectionlists.add_user_cloud_alias()`
     - `sdk.detectionlists.remove_user_cloud_alias()`
 - `sdk.archive.get_all_org_cold_storage_archives()` now actually uses parameters `include_child_orgs`, `sort_key` and `sort_dir`.
+
+### Changed
+
+- `py42.detectionlists.departing_employee.add()` now raises `Py42UserAlreadyAddedError` when user already present on list.
+- `py42.detectionlists.high_risk_employee.add()` now raises `Py42UserAlreadyAddedError` when user already present on list.
+- `py42.legalhold.add_to_matter()` now raises `Py42UserAlreadyAddedError` when use already on matter.
+- `py42.legalhold.get_matter_by_uid()` now raises `Py42LegalHoldNotFoundOrPermissionDeniedError` when matter unavailable.
 
 ## 1.7.0 - 2020-07-21
 

--- a/src/py42/_internal/archive_access.py
+++ b/src/py42/_internal/archive_access.py
@@ -95,11 +95,11 @@ class ArchiveAccessor(object):
         response = self._get_children(node_id=None)
         for root in response:
             if root[u"path"].lower() == path_root.lower():
-                return self._walk_tree(root, path_parts[1:])
+                return self._walk_tree(response, root, path_parts[1:])
 
-        raise Py42ArchiveFileNotFoundError(self._device_guid, file_path)
+        raise Py42ArchiveFileNotFoundError(response, self._device_guid, file_path)
 
-    def _walk_tree(self, current_node, remaining_path_components):
+    def _walk_tree(self, response, current_node, remaining_path_components):
         if not remaining_path_components or not remaining_path_components[0]:
             return current_node
 
@@ -111,9 +111,9 @@ class ArchiveAccessor(object):
 
         for child in children:
             if child[u"path"].lower() == target_child_path.lower():
-                return self._walk_tree(child, remaining_path_components[1:])
+                return self._walk_tree(response, child, remaining_path_components[1:])
 
-        raise Py42ArchiveFileNotFoundError(self._device_guid, target_child_path)
+        raise Py42ArchiveFileNotFoundError(response, self._device_guid, target_child_path)
 
     def _get_children(self, node_id=None):
         return self._storage_archive_client.get_file_path_metadata(

--- a/src/py42/_internal/archive_access.py
+++ b/src/py42/_internal/archive_access.py
@@ -113,7 +113,9 @@ class ArchiveAccessor(object):
             if child[u"path"].lower() == target_child_path.lower():
                 return self._walk_tree(response, child, remaining_path_components[1:])
 
-        raise Py42ArchiveFileNotFoundError(response, self._device_guid, target_child_path)
+        raise Py42ArchiveFileNotFoundError(
+            response, self._device_guid, target_child_path
+        )
 
     def _get_children(self, node_id=None):
         return self._storage_archive_client.get_file_path_metadata(

--- a/src/py42/_internal/storage_session_manager.py
+++ b/src/py42/_internal/storage_session_manager.py
@@ -29,7 +29,7 @@ class StorageSessionManager(object):
             message = u"Failed to create or retrieve session, caused by: {}".format(
                 str(ex)
             )
-            raise Py42StorageSessionInitializationError(message)
+            raise Py42StorageSessionInitializationError(ex, message)
         return session
 
     def create_storage_session(self, url, token_provider):

--- a/src/py42/clients/detectionlists/__init__.py
+++ b/src/py42/clients/detectionlists/__init__.py
@@ -4,6 +4,6 @@ _PAGE_SIZE = 100
 
 
 def handle_user_already_added_error(bad_request_err, username_tried_adding, list_name):
-    if "User already on list" in bad_request_err.response.text:
+    if u"User already on list" in bad_request_err.response.text:
         raise Py42UserAlreadyAddedError(username_tried_adding, list_name)
     return False

--- a/src/py42/clients/detectionlists/__init__.py
+++ b/src/py42/clients/detectionlists/__init__.py
@@ -1,1 +1,9 @@
+from py42.exceptions import Py42UserAlreadyAddedError
+
 _PAGE_SIZE = 100
+
+
+def handle_user_already_added_error(bad_request_err, username_tried_adding, list_name):
+    if "User already on list" in bad_request_err.response.text:
+        raise Py42UserAlreadyAddedError(username_tried_adding, list_name)
+    return False

--- a/src/py42/clients/detectionlists/__init__.py
+++ b/src/py42/clients/detectionlists/__init__.py
@@ -5,4 +5,6 @@ _PAGE_SIZE = 100
 
 def handle_user_already_added_error(bad_request_err, username_tried_adding, list_name):
     if u"User already on list" in bad_request_err.response.text:
-        raise Py42UserAlreadyAddedError(username_tried_adding, list_name)
+        raise Py42UserAlreadyAddedError(
+            bad_request_err, username_tried_adding, list_name
+        )

--- a/src/py42/clients/detectionlists/__init__.py
+++ b/src/py42/clients/detectionlists/__init__.py
@@ -6,4 +6,3 @@ _PAGE_SIZE = 100
 def handle_user_already_added_error(bad_request_err, username_tried_adding, list_name):
     if u"User already on list" in bad_request_err.response.text:
         raise Py42UserAlreadyAddedError(username_tried_adding, list_name)
-    return False

--- a/src/py42/clients/detectionlists/departing_employee.py
+++ b/src/py42/clients/detectionlists/departing_employee.py
@@ -44,9 +44,8 @@ class DepartingEmployeeClient(BaseClient):
             try:
                 return self._session.post(uri, data=json.dumps(data))
             except Py42BadRequestError as err:
-                user_text = u"User with ID {}".format(user_id)
                 handle_user_already_added_error(
-                    err, user_text, u"departing-employee list"
+                    err, user_id, u"departing-employee list"
                 )
                 raise
 

--- a/src/py42/clients/detectionlists/high_risk_employee.py
+++ b/src/py42/clients/detectionlists/high_risk_employee.py
@@ -47,9 +47,8 @@ class HighRiskEmployeeClient(BaseClient):
             try:
                 return self._add_high_risk_employee(tenant_id, user_id)
             except Py42BadRequestError as err:
-                user_text = u"User with ID {}".format(user_id)
                 handle_user_already_added_error(
-                    err, user_text, u"high-risk-employee list"
+                    err, user_id, u"high-risk-employee list"
                 )
                 raise
 

--- a/src/py42/clients/legalhold.py
+++ b/src/py42/clients/legalhold.py
@@ -6,8 +6,7 @@ from py42.clients.util import get_all_pages
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42Error
 from py42.exceptions import Py42ForbiddenError
-from py42.exceptions import Py42LegalHoldNotFoundError
-from py42.exceptions import Py42LegalHoldPermissionDeniedError
+from py42.exceptions import Py42LegalHoldNotFoundOrPermissionDeniedError
 from py42.exceptions import Py42UserAlreadyAddedError
 
 
@@ -111,10 +110,8 @@ class LegalHoldClient(BaseClient):
         uri = u"/api/LegalHold/{}".format(legal_hold_uid)
         try:
             return self._session.get(uri)
-        except Py42BadRequestError as err:
-            raise Py42LegalHoldNotFoundError(err, legal_hold_uid)
         except Py42ForbiddenError as err:
-            raise Py42LegalHoldPermissionDeniedError(err, legal_hold_uid)
+            raise Py42LegalHoldNotFoundOrPermissionDeniedError(err, legal_hold_uid)
 
     def get_matters_page(
         self,

--- a/src/py42/clients/legalhold.py
+++ b/src/py42/clients/legalhold.py
@@ -110,8 +110,8 @@ class LegalHoldClient(BaseClient):
         uri = u"/api/LegalHold/{}".format(legal_hold_uid)
         try:
             return self._session.get(uri)
-        except (Py42BadRequestError, Py42ForbiddenError):
-            raise Py42LegalHoldNotFoundOrPermissionDeniedError(legal_hold_uid)
+        except (Py42BadRequestError, Py42ForbiddenError) as err:
+            raise Py42LegalHoldNotFoundOrPermissionDeniedError(err, legal_hold_uid)
 
     def get_matters_page(
         self,
@@ -282,13 +282,13 @@ class LegalHoldClient(BaseClient):
         data = {u"legalHoldUid": legal_hold_uid, u"userUid": user_uid}
         try:
             return self._session.post(uri, data=json.dumps(data))
-        except Py42BadRequestError as e:
-            if u"USER_ALREADY_IN_HOLD" in e.response.text:
+        except Py42BadRequestError as err:
+            if u"USER_ALREADY_IN_HOLD" in err.response.text:
                 matter = self.get_matter_by_uid(legal_hold_uid)
                 matter_id_and_name_text = u"legal hold matter id={}, name={}".format(
                     legal_hold_uid, matter[u"name"]
                 )
-                raise Py42UserAlreadyAddedError(user_uid, matter_id_and_name_text)
+                raise Py42UserAlreadyAddedError(err, user_uid, matter_id_and_name_text)
             raise
 
     def remove_from_matter(self, legal_hold_membership_uid):

--- a/src/py42/clients/legalhold.py
+++ b/src/py42/clients/legalhold.py
@@ -6,7 +6,8 @@ from py42.clients.util import get_all_pages
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42Error
 from py42.exceptions import Py42ForbiddenError
-from py42.exceptions import Py42LegalHoldNotFoundOrPermissionDeniedError
+from py42.exceptions import Py42LegalHoldNotFoundError
+from py42.exceptions import Py42LegalHoldPermissionDeniedError
 from py42.exceptions import Py42UserAlreadyAddedError
 
 
@@ -110,8 +111,10 @@ class LegalHoldClient(BaseClient):
         uri = u"/api/LegalHold/{}".format(legal_hold_uid)
         try:
             return self._session.get(uri)
-        except (Py42BadRequestError, Py42ForbiddenError) as err:
-            raise Py42LegalHoldNotFoundOrPermissionDeniedError(err, legal_hold_uid)
+        except Py42BadRequestError as err:
+            raise Py42LegalHoldNotFoundError(err, legal_hold_uid)
+        except Py42ForbiddenError as err:
+            raise Py42LegalHoldPermissionDeniedError(err, legal_hold_uid)
 
     def get_matters_page(
         self,

--- a/src/py42/clients/legalhold.py
+++ b/src/py42/clients/legalhold.py
@@ -288,8 +288,7 @@ class LegalHoldClient(BaseClient):
                 matter_id_and_name_text = u"legal hold matter id={}, name={}".format(
                     legal_hold_uid, matter[u"name"]
                 )
-                user_text = u"User with ID {}".format(user_uid)
-                raise Py42UserAlreadyAddedError(user_text, matter_id_and_name_text)
+                raise Py42UserAlreadyAddedError(user_uid, matter_id_and_name_text)
             raise
 
     def remove_from_matter(self, legal_hold_membership_uid):

--- a/src/py42/clients/legalhold.py
+++ b/src/py42/clients/legalhold.py
@@ -105,7 +105,7 @@ class LegalHoldClient(BaseClient):
             legal_hold_uid (str): The identifier of the Legal Hold Matter.
 
         Returns:
-            :class:`py 42.response.Py42Response`: A response containing the Matter.
+            :class:`py42.response.Py42Response`: A response containing the Matter.
         """
         uri = u"/api/LegalHold/{}".format(legal_hold_uid)
         try:

--- a/src/py42/clients/users.py
+++ b/src/py42/clients/users.py
@@ -93,7 +93,7 @@ class UserClient(BaseClient):
         uri = u"/api/User"
         params = dict(username=username, **kwargs)
         users = self._session.get(uri, params=params)
-        if not users["users"]:
+        if not users[u"users"]:
             raise Py42UserDoesNotExistError(username)
         return users
 

--- a/src/py42/clients/users.py
+++ b/src/py42/clients/users.py
@@ -129,7 +129,6 @@ class UserClient(BaseClient):
             org_uid (str, optional): Limits users to only those in the organization with this org
                 UID. Defaults to None.
             role_id (int, optional): Limits users to only those with a given role ID. Defaults to
-            role_id (int, optional): Limits users to only those with a given role ID. Defaults to
                 None.
             page_size (int, optional): The number of items on the page. Defaults to `py42.settings.items_per_page`.
             q (str, optional): A generic query filter that searches across name, username, and

--- a/src/py42/clients/users.py
+++ b/src/py42/clients/users.py
@@ -94,7 +94,7 @@ class UserClient(BaseClient):
         params = dict(username=username, **kwargs)
         response = self._session.get(uri, params=params)
         if not response[u"users"]:
-            raise Py42UserDoesNotExistError(username, response)
+            raise Py42UserDoesNotExistError(response, username)
         return response
 
     def get_current(self, **kwargs):

--- a/src/py42/clients/users.py
+++ b/src/py42/clients/users.py
@@ -92,10 +92,10 @@ class UserClient(BaseClient):
         """
         uri = u"/api/User"
         params = dict(username=username, **kwargs)
-        users = self._session.get(uri, params=params)
-        if not users[u"users"]:
-            raise Py42UserDoesNotExistError(username)
-        return users
+        response = self._session.get(uri, params=params)
+        if not response[u"users"]:
+            raise Py42UserDoesNotExistError(username, response)
+        return response
 
     def get_current(self, **kwargs):
         """Gets the currently signed in user.

--- a/src/py42/clients/users.py
+++ b/src/py42/clients/users.py
@@ -4,6 +4,7 @@ from py42 import settings
 from py42._internal.compat import quote
 from py42.clients import BaseClient
 from py42.clients.util import get_all_pages
+from py42.exceptions import Py42UserDoesNotExistError
 
 
 class UserClient(BaseClient):
@@ -79,7 +80,8 @@ class UserClient(BaseClient):
         return self._session.get(uri, params=params)
 
     def get_by_username(self, username, **kwargs):
-        """Gets the user with the given username.
+        """Gets the user with the given username. Raises :class:`~py42.exceptions.Py42UserDoesNotExistError`
+        when no user is found.
         `REST Documentation <https://console.us.code42.com/apidocviewer/#User-get>`__
 
         Args:
@@ -90,7 +92,10 @@ class UserClient(BaseClient):
         """
         uri = u"/api/User"
         params = dict(username=username, **kwargs)
-        return self._session.get(uri, params=params)
+        users = self._session.get(uri, params=params)
+        if not users["users"]:
+            raise Py42UserDoesNotExistError(username)
+        return users
 
     def get_current(self, **kwargs):
         """Gets the currently signed in user.
@@ -123,6 +128,7 @@ class UserClient(BaseClient):
             email (str, optional): Limits users to only those with this email. Defaults to None.
             org_uid (str, optional): Limits users to only those in the organization with this org
                 UID. Defaults to None.
+            role_id (int, optional): Limits users to only those with a given role ID. Defaults to
             role_id (int, optional): Limits users to only those with a given role ID. Defaults to
                 None.
             page_size (int, optional): The number of items on the page. Defaults to `py42.settings.items_per_page`.

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -77,8 +77,9 @@ class Py42LegalHoldNotFoundOrPermissionDeniedError(Py42Error):
 
     def __init__(self, matter_id):
         super().__init__(
-            u"Matter with id={} either does not exist or your account does not have permission to "
-            u"view it.".format(matter_id)
+            u"Matter with id={} either does not exist or your account does not have permission to view it.".format(
+                matter_id
+            )
         )
 
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -63,27 +63,28 @@ class Py42StorageSessionInitializationError(Py42Error):
         super(Py42StorageSessionInitializationError, self).__init__(error_message)
 
 
-class Py42UserDoesNotExistError(Py42Error):
-    """An exception raised when a username is not in our system."""
-
-    def __init__(self, username):
-        super(Py42UserDoesNotExistError, self).__init__(
-            u"User '{}' does not exist.".format(username)
-        )
-
-
 class Py42HTTPError(Py42Error):
     """A base custom class to manage all HTTP errors raised by an API endpoint."""
 
-    def __init__(self, exception, message=None):
+    def __init__(self, exception=None, message=None, response=None):
         message = message or u"Failure in HTTP call {}".format(str(exception))
         super(Py42HTTPError, self).__init__(message)
-        self._response = exception.response
+        self._response = response or exception.response
 
     @property
     def response(self):
         """The response object containing the HTTP error details."""
         return self._response
+
+
+class Py42UserDoesNotExistError(Py42HTTPError):
+    """An exception raised when a username is not in our system."""
+
+    def __init__(self, username, response):
+        super(Py42UserDoesNotExistError, self).__init__(
+            message=u"User '{}' does not exist.".format(username),
+            response=response,
+        )
 
 
 class Py42UserAlreadyAddedError(Py42HTTPError):
@@ -121,36 +122,21 @@ class Py42InvalidRuleTypeError(Py42HTTPError):
 class Py42BadRequestError(Py42HTTPError):
     """A wrapper to represent an HTTP 400 error."""
 
-    def __init__(self, exception):
-        super(Py42BadRequestError, self).__init__(exception)
-
 
 class Py42UnauthorizedError(Py42HTTPError):
     """A wrapper to represent an HTTP 401 error."""
-
-    def __init__(self, exception):
-        super(Py42UnauthorizedError, self).__init__(exception)
 
 
 class Py42ForbiddenError(Py42HTTPError):
     """A wrapper to represent an HTTP 403 error."""
 
-    def __init__(self, exception):
-        super(Py42ForbiddenError, self).__init__(exception)
-
 
 class Py42NotFoundError(Py42HTTPError):
     """A wrapper to represent an HTTP 404 error."""
 
-    def __init__(self, exception):
-        super(Py42NotFoundError, self).__init__(exception)
-
 
 class Py42InternalServerError(Py42HTTPError):
     """A wrapper to represent an HTTP 500 error."""
-
-    def __init__(self, exception):
-        super(Py42InternalServerError, self).__init__(exception)
 
 
 def raise_py42_error(raised_error):

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -69,14 +69,14 @@ class Py42UserAlreadyAddedError(Py42Error):
 
     def __init__(self, user_id, list_name):
         msg = u"User with ID {} is already on the {}.".format(user_id, list_name)
-        super().__init__(msg)
+        super(Py42UserAlreadyAddedError, self).__init__(msg)
 
 
 class Py42LegalHoldNotFoundOrPermissionDeniedError(Py42Error):
     """An exception raised when a legal hold matter is inaccessible from your account."""
 
     def __init__(self, matter_id):
-        super().__init__(
+        super(Py42LegalHoldNotFoundOrPermissionDeniedError, self).__init__(
             u"Matter with id={} either does not exist or your account does not have permission to view it.".format(
                 matter_id
             )
@@ -87,7 +87,7 @@ class Py42UserDoesNotExistError(Py42Error):
     """An exception raised when a username is not in our system."""
 
     def __init__(self, username):
-        super().__init__(u"User '{}' does not exist.".format(username))
+        super(Py42UserDoesNotExistError, self).__init__(u"User '{}' does not exist.".format(username))
 
 
 class Py42InvalidRuleTypeError(Py42Error):
@@ -96,7 +96,7 @@ class Py42InvalidRuleTypeError(Py42Error):
     def __init__(self, rule_id, source):
         msg = u"Only alert rules with a source of 'Alerting' can be targeted by this command. "
         msg += u"Rule {0} has a source of '{1}'."
-        super().__init__(msg.format(rule_id, source))
+        super(Py42InvalidRuleTypeError, self).__init__(msg.format(rule_id, source))
 
 
 class Py42HTTPError(Py42Error):

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -155,7 +155,7 @@ class Py42InternalServerError(Py42HTTPError):
 
 def raise_py42_error(raised_error):
     """Raises the appropriate :class:`py42.exceptions.Py42HttpError` based on the given
-    error's response status code.
+    HTTPError's response status code.
     """
     if raised_error.response.status_code == 400:
         raise Py42BadRequestError(raised_error)

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -63,26 +63,6 @@ class Py42StorageSessionInitializationError(Py42Error):
         super(Py42StorageSessionInitializationError, self).__init__(error_message)
 
 
-class Py42UserAlreadyAddedError(Py42Error):
-    """An exception raised when the user is already added to group or list, such as the
-    Departing Employee list."""
-
-    def __init__(self, user_id, list_name):
-        msg = u"User with ID {} is already on the {}.".format(user_id, list_name)
-        super(Py42UserAlreadyAddedError, self).__init__(msg)
-
-
-class Py42LegalHoldNotFoundOrPermissionDeniedError(Py42Error):
-    """An exception raised when a legal hold matter is inaccessible from your account."""
-
-    def __init__(self, matter_id):
-        super(Py42LegalHoldNotFoundOrPermissionDeniedError, self).__init__(
-            u"Matter with id={} either does not exist or your account does not have permission to view it.".format(
-                matter_id
-            )
-        )
-
-
 class Py42UserDoesNotExistError(Py42Error):
     """An exception raised when a username is not in our system."""
 
@@ -92,20 +72,11 @@ class Py42UserDoesNotExistError(Py42Error):
         )
 
 
-class Py42InvalidRuleTypeError(Py42Error):
-    """An exception raised when trying to add or remove users to a system rule."""
-
-    def __init__(self, rule_id, source):
-        msg = u"Only alert rules with a source of 'Alerting' can be targeted by this command. "
-        msg += u"Rule {0} has a source of '{1}'."
-        super(Py42InvalidRuleTypeError, self).__init__(msg.format(rule_id, source))
-
-
 class Py42HTTPError(Py42Error):
     """A base custom class to manage all HTTP errors raised by an API endpoint."""
 
-    def __init__(self, exception):
-        message = u"Failure in HTTP call {}".format(str(exception))
+    def __init__(self, exception, message=None):
+        message = message or u"Failure in HTTP call {}".format(str(exception))
         super(Py42HTTPError, self).__init__(message)
         self._response = exception.response
 
@@ -113,6 +84,38 @@ class Py42HTTPError(Py42Error):
     def response(self):
         """The response object containing the HTTP error details."""
         return self._response
+
+
+class Py42UserAlreadyAddedError(Py42HTTPError):
+    """An exception raised when the user is already added to group or list, such as the
+    Departing Employee list."""
+
+    def __init__(self, exception, user_id, list_name):
+        msg = u"User with ID {} is already on the {}.".format(user_id, list_name)
+        super(Py42UserAlreadyAddedError, self).__init__(exception, msg)
+
+
+class Py42LegalHoldNotFoundOrPermissionDeniedError(Py42HTTPError):
+    """An exception raised when a legal hold matter is inaccessible from your account."""
+
+    def __init__(self, exception, matter_id):
+        super(Py42LegalHoldNotFoundOrPermissionDeniedError, self).__init__(
+            exception,
+            u"Matter with id={} either does not exist or your account does not have permission to view it.".format(
+                matter_id
+            ),
+        )
+
+
+class Py42InvalidRuleTypeError(Py42HTTPError):
+    """An exception raised when trying to add or remove users to a system rule."""
+
+    def __init__(self, exception, rule_id, source):
+        msg = u"Only alert rules with a source of 'Alerting' can be targeted by this command. "
+        msg += u"Rule {0} has a source of '{1}'."
+        super(Py42InvalidRuleTypeError, self).__init__(
+            exception, msg.format(rule_id, source)
+        )
 
 
 class Py42BadRequestError(Py42HTTPError):

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -6,7 +6,7 @@ class Py42Error(Exception):
 
 
 class Py42ResponseError(Py42Error):
-    """A generic, Py42 custom base exception from a HTTP response."""
+    """A generic, Py42 custom base exception from an HTTP response."""
 
     def __init__(self, response, message):
         super(Py42ResponseError, self).__init__(message)

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -84,15 +84,15 @@ class Py42LegalHoldNotFoundOrPermissionDeniedError(Py42Error):
 
 
 class Py42UserDoesNotExistError(Py42Error):
-    """An error to represent a username that is not in our system. The CLI shows this error when
-    the user tries to add or remove a user that does not exist. This error is not shown during
-    bulk add or remove."""
+    """An exception raised when a username is not in our system."""
 
     def __init__(self, username):
         super().__init__(u"User '{}' does not exist.".format(username))
 
 
 class Py42InvalidRuleTypeError(Py42Error):
+    """An exception raised when trying to add or remove users to a system rule."""
+
     def __init__(self, rule_id, source):
         msg = u"Only alert rules with a source of 'Alerting' can be targeted by this command. "
         msg += u"Rule {0} has a source of '{1}'."

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -105,13 +105,26 @@ class Py42UserAlreadyAddedError(Py42HTTPError):
         super(Py42UserAlreadyAddedError, self).__init__(exception, msg)
 
 
-class Py42LegalHoldNotFoundOrPermissionDeniedError(Py42HTTPError):
+class Py42LegalHoldNotFoundError(Py42HTTPError):
     """An exception raised when a legal hold matter is inaccessible from your account."""
 
     def __init__(self, exception, matter_id):
-        super(Py42LegalHoldNotFoundOrPermissionDeniedError, self).__init__(
+        super(Py42LegalHoldNotFoundError, self).__init__(
             exception,
-            u"Matter with id={} either does not exist or your account does not have permission to view it.".format(
+            u"Matter with ID={} can not be found.".format(
+                matter_id
+            ),
+        )
+
+
+class Py42LegalHoldPermissionDeniedError(Py42HTTPError):
+    """An exception raised when a legal hold matter is inaccessible from your account
+    due to permission constraints."""
+
+    def __init__(self, exception, matter_id):
+        super(Py42LegalHoldPermissionDeniedError, self).__init__(
+            exception,
+            u"Your account does not have permission to view matter with ID={}.".format(
                 matter_id
             ),
         )

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -110,10 +110,7 @@ class Py42LegalHoldNotFoundError(Py42HTTPError):
 
     def __init__(self, exception, matter_id):
         super(Py42LegalHoldNotFoundError, self).__init__(
-            exception,
-            u"Matter with ID={} can not be found.".format(
-                matter_id
-            ),
+            exception, u"Matter with ID={} can not be found.".format(matter_id),
         )
 
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -51,7 +51,7 @@ class Py42FeatureUnavailableError(Py42ResponseError):
 class Py42UserDoesNotExistError(Py42ResponseError):
     """An exception raised when a username is not in our system."""
 
-    def __init__(self, username, response):
+    def __init__(self, response, username):
         super(Py42UserDoesNotExistError, self).__init__(
             response, message=u"User '{}' does not exist.".format(username),
         )

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -64,24 +64,20 @@ class Py42StorageSessionInitializationError(Py42Error):
 
 
 class Py42UserAlreadyAddedError(Py42Error):
+    """An exception raised when the user is already added to group or list, such as the
+    Departing Employee list."""
+
     def __init__(self, user_id, list_name):
         msg = u"User with ID {} is already on the {}.".format(user_id, list_name)
         super().__init__(msg)
 
 
-class Py42UserNotInLegalHoldError(Py42Error):
-    def __init__(self, username, matter_id):
-        super().__init__(
-            u"{} is not an active member of legal hold matter '{}'".format(
-                username, matter_id
-            )
-        )
-
-
 class Py42LegalHoldNotFoundOrPermissionDeniedError(Py42Error):
+    """An exception raised when a legal hold matter is inaccessible from your account."""
+
     def __init__(self, matter_id):
         super().__init__(
-            u"Matter with id={} either does not exist or your profile does not have permission to "
+            u"Matter with id={} either does not exist or your account does not have permission to "
             u"view it.".format(matter_id)
         )
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -87,7 +87,9 @@ class Py42UserDoesNotExistError(Py42Error):
     """An exception raised when a username is not in our system."""
 
     def __init__(self, username):
-        super(Py42UserDoesNotExistError, self).__init__(u"User '{}' does not exist.".format(username))
+        super(Py42UserDoesNotExistError, self).__init__(
+            u"User '{}' does not exist.".format(username)
+        )
 
 
 class Py42InvalidRuleTypeError(Py42Error):

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -105,23 +105,14 @@ class Py42UserAlreadyAddedError(Py42HTTPError):
         super(Py42UserAlreadyAddedError, self).__init__(exception, msg)
 
 
-class Py42LegalHoldNotFoundError(Py42HTTPError):
-    """An exception raised when a legal hold matter is inaccessible from your account."""
+class Py42LegalHoldNotFoundOrPermissionDeniedError(Py42HTTPError):
+    """An exception raised when a legal hold matter is inaccessible from your account or
+    the matter ID is not valid."""
 
     def __init__(self, exception, matter_id):
-        super(Py42LegalHoldNotFoundError, self).__init__(
-            exception, u"Matter with ID={} can not be found.".format(matter_id),
-        )
-
-
-class Py42LegalHoldPermissionDeniedError(Py42HTTPError):
-    """An exception raised when a legal hold matter is inaccessible from your account
-    due to permission constraints."""
-
-    def __init__(self, exception, matter_id):
-        super(Py42LegalHoldPermissionDeniedError, self).__init__(
+        super(Py42LegalHoldNotFoundOrPermissionDeniedError, self).__init__(
             exception,
-            u"Your account does not have permission to view matter with ID={}.".format(
+            u"Matter with ID={} can not be found. Your account may not have permission to view the matter.".format(
                 matter_id
             ),
         )

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -82,8 +82,7 @@ class Py42UserDoesNotExistError(Py42HTTPError):
 
     def __init__(self, username, response):
         super(Py42UserDoesNotExistError, self).__init__(
-            message=u"User '{}' does not exist.".format(username),
-            response=response,
+            message=u"User '{}' does not exist.".format(username), response=response,
         )
 
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -63,6 +63,29 @@ class Py42StorageSessionInitializationError(Py42Error):
         super(Py42StorageSessionInitializationError, self).__init__(error_message)
 
 
+class Py42UserAlreadyAddedError(Py42Error):
+    def __init__(self, username, list_name):
+        msg = "{} is already on the {}.".format(username, list_name)
+        super().__init__(msg)
+
+
+class Py42UserNotInLegalHoldError(Py42Error):
+    def __init__(self, username, matter_id):
+        super().__init__(
+            "{} is not an active member of legal hold matter '{}'".format(
+                username, matter_id
+            )
+        )
+
+
+class Py42LegalHoldNotFoundOrPermissionDeniedError(Py42Error):
+    def __init__(self, matter_id):
+        super().__init__(
+            "Matter with id={} either does not exist or your profile does not have permission to "
+            "view it.".format(matter_id)
+        )
+
+
 class Py42HTTPError(Py42Error):
     """A base custom class to manage all HTTP errors raised by an API endpoint."""
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -95,6 +95,13 @@ class Py42UserDoesNotExistError(Py42Error):
         super().__init__(u"User '{}' does not exist.".format(username))
 
 
+class Py42InvalidRuleTypeError(Py42Error):
+    def __init__(self, rule_id, source):
+        msg = u"Only alert rules with a source of 'Alerting' can be targeted by this command. "
+        msg += u"Rule {0} has a source of '{1}'."
+        super().__init__(msg.format(rule_id, source))
+
+
 class Py42HTTPError(Py42Error):
     """A base custom class to manage all HTTP errors raised by an API endpoint."""
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -65,14 +65,14 @@ class Py42StorageSessionInitializationError(Py42Error):
 
 class Py42UserAlreadyAddedError(Py42Error):
     def __init__(self, username, list_name):
-        msg = "{} is already on the {}.".format(username, list_name)
+        msg = u"{} is already on the {}.".format(username, list_name)
         super().__init__(msg)
 
 
 class Py42UserNotInLegalHoldError(Py42Error):
     def __init__(self, username, matter_id):
         super().__init__(
-            "{} is not an active member of legal hold matter '{}'".format(
+            u"{} is not an active member of legal hold matter '{}'".format(
                 username, matter_id
             )
         )
@@ -81,9 +81,18 @@ class Py42UserNotInLegalHoldError(Py42Error):
 class Py42LegalHoldNotFoundOrPermissionDeniedError(Py42Error):
     def __init__(self, matter_id):
         super().__init__(
-            "Matter with id={} either does not exist or your profile does not have permission to "
-            "view it.".format(matter_id)
+            u"Matter with id={} either does not exist or your profile does not have permission to "
+            u"view it.".format(matter_id)
         )
+
+
+class Py42UserDoesNotExistError(Py42Error):
+    """An error to represent a username that is not in our system. The CLI shows this error when
+    the user tries to add or remove a user that does not exist. This error is not shown during
+    bulk add or remove."""
+
+    def __init__(self, username):
+        super().__init__(u"User '{}' does not exist.".format(username))
 
 
 class Py42HTTPError(Py42Error):

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -127,13 +127,13 @@ class Py42LegalHoldPermissionDeniedError(Py42HTTPError):
         )
 
 
-class Py42InvalidRuleTypeError(Py42HTTPError):
+class Py42InvalidRuleOperationError(Py42HTTPError):
     """An exception raised when trying to add or remove users to a system rule."""
 
     def __init__(self, exception, rule_id, source):
         msg = u"Only alert rules with a source of 'Alerting' can be targeted by this command. "
         msg += u"Rule {0} has a source of '{1}'."
-        super(Py42InvalidRuleTypeError, self).__init__(
+        super(Py42InvalidRuleOperationError, self).__init__(
             exception, msg.format(rule_id, source)
         )
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -64,8 +64,8 @@ class Py42StorageSessionInitializationError(Py42Error):
 
 
 class Py42UserAlreadyAddedError(Py42Error):
-    def __init__(self, username, list_name):
-        msg = u"{} is already on the {}.".format(username, list_name)
+    def __init__(self, user_id, list_name):
+        msg = u"User with ID {} is already on the {}.".format(user_id, list_name)
         super().__init__(msg)
 
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -6,7 +6,7 @@ class Py42Error(Exception):
 
 
 class Py42ResponseError(Py42Error):
-    """A generic, Py42 custom base exception from an HTTP response."""
+    """A base custom class to manage all errors raised because of an HTTP response."""
 
     def __init__(self, response, message):
         super(Py42ResponseError, self).__init__(message)

--- a/src/py42/modules/alertrules.py
+++ b/src/py42/modules/alertrules.py
@@ -155,7 +155,7 @@ class AlertRulesModule(object):
 
 def _check_if_system_rule(rules):
     """You cannot add or remove users from system rules this way."""
-    if rules and rules[0]["isSystem"]:
+    if rules and rules[0][u"isSystem"]:
         raise Py42InvalidRuleTypeError(
-            rules[0]["observerRuleId"], rules[0]["ruleSource"]
+            rules[0][u"observerRuleId"], rules[0][u"ruleSource"]
         )

--- a/src/py42/modules/alertrules.py
+++ b/src/py42/modules/alertrules.py
@@ -154,7 +154,8 @@ class AlertRulesModule(object):
 
 
 def _check_if_system_rule(base_err, rules):
-    """You cannot add or remove users from system rules this way."""
+    """You cannot add or remove users from system rules this way; use the specific
+    feature behind the rule, such as the Departing Employee list."""
     if rules and rules[0][u"isSystem"]:
         raise Py42InvalidRuleTypeError(
             base_err, rules[0][u"observerRuleId"], rules[0][u"ruleSource"]

--- a/src/py42/modules/alertrules.py
+++ b/src/py42/modules/alertrules.py
@@ -1,6 +1,6 @@
 from py42 import settings
 from py42.exceptions import Py42InternalServerError
-from py42.exceptions import Py42InvalidRuleTypeError
+from py42.exceptions import Py42InvalidRuleOperationError
 
 
 class AlertRulesModule(object):
@@ -157,6 +157,6 @@ def _check_if_system_rule(base_err, rules):
     """You cannot add or remove users from system rules this way; use the specific
     feature behind the rule, such as the Departing Employee list."""
     if rules and rules[0][u"isSystem"]:
-        raise Py42InvalidRuleTypeError(
+        raise Py42InvalidRuleOperationError(
             base_err, rules[0][u"observerRuleId"], rules[0][u"ruleSource"]
         )

--- a/src/py42/modules/alertrules.py
+++ b/src/py42/modules/alertrules.py
@@ -1,4 +1,6 @@
 from py42 import settings
+from py42.exceptions import Py42InternalServerError
+from py42.exceptions import Py42InvalidRuleTypeError
 
 
 class AlertRulesModule(object):
@@ -46,7 +48,12 @@ class AlertRulesModule(object):
             :class:`py42.response.Py42Response`
         """
         rules_client = self.microservice_client_factory.get_alert_rules_client()
-        return rules_client.add_user(rule_id, user_id)
+        try:
+            return rules_client.add_user(rule_id, user_id)
+        except Py42InternalServerError:
+            rules = self.get_by_observer_id(rule_id)[u"ruleMetadata"]
+            _check_if_system_rule(rules)
+            raise
 
     def remove_user(self, rule_id, user_id):
         """Update alert rule criteria to remove a user and all its aliases from a rule.
@@ -59,7 +66,12 @@ class AlertRulesModule(object):
             :class:`py42.response.Py42Response`
         """
         rules_client = self.microservice_client_factory.get_alert_rules_client()
-        return rules_client.remove_user(rule_id, user_id)
+        try:
+            return rules_client.remove_user(rule_id, user_id)
+        except Py42InternalServerError:
+            rules = self.get_by_observer_id(rule_id)[u"ruleMetadata"]
+            _check_if_system_rule(rules)
+            raise
 
     def remove_all_users(self, rule_id):
         """Update alert rule criteria to remove all users the from the alert rule.
@@ -139,3 +151,11 @@ class AlertRulesModule(object):
         """
         alerts_client = self.microservice_client_factory.get_alerts_client()
         return alerts_client.get_rule_by_observer_id(observer_id)
+
+
+def _check_if_system_rule(rules):
+    """You cannot add or remove users from system rules this way."""
+    if rules and rules[0]["isSystem"]:
+        raise Py42InvalidRuleTypeError(
+            rules[0]["observerRuleId"], rules[0]["ruleSource"]
+        )

--- a/src/py42/modules/alertrules.py
+++ b/src/py42/modules/alertrules.py
@@ -50,9 +50,9 @@ class AlertRulesModule(object):
         rules_client = self.microservice_client_factory.get_alert_rules_client()
         try:
             return rules_client.add_user(rule_id, user_id)
-        except Py42InternalServerError:
+        except Py42InternalServerError as err:
             rules = self.get_by_observer_id(rule_id)[u"ruleMetadata"]
-            _check_if_system_rule(rules)
+            _check_if_system_rule(err, rules)
             raise
 
     def remove_user(self, rule_id, user_id):
@@ -68,9 +68,9 @@ class AlertRulesModule(object):
         rules_client = self.microservice_client_factory.get_alert_rules_client()
         try:
             return rules_client.remove_user(rule_id, user_id)
-        except Py42InternalServerError:
+        except Py42InternalServerError as err:
             rules = self.get_by_observer_id(rule_id)[u"ruleMetadata"]
-            _check_if_system_rule(rules)
+            _check_if_system_rule(err, rules)
             raise
 
     def remove_all_users(self, rule_id):
@@ -153,9 +153,9 @@ class AlertRulesModule(object):
         return alerts_client.get_rule_by_observer_id(observer_id)
 
 
-def _check_if_system_rule(rules):
+def _check_if_system_rule(base_err, rules):
     """You cannot add or remove users from system rules this way."""
     if rules and rules[0][u"isSystem"]:
         raise Py42InvalidRuleTypeError(
-            rules[0][u"observerRuleId"], rules[0][u"ruleSource"]
+            base_err, rules[0][u"observerRuleId"], rules[0][u"ruleSource"]
         )

--- a/src/py42/modules/securitydata.py
+++ b/src/py42/modules/securitydata.py
@@ -5,8 +5,8 @@ from requests.exceptions import HTTPError
 
 from py42.exceptions import Py42ChecksumNotFoundError
 from py42.exceptions import Py42Error
-from py42.exceptions import Py42ResponseError
 from py42.exceptions import Py42HTTPError
+from py42.exceptions import Py42ResponseError
 from py42.exceptions import Py42SecurityPlanConnectionError
 from py42.exceptions import raise_py42_error
 from py42.sdk.queries.fileevents.file_event_query import FileEventQuery
@@ -63,7 +63,7 @@ class SecurityModule(object):
                 raise Py42SecurityPlanConnectionError(
                     response,
                     u"Could not establish a connection to retrieve "
-                    u"security events for user {}".format(user_uid)
+                    u"security events for user {}".format(user_uid),
                 )
 
             return selected_plan_infos
@@ -203,7 +203,7 @@ class SecurityModule(object):
             raise Py42ResponseError(
                 response,
                 u"PDS service can't find requested file "
-                u"with md5 hash {} and sha256 hash {}.".format(md5_hash, sha256_hash)
+                u"with md5 hash {} and sha256 hash {}.".format(md5_hash, sha256_hash),
             )
 
         for device_id, paths in _parse_file_location_response(response):

--- a/src/py42/modules/securitydata.py
+++ b/src/py42/modules/securitydata.py
@@ -5,6 +5,7 @@ from requests.exceptions import HTTPError
 
 from py42.exceptions import Py42ChecksumNotFoundError
 from py42.exceptions import Py42Error
+from py42.exceptions import Py42ResponseError
 from py42.exceptions import Py42HTTPError
 from py42.exceptions import Py42SecurityPlanConnectionError
 from py42.exceptions import raise_py42_error
@@ -44,6 +45,7 @@ class SecurityModule(object):
         Returns:
             list[:class:`py42.modules.securitydata.PlanStorageInfo`]
         """
+        response = None
         locations = None
         try:
             response = self._security_client.get_security_event_locations(user_uid)
@@ -54,11 +56,12 @@ class SecurityModule(object):
             else:
                 raise_py42_error(err)
 
-        if locations:
+        if response and locations:
             plan_destination_map = _get_plan_destination_map(locations)
             selected_plan_infos = self._get_plan_storage_infos(plan_destination_map)
             if not selected_plan_infos:
                 raise Py42SecurityPlanConnectionError(
+                    response,
                     u"Could not establish a connection to retrieve "
                     u"security events for user {}".format(user_uid)
                 )
@@ -187,7 +190,7 @@ class SecurityModule(object):
     def _search_by_hash(self, hash, type):
         query = FileEventQuery.all(type.eq(hash))
         response = self.search_file_events(query)
-        return response[u"fileEvents"]
+        return response
 
     def _find_file_versions(self, md5_hash, sha256_hash):
         file_event_client = self._microservices_client_factory.get_file_event_client()
@@ -197,7 +200,8 @@ class SecurityModule(object):
         response = file_event_client.get_file_location_detail_by_sha256(sha256_hash)
 
         if u"locations" not in response and not len(response[u"locations"]):
-            raise Py42Error(
+            raise Py42ResponseError(
+                response,
                 u"PDS service can't find requested file "
                 u"with md5 hash {} and sha256 hash {}.".format(md5_hash, sha256_hash)
             )
@@ -255,9 +259,10 @@ class SecurityModule(object):
         Returns:
             Returns a stream of the requested file.
         """
-        events = self._search_by_hash(checksum, SHA256)
+        response = self._search_by_hash(checksum, SHA256)
+        events = response[u"fileEvents"]
         if not len(events):
-            raise Py42ChecksumNotFoundError(u"SHA256", checksum)
+            raise Py42ChecksumNotFoundError(response, u"SHA256", checksum)
         md5_hash = events[0][u"md5Checksum"]
 
         return self._stream_file(self._find_file_versions(md5_hash, checksum), checksum)
@@ -271,9 +276,10 @@ class SecurityModule(object):
         Returns:
             Returns a stream of the requested file.
         """
-        events = self._search_by_hash(checksum, MD5)
+        response = self._search_by_hash(checksum, MD5)
+        events = response[u"fileEvents"]
         if not len(events):
-            raise Py42ChecksumNotFoundError(u"MD5", checksum)
+            raise Py42ChecksumNotFoundError(response, u"MD5", checksum)
         sha256_hash = events[0][u"sha256Checksum"]
         return self._stream_file(
             self._find_file_versions(checksum, sha256_hash), checksum

--- a/tests/_internal/test_storage_session_manager.py
+++ b/tests/_internal/test_storage_session_manager.py
@@ -1,4 +1,7 @@
+from urllib.error import HTTPError
+
 import pytest
+from requests import Response
 
 from py42._internal.session_factory import SessionFactory
 from py42._internal.storage_session_manager import StorageSessionManager
@@ -45,10 +48,13 @@ class TestStorageSessionManager(object):
         assert session1 is session2
 
     def test_get_storage_session_raises_exception_when_factory_raises_exception(
-        self, session_factory, token_provider
+        self, mocker, session_factory, token_provider
     ):
         def mock_get_session(host_address, provider, **kwargs):
-            raise Py42StorageSessionInitializationError("Mock error!")
+            exception = mocker.MagicMock(spec=HTTPError)
+            response = mocker.MagicMock(spec=Response)
+            exception.response = response
+            raise Py42StorageSessionInitializationError(exception, "Mock error!")
 
         storage_session_manager = StorageSessionManager(session_factory)
         session_factory.create_storage_session.side_effect = mock_get_session

--- a/tests/_internal/test_storage_session_manager.py
+++ b/tests/_internal/test_storage_session_manager.py
@@ -1,6 +1,5 @@
-from urllib.error import HTTPError
-
 import pytest
+from requests import HTTPError
 from requests import Response
 
 from py42._internal.session_factory import SessionFactory

--- a/tests/clients/test_legalhold.py
+++ b/tests/clients/test_legalhold.py
@@ -92,7 +92,9 @@ class TestLegalHoldClient(object):
         with pytest.raises(Py42LegalHoldPermissionDeniedError) as err:
             client.get_matter_by_uid("matter")
 
-        expected = "Your account does not have permission to view matter with ID=matter."
+        expected = (
+            "Your account does not have permission to view matter with ID=matter."
+        )
         assert str(err.value) == expected
 
     def test_get_matter_by_uid_when_bad_request_raises_legal_hold_not_found_error(

--- a/tests/clients/test_legalhold.py
+++ b/tests/clients/test_legalhold.py
@@ -8,7 +8,8 @@ import py42
 from py42.clients.legalhold import LegalHoldClient
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42ForbiddenError
-from py42.exceptions import Py42LegalHoldNotFoundOrPermissionDeniedError
+from py42.exceptions import Py42LegalHoldNotFoundError
+from py42.exceptions import Py42LegalHoldPermissionDeniedError
 from py42.exceptions import Py42UserAlreadyAddedError
 from py42.response import Py42Response
 
@@ -78,7 +79,7 @@ class TestLegalHoldClient(object):
         uri = "{}/{}".format(LEGAL_HOLD_URI, "LEGAL_HOLD_UID")
         mock_session.get.assert_called_once_with(uri)
 
-    def test_get_matter_by_uid_when_forbidden_raises_legal_hold_not_found_or_permissions_denied(
+    def test_get_matter_by_uid_when_forbidden_raises_legal_hold_permission_denied_error(
         self, mocker, mock_session, successful_response
     ):
         def side_effect(*args, **kwargs):
@@ -88,13 +89,13 @@ class TestLegalHoldClient(object):
 
         mock_session.get.side_effect = side_effect
         client = LegalHoldClient(mock_session)
-        with pytest.raises(Py42LegalHoldNotFoundOrPermissionDeniedError) as err:
+        with pytest.raises(Py42LegalHoldPermissionDeniedError) as err:
             client.get_matter_by_uid("matter")
 
-        expected = "Matter with id=matter either does not exist or your account does not have permission to view it."
+        expected = "Your account does not have permission to view matter with ID=matter."
         assert str(err.value) == expected
 
-    def test_get_matter_by_uid_when_bad_request_raises_legal_hold_not_found_or_permissions_denied(
+    def test_get_matter_by_uid_when_bad_request_raises_legal_hold_not_found_error(
         self, mocker, mock_session, successful_response
     ):
         def side_effect(*args, **kwargs):
@@ -104,10 +105,10 @@ class TestLegalHoldClient(object):
 
         mock_session.get.side_effect = side_effect
         client = LegalHoldClient(mock_session)
-        with pytest.raises(Py42LegalHoldNotFoundOrPermissionDeniedError) as err:
+        with pytest.raises(Py42LegalHoldNotFoundError) as err:
             client.get_matter_by_uid("matter")
 
-        expected = "Matter with id=matter either does not exist or your account does not have permission to view it."
+        expected = "Matter with ID=matter can not be found."
         assert str(err.value) == expected
 
     def test_get_all_matters_calls_get_expected_number_of_times(

--- a/tests/clients/test_legalhold.py
+++ b/tests/clients/test_legalhold.py
@@ -8,8 +8,7 @@ import py42
 from py42.clients.legalhold import LegalHoldClient
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42ForbiddenError
-from py42.exceptions import Py42LegalHoldNotFoundError
-from py42.exceptions import Py42LegalHoldPermissionDeniedError
+from py42.exceptions import Py42LegalHoldNotFoundOrPermissionDeniedError
 from py42.exceptions import Py42UserAlreadyAddedError
 from py42.response import Py42Response
 
@@ -89,28 +88,10 @@ class TestLegalHoldClient(object):
 
         mock_session.get.side_effect = side_effect
         client = LegalHoldClient(mock_session)
-        with pytest.raises(Py42LegalHoldPermissionDeniedError) as err:
+        with pytest.raises(Py42LegalHoldNotFoundOrPermissionDeniedError) as err:
             client.get_matter_by_uid("matter")
 
-        expected = (
-            "Your account does not have permission to view matter with ID=matter."
-        )
-        assert str(err.value) == expected
-
-    def test_get_matter_by_uid_when_bad_request_raises_legal_hold_not_found_error(
-        self, mocker, mock_session, successful_response
-    ):
-        def side_effect(*args, **kwargs):
-            base_err = mocker.MagicMock(spec=HTTPError)
-            base_err.response = mocker.MagicMock(spec=Response)
-            raise Py42BadRequestError(base_err)
-
-        mock_session.get.side_effect = side_effect
-        client = LegalHoldClient(mock_session)
-        with pytest.raises(Py42LegalHoldNotFoundError) as err:
-            client.get_matter_by_uid("matter")
-
-        expected = "Matter with ID=matter can not be found."
+        expected = "Matter with ID=matter can not be found. Your account may not have permission to view the matter."
         assert str(err.value) == expected
 
     def test_get_all_matters_calls_get_expected_number_of_times(

--- a/tests/clients/test_legalhold.py
+++ b/tests/clients/test_legalhold.py
@@ -91,7 +91,7 @@ class TestLegalHoldClient(object):
         with pytest.raises(Py42LegalHoldNotFoundOrPermissionDeniedError) as err:
             client.get_matter_by_uid("matter")
 
-        expected = "Matter with id=matter either does not exist or your profile does not have permission to view it."
+        expected = "Matter with id=matter either does not exist or your account does not have permission to view it."
         assert str(err.value) == expected
 
     def test_get_matter_by_uid_when_bad_request_raises_legal_hold_not_found_or_permissions_denied(
@@ -107,7 +107,7 @@ class TestLegalHoldClient(object):
         with pytest.raises(Py42LegalHoldNotFoundOrPermissionDeniedError) as err:
             client.get_matter_by_uid("matter")
 
-        expected = "Matter with id=matter either does not exist or your profile does not have permission to view it."
+        expected = "Matter with id=matter either does not exist or your account does not have permission to view it."
         assert str(err.value) == expected
 
     def test_get_all_matters_calls_get_expected_number_of_times(

--- a/tests/modules/test_alertrules.py
+++ b/tests/modules/test_alertrules.py
@@ -25,17 +25,6 @@ TEST_SYSTEM_RULE_RESPONSE = {
     ]
 }
 
-TEST_USER_RULE_RESPONSE = {
-    "ruleMetadata": [
-        {
-            "observerRuleId": TEST_RULE_ID,
-            "type": "FED_FILE_TYPE_MISMATCH",
-            "isSystem": False,
-            "ruleSource": "Testing",
-        }
-    ]
-}
-
 
 @pytest.fixture
 def mock_microservice_client_factory(mocker):

--- a/tests/modules/test_alertrules.py
+++ b/tests/modules/test_alertrules.py
@@ -11,6 +11,32 @@ from py42.modules.alertrules import AlertRulesModule
 from py42.response import Py42Response
 
 
+TEST_RULE_ID = "rule-id"
+
+
+TEST_SYSTEM_RULE_RESPONSE = {
+    "ruleMetadata": [
+        {
+            "observerRuleId": TEST_RULE_ID,
+            "type": "FED_FILE_TYPE_MISMATCH",
+            "isSystem": True,
+            "ruleSource": "NOTVALID",
+        }
+    ]
+}
+
+TEST_USER_RULE_RESPONSE = {
+    "ruleMetadata": [
+        {
+            "observerRuleId": TEST_RULE_ID,
+            "type": "FED_FILE_TYPE_MISMATCH",
+            "isSystem": False,
+            "ruleSource": "Testing",
+        }
+    ]
+}
+
+
 @pytest.fixture
 def mock_microservice_client_factory(mocker):
     return mocker.MagicMock(spec=MicroserviceClientFactory)
@@ -29,7 +55,7 @@ def mock_alerts_client(mocker):
 @pytest.fixture
 def mock_alerts_client_system_rule(mocker, mock_alerts_client):
     response = mocker.MagicMock(spec=Py42Response)
-    response.text = """{ruleMetadata: [{"isSystem": "true", "observerRuleId": "OBS_ID", "ruleSource": "RULE_SRC"}]}"""
+    response.text = TEST_SYSTEM_RULE_RESPONSE
     mock_alerts_client.get_rule_by_observer_id.return_value = response
     return mock_alerts_client
 

--- a/tests/modules/test_alertrules.py
+++ b/tests/modules/test_alertrules.py
@@ -6,7 +6,7 @@ from py42._internal.client_factories import MicroserviceClientFactory
 from py42._internal.clients.alertrules import AlertRulesClient
 from py42._internal.clients.alerts import AlertClient
 from py42.exceptions import Py42InternalServerError
-from py42.exceptions import Py42InvalidRuleTypeError
+from py42.exceptions import Py42InvalidRuleOperationError
 from py42.modules.alertrules import AlertRulesModule
 from py42.response import Py42Response
 
@@ -86,7 +86,7 @@ class TestAlertRulesModules(object):
             mock_alerts_client_system_rule
         )
         alert_rules_module = AlertRulesModule(mock_microservice_client_factory)
-        with pytest.raises(Py42InvalidRuleTypeError) as err:
+        with pytest.raises(Py42InvalidRuleOperationError) as err:
             alert_rules_module.add_user(self._rule_id, self._rule_id)
 
         assert (


### PR DESCRIPTION
### Description of Change ###

    - `Py42UserAlreadyAddedError`
    - `Py42UserNotInLegalHoldError`
    - `Py42LegalHoldNotFoundOrPermissionDeniedError`
    - `Py42UserDoesNotExistError`
    - `Py42InvalidRuleTypeError`

And their logic mirrored from what is in the CLI.
The CLI tests still pass as well.

### Issues Resolved ###
INTEG-1072

### Testing Procedure ###
Verify these statements:
- `py42.detectionlists.departing_employee.add()` now raises `Py42UserAlreadyAddedError` when the user is already on the list.
- `py42.detectionlists.high_risk_employee.add()` now raises `Py42UserAlreadyAddedError` when the user already on the list.
- `py42.legalhold.add_to_matter()` now raises `Py42UserAlreadyAddedError` when the user is already on the matter.
- `py42.legalhold.get_matter_by_uid()` now raises `Py42LegalHoldNotFoundOrPermissionDeniedError` when the matter is unavailable.
- `py42.users.get_by_username()` now raises `Py42UserDoesNotExistError`.
- `py42.alerts.rules.add_user()` now raises `Py42InvalidRuleTypeError` when trying to add a user to a system rule.
- `py42.alerts.rules.remove_user()` now raises `Py42InvalidRuleTypeError` when trying to a remove user from a system rule.

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
