### PR TITLE
Feature/show-more-directory-support

### DIFF
--- a/src/py42/_internal/archive_access.py
+++ b/src/py42/_internal/archive_access.py
@@ -43,16 +43,16 @@ class ArchiveAccessorManager(object):
     def _get_decryption_keys(self, device_guid, private_password, encryption_key):
         decryption_keys = {}
         if encryption_key:
-            decryption_keys["encryption_key"] = encryption_key
+            decryption_keys[u"encryption_key"] = encryption_key
         else:
             data_key_token = (
                 self._get_data_key_token(device_guid) if not encryption_key else None
             )
             if data_key_token:
-                decryption_keys["data_key_token"] = data_key_token
+                decryption_keys[u"data_key_token"] = data_key_token
 
             if private_password:
-                decryption_keys["private_password"] = private_password
+                decryption_keys[u"private_password"] = private_password
         return decryption_keys
 
     def _get_data_key_token(self, device_guid):
@@ -148,7 +148,7 @@ class RestoreJobManager(object):
 
     def get_stream(self, file_selection):
         response = self._start_restore(file_selection)
-        job_id = response["jobId"]
+        job_id = response[u"jobId"]
 
         while not self.is_job_complete(job_id):
             time.sleep(self._job_polling_interval)

--- a/src/py42/_internal/archive_access.py
+++ b/src/py42/_internal/archive_access.py
@@ -160,13 +160,17 @@ class RestoreJobManager(object):
         return self._get_completion_status(response)
 
     def _start_restore(self, file_selection):
+        zip_result = (
+            str(file_selection.path_set[0][u"type"]).lower() == u"directory" or None
+        )
         return self._storage_archive_client.start_restore(
-            self._device_guid,
-            self._archive_session_id,
-            file_selection.path_set,
-            file_selection.num_files,
-            file_selection.num_dirs,
-            file_selection.size,
+            guid=self._device_guid,
+            web_restore_session_id=self._archive_session_id,
+            path_set=file_selection.path_set,
+            num_files=file_selection.num_files,
+            num_dirs=file_selection.num_dirs,
+            size=file_selection.size,
+            zip_result=zip_result,
             show_deleted=True,
         )
 

--- a/src/py42/modules/archive.py
+++ b/src/py42/modules/archive.py
@@ -15,7 +15,8 @@ class ArchiveModule(object):
         archive_password=None,
         encryption_key=None,
     ):
-        """Streams a file from a backup archive to memory.
+        """Streams a file from a backup archive to memory. If streaming a directory, the
+        results will be zipped.
         `REST Documentation <https://console.us.code42.com/apidocviewer/#WebRestoreJobResult-get>`__
 
         Args:
@@ -37,10 +38,16 @@ class ArchiveModule(object):
         Usage example::
 
             stream_response = sdk.archive.stream_from_backup("/full/path/to/file.txt", "1234567890")
-            with open("/path/to/my/file", 'wb') as f:
+            with open("/path/to/my/file", "wb") as f:
                 for chunk in stream_response.iter_content(chunk_size=128):
                     if chunk:
                         f.write(chunk)
+
+        If downloading a directory, you will need to unzip the results::
+
+            import zipfile
+            with zipfile.ZipFile("downloaded_directory.zip", "r") as zf:
+                zf.extractall(".")
         """
         archive_accessor = self._archive_accessor_manager.get_archive_accessor(
             device_guid,


### PR DESCRIPTION
### Description of Change ###

Kind of a prerequisite for enabling restoring multiple files or directories. INTEG-206.
Wanted to document a little more on restoring directories and also use the `zip_result` param because it does not hurt and looks more intentional. I also cleaned up some testing around this, using kwargs because it is more clear to test parameters I think this way.

### Issues Resolved ###

Does not resolve any issue but is part of INTEG-206 work

### Testing Procedure ###

Make sure you can still restore files via `archive.stream_from_backup()`.
Run in debug mode to set `zip_result` set to `True` when restoring a directory.

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [n/a] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes

### Additional Notes

I don't think a CHANGELOG entry is needed here, but correct me if I'm wrong. A request parameter is changing under the hood.

We could also make `zip_result` a parameter if you request

