### PR TITLE
add get_agent_state methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ## Unreleased
 
+- Methods for calling the agent-state APIs"
+    - `sdk.devices.get_agent_state()`
+    - `sdk.devices.get_agent_full_disk_access_state()`
+    - `sdk.orgs.get_agent_state()`
+    - `sdk.orgs.get_agent_full_disk_access_states()`
+
 ### Added
 
 - Methods for getting individual response pages:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ## Unreleased
 
-- Methods for calling the agent-state APIs"
+- Methods for calling the agent-state APIs:
     - `sdk.devices.get_agent_state()`
     - `sdk.devices.get_agent_full_disk_access_state()`
     - `sdk.orgs.get_agent_state()`

--- a/src/py42/clients/devices.py
+++ b/src/py42/clients/devices.py
@@ -245,7 +245,7 @@ class DeviceClient(BaseClient):
 
             Args:
                 guid (str): The globally unique identifier of the device.
-                propertyName (str): The name of the property to retrieve (e.g. `fullDiskAccess`).
+                property_name (str): The name of the property to retrieve (e.g. `fullDiskAccess`).
 
             Returns:
                 :class:`py42.response.Py42Response`: A response containing settings information.

--- a/src/py42/clients/devices.py
+++ b/src/py42/clients/devices.py
@@ -239,19 +239,19 @@ class DeviceClient(BaseClient):
         params = {u"guid": guid, u"keys": keys}
         return self._session.get(uri, params=params)
 
-    def get_agent_state(self, guid, propertyName):
+    def get_agent_state(self, guid, property_name):
         """Gets the agent state of the device.
             `REST Documentation <https://console.us.code42.com/swagger/index.html?urls.primaryName=v14#/agent-state/AgentState_ViewByDeviceGuid>`__
 
             Args:
                 guid (str): The globally unique identifier of the device.
-                propertyName (str): The name of the property to retrieve.
+                propertyName (str): The name of the property to retrieve (e.g. `fullDiskAccess`).
 
             Returns:
                 :class:`py42.response.Py42Response`: A response containing settings information.
             """
         uri = u"/api/v14/agent-state/view-by-device-guid"
-        params = {u"deviceGuid": guid, u"propertyName": propertyName}
+        params = {u"deviceGuid": guid, u"propertyName": property_name}
         return self._session.get(uri, params=params)
 
     def get_agent_full_disk_access_state(self, guid):
@@ -264,5 +264,4 @@ class DeviceClient(BaseClient):
             Returns:
                 :class:`py42.response.Py42Response`: A response containing settings information.
             """
-        FULLDISKACCESS = "fullDiskAccess"
-        return self.get_agent_state(guid, FULLDISKACCESS)
+        return self.get_agent_state(guid, "fullDiskAccess")

--- a/src/py42/clients/devices.py
+++ b/src/py42/clients/devices.py
@@ -238,3 +238,31 @@ class DeviceClient(BaseClient):
         uri = u"/api/v4/device-setting/view"
         params = {u"guid": guid, u"keys": keys}
         return self._session.get(uri, params=params)
+
+    def get_agent_state(self, guid, propertyName):
+        """Gets the agent state of the device.
+            `REST Documentation <https://console.us.code42.com/swagger/index.html?urls.primaryName=v14#/agent-state/AgentState_ViewByDeviceGuid>`__
+
+            Args:
+                guid (str): The globally unique identifier of the device.
+                propertyName (str): The name of the property to retrieve.
+
+            Returns:
+                :class:`py42.response.Py42Response`: A response containing settings information.
+            """
+        uri = u"/api/v14/agent-state/view-by-device-guid"
+        params = {u"deviceGuid": guid, u"propertyName": propertyName}
+        return self._session.get(uri, params=params)
+
+    def get_agent_full_disk_access_state(self, guid):
+        """Gets the full disk access status of a device.
+            `REST Documentation <https://console.us.code42.com/swagger/index.html?urls.primaryName=v14#/agent-state/AgentState_ViewByDeviceGuid>`__
+
+            Args:
+                guid (str): The globally unique identifier of the device.
+
+            Returns:
+                :class:`py42.response.Py42Response`: A response containing settings information.
+            """
+        FULLDISKACCESS = "fullDiskAccess"
+        return self.get_agent_state(guid, FULLDISKACCESS)

--- a/src/py42/clients/devices.py
+++ b/src/py42/clients/devices.py
@@ -264,4 +264,4 @@ class DeviceClient(BaseClient):
             Returns:
                 :class:`py42.response.Py42Response`: A response containing settings information.
             """
-        return self.get_agent_state(guid, "fullDiskAccess")
+        return self.get_agent_state(guid, u"fullDiskAccess")

--- a/src/py42/clients/orgs.py
+++ b/src/py42/clients/orgs.py
@@ -167,7 +167,7 @@ class OrgClient(BaseClient):
 
             Args:
                 orgId (str): The org's identifier.
-                propertyName (str): The name of the property to retrieve (e.g. `fullDiskAccess`).
+                property_name (str): The name of the property to retrieve (e.g. `fullDiskAccess`).
 
             Returns:
                 :class:`py42.response.Py42Response`: A response containing settings information.

--- a/src/py42/clients/orgs.py
+++ b/src/py42/clients/orgs.py
@@ -160,3 +160,31 @@ class OrgClient(BaseClient):
         """
         uri = u"/api/Org/my"
         return self._session.get(uri, params=kwargs)
+
+    def get_agent_state(self, orgId, propertyName):
+        """Gets the agent state of the devices in the org.
+            `REST Documentation <https://console.us.code42.com/swagger/index.html?urls.primaryName=v14#/agent-state/AgentState_ViewByDeviceGuid>`__
+
+            Args:
+                orgId (str): The org's identifier.
+                propertyName (str): The name of the property to retrieve
+
+            Returns:
+                :class:`py42.response.Py42Response`: A response containing settings information.
+            """
+        uri = u"/api/v14/agent-state/view-by-organization-id"
+        params = {u"orgId": orgId, u"propertyName": propertyName}
+        return self._session.get(uri, params=params)
+
+    def get_agent_full_disk_access_states(self, guid):
+        """Gets the full disk access status for devices in an org.
+            `REST Documentation <https://console.us.code42.com/swagger/index.html?urls.primaryName=v14#/agent-state/AgentState_ViewByDeviceGuid>`__
+
+            Args:
+                orgId (str): The org's identifier.
+
+            Returns:
+                :class:`py42.response.Py42Response`: A response containing settings information.
+            """
+        FULLDISKACCESS = "fullDiskAccess"
+        return self.get_agent_state(guid, FULLDISKACCESS)

--- a/src/py42/clients/orgs.py
+++ b/src/py42/clients/orgs.py
@@ -186,4 +186,4 @@ class OrgClient(BaseClient):
             Returns:
                 :class:`py42.response.Py42Response`: A response containing settings information.
             """
-        return self.get_agent_state(guid, "fullDiskAccess")
+        return self.get_agent_state(guid, u"fullDiskAccess")

--- a/src/py42/clients/orgs.py
+++ b/src/py42/clients/orgs.py
@@ -161,19 +161,19 @@ class OrgClient(BaseClient):
         uri = u"/api/Org/my"
         return self._session.get(uri, params=kwargs)
 
-    def get_agent_state(self, orgId, propertyName):
+    def get_agent_state(self, orgId, property_name):
         """Gets the agent state of the devices in the org.
             `REST Documentation <https://console.us.code42.com/swagger/index.html?urls.primaryName=v14#/agent-state/AgentState_ViewByDeviceGuid>`__
 
             Args:
                 orgId (str): The org's identifier.
-                propertyName (str): The name of the property to retrieve
+                propertyName (str): The name of the property to retrieve (e.g. `fullDiskAccess`).
 
             Returns:
                 :class:`py42.response.Py42Response`: A response containing settings information.
             """
         uri = u"/api/v14/agent-state/view-by-organization-id"
-        params = {u"orgId": orgId, u"propertyName": propertyName}
+        params = {u"orgId": orgId, u"propertyName": property_name}
         return self._session.get(uri, params=params)
 
     def get_agent_full_disk_access_states(self, guid):
@@ -186,5 +186,4 @@ class OrgClient(BaseClient):
             Returns:
                 :class:`py42.response.Py42Response`: A response containing settings information.
             """
-        FULLDISKACCESS = "fullDiskAccess"
-        return self.get_agent_state(guid, FULLDISKACCESS)
+        return self.get_agent_state(guid, "fullDiskAccess")

--- a/tests/clients/test_devices.py
+++ b/tests/clients/test_devices.py
@@ -113,3 +113,25 @@ class TestDeviceClient(object):
                 "q": None,
             },
         )
+
+    def test_get_agent_state_calls_get_with_uri_and_params(
+        self, mock_session, successful_response
+    ):
+        mock_session.get.return_value = successful_response
+        client = DeviceClient(mock_session)
+        client.get_agent_state("DEVICE_ID", propertyName="KEY")
+        expected_params = {"deviceGuid": "DEVICE_ID", "propertyName": "KEY"}
+        uri = u"/api/v14/agent-state/view-by-device-guid"
+        mock_session.get.assert_called_once_with(uri, params=expected_params)
+
+    def test_get_agent_full_disk_access_state_calls_get_agent_state_with_arguments(
+        self, mock_session, successful_response, mocker
+    ):
+        mock_session.get.return_value = successful_response
+        client = DeviceClient(mock_session)
+        client.get_agent_state = mocker.Mock()
+        client.get_agent_full_disk_access_state("DEVICE_ID")
+        expected_propertyName = "fullDiskAccess"
+        client.get_agent_state.assert_called_once_with(
+            "DEVICE_ID", expected_propertyName
+        )

--- a/tests/clients/test_devices.py
+++ b/tests/clients/test_devices.py
@@ -119,7 +119,7 @@ class TestDeviceClient(object):
     ):
         mock_session.get.return_value = successful_response
         client = DeviceClient(mock_session)
-        client.get_agent_state("DEVICE_ID", propertyName="KEY")
+        client.get_agent_state("DEVICE_ID", property_name="KEY")
         expected_params = {"deviceGuid": "DEVICE_ID", "propertyName": "KEY"}
         uri = u"/api/v14/agent-state/view-by-device-guid"
         mock_session.get.assert_called_once_with(uri, params=expected_params)
@@ -131,7 +131,4 @@ class TestDeviceClient(object):
         client = DeviceClient(mock_session)
         client.get_agent_state = mocker.Mock()
         client.get_agent_full_disk_access_state("DEVICE_ID")
-        expected_propertyName = "fullDiskAccess"
-        client.get_agent_state.assert_called_once_with(
-            "DEVICE_ID", expected_propertyName
-        )
+        client.get_agent_state.assert_called_once_with("DEVICE_ID", "fullDiskAccess")

--- a/tests/clients/test_orgs.py
+++ b/tests/clients/test_orgs.py
@@ -62,3 +62,23 @@ class TestOrgClient(object):
         mock_session.get.assert_called_once_with(
             "/api/Org", params={"pgNum": 3, "pgSize": 25}
         )
+
+    def test_get_agent_state_calls_get_with_uri_and_params(
+        self, mock_session, successful_response
+    ):
+        mock_session.get.return_value = successful_response
+        client = OrgClient(mock_session)
+        client.get_agent_state("ORG_ID", propertyName="KEY")
+        expected_params = {"orgId": "ORG_ID", "propertyName": "KEY"}
+        uri = u"/api/v14/agent-state/view-by-organization-id"
+        mock_session.get.assert_called_once_with(uri, params=expected_params)
+
+    def test_get_agent_full_disk_access_states_calls_get_agent_state_with_arguments(
+        self, mock_session, successful_response, mocker
+    ):
+        mock_session.get.return_value = successful_response
+        client = OrgClient(mock_session)
+        client.get_agent_state = mocker.Mock()
+        client.get_agent_full_disk_access_states("ORG_ID")
+        expected_propertyName = "fullDiskAccess"
+        client.get_agent_state.assert_called_once_with("ORG_ID", expected_propertyName)

--- a/tests/clients/test_orgs.py
+++ b/tests/clients/test_orgs.py
@@ -68,7 +68,7 @@ class TestOrgClient(object):
     ):
         mock_session.get.return_value = successful_response
         client = OrgClient(mock_session)
-        client.get_agent_state("ORG_ID", propertyName="KEY")
+        client.get_agent_state("ORG_ID", property_name="KEY")
         expected_params = {"orgId": "ORG_ID", "propertyName": "KEY"}
         uri = u"/api/v14/agent-state/view-by-organization-id"
         mock_session.get.assert_called_once_with(uri, params=expected_params)
@@ -80,5 +80,4 @@ class TestOrgClient(object):
         client = OrgClient(mock_session)
         client.get_agent_state = mocker.Mock()
         client.get_agent_full_disk_access_states("ORG_ID")
-        expected_propertyName = "fullDiskAccess"
-        client.get_agent_state.assert_called_once_with("ORG_ID", expected_propertyName)
+        client.get_agent_state.assert_called_once_with("ORG_ID", "fullDiskAccess")


### PR DESCRIPTION
### Description of Change ###

Adds four methods:

```
sdk.devices.get_agent_state()
sdk.orgs.get_agent_state()
sdk.devices.get_agent_full_disk_access_state()
sdk.orgs.get_agent_full_disk_access_states()
```

### Issues Resolved ###
fixes #161 


### Testing Procedure ###
1. Add a Mac OS endpoint on a recent client (8.2 or later) to a Code42 server
2. Call the new endpoints for its guid and orgId
3. Verify that the status is returned as expected

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
