### PR TITLE
Fix tenant ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ## Unreleased
 
+### Removed
+
+- `tenant_id` parameter from `sdk.alerts.get_details()` method. It is now populated automatically.
+
 ### Added
 
 - Methods for calling the agent-state APIs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Removed
 
-- `tenant_id` parameter from `sdk.alerts.get_details()` method. It is now populated automatically.
+- Removed `tenant_id` parameter from methods:
+    - `sdk.alerts.get_details()`
+    - `sdk.alerts.resolve()`
+    - `sdk.alerts.reopen()`
 
 ### Added
 

--- a/src/py42/modules/alerts.py
+++ b/src/py42/modules/alerts.py
@@ -46,34 +46,28 @@ class AlertsModule(object):
         alert_client = self._microservice_client_factory.get_alerts_client()
         return alert_client.get_details(alert_ids)
 
-    def resolve(self, alert_ids, tenant_id=None, reason=None):
+    def resolve(self, alert_ids, reason=None):
         """Resolves the alerts with the given IDs.
 
         Args:
             alert_ids (iter[str]): The identification numbers for the alerts to resolve.
-            tenant_id (str, optional): The unique identifier for the tenant that the alerts belong
-                to. When given None, it uses the currently logged in user's tenant ID. Defaults to
-                None.
             reason (str, optional): The reason the alerts are now resolved. Defaults to None.
 
         Returns:
             :class:`py42.response.Py42Response`
         """
         alert_client = self._microservice_client_factory.get_alerts_client()
-        return alert_client.resolve(alert_ids, tenant_id=tenant_id, reason=reason)
+        return alert_client.resolve(alert_ids, reason=reason)
 
-    def reopen(self, alert_ids, tenant_id=None, reason=None):
+    def reopen(self, alert_ids, reason=None):
         """Reopens the resolved alerts with the given IDs.
 
         Args:
             alert_ids (iter[str]): The identification numbers for the alerts to reopen.
-            tenant_id (str, optional): The unique identifier for the tenant that the alerts belong
-                to. When given None, it uses the currently logged in user's tenant ID. Defaults to
-                None.
             reason (str, optional): The reason the alerts are reopened. Defaults to None.
 
         Returns:
             :class:`py42.response.Py42Response`
         """
         alert_client = self._microservice_client_factory.get_alerts_client()
-        return alert_client.reopen(alert_ids, tenant_id=tenant_id, reason=reason)
+        return alert_client.reopen(alert_ids, reason=reason)

--- a/src/py42/modules/alerts.py
+++ b/src/py42/modules/alerts.py
@@ -32,22 +32,19 @@ class AlertsModule(object):
         alert_client = self._microservice_client_factory.get_alerts_client()
         return alert_client.search(query)
 
-    def get_details(self, alert_ids, tenant_id=None):
+    def get_details(self, alert_ids):
         """Gets the details for the alerts with the given IDs, including the file event query that,
         when passed into a search, would result in events that could have triggered the alerts.
 
         Args:
             alert_ids (iter[str]): The identification numbers of the alerts for which you want to
                 get details for.
-            tenant_id (str, optional): The unique identifier of the tenant that the alerts belong to.
-                When given None, it uses the currently logged in user's tenant ID. Defaults to
-                None.
 
         Returns:
             :class:`py42.response.Py42Response`: A response containing the alert details.
         """
         alert_client = self._microservice_client_factory.get_alerts_client()
-        return alert_client.get_details(alert_ids, tenant_id=tenant_id)
+        return alert_client.get_details(alert_ids)
 
     def resolve(self, alert_ids, tenant_id=None, reason=None):
         """Resolves the alerts with the given IDs.

--- a/tests/modules/test_alerts.py
+++ b/tests/modules/test_alerts.py
@@ -69,9 +69,7 @@ class TestAlertsModule(object):
         )
         alert_module = AlertsModule(mock_microservice_client_factory)
         alert_module.resolve(self._alert_ids)
-        mock_alerts_client.resolve.assert_called_once_with(
-            self._alert_ids, tenant_id=None, reason=None
-        )
+        mock_alerts_client.resolve.assert_called_once_with(self._alert_ids, reason=None)
 
     def test_alerts_module_calls_reopen_with_expected_value(
         self,
@@ -84,6 +82,4 @@ class TestAlertsModule(object):
         )
         alert_module = AlertsModule(mock_microservice_client_factory)
         alert_module.reopen(self._alert_ids)
-        mock_alerts_client.reopen.assert_called_once_with(
-            self._alert_ids, tenant_id=None, reason=None
-        )
+        mock_alerts_client.reopen.assert_called_once_with(self._alert_ids, reason=None)

--- a/tests/modules/test_alerts.py
+++ b/tests/modules/test_alerts.py
@@ -56,9 +56,7 @@ class TestAlertsModule(object):
         )
         alert_module = AlertsModule(mock_microservice_client_factory)
         alert_module.get_details(self._alert_ids)
-        mock_alerts_client.get_details.assert_called_once_with(
-            self._alert_ids, tenant_id=None
-        )
+        mock_alerts_client.get_details.assert_called_once_with(self._alert_ids)
 
     def test_alerts_module_calls_resolve_with_expected_value(
         self,


### PR DESCRIPTION
### Description of Change ###

Removed tenant ID from `alerts.get_details()`.  This is because it was removed from an internal client and it is not needed.

### Issues Resolved ###


### Testing Procedure ###
Run this CLI command `code42 alerts search -f JSON -b 2020-05-20` and make sure it does indicate this error at the very top of the output.

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
