### PR TITLE
Chore/exception compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 - Exception classes (`py42.exceptions`)
     - `Py42ResponseError`
     - `Py42UserAlreadyAddedError`
-    - `Py42UserNotInLegalHoldError`
     - `Py42LegalHoldNotFoundOrPermissionDeniedError`
-    - `Py42UserDoesNotExistError`
     - `Py42InvalidRuleOperationError`
 
 - Methods for getting individual response pages:

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -87,7 +87,27 @@ class Py42SessionInitializationError(Py42Error):
         super(Py42SessionInitializationError, self).__init__(exception, error_message)
 
 
-class Py42UserAlreadyAddedError(Py42HTTPError):
+class Py42BadRequestError(Py42HTTPError):
+    """A wrapper to represent an HTTP 400 error."""
+
+
+class Py42UnauthorizedError(Py42HTTPError):
+    """A wrapper to represent an HTTP 401 error."""
+
+
+class Py42ForbiddenError(Py42HTTPError):
+    """A wrapper to represent an HTTP 403 error."""
+
+
+class Py42NotFoundError(Py42HTTPError):
+    """A wrapper to represent an HTTP 404 error."""
+
+
+class Py42InternalServerError(Py42HTTPError):
+    """A wrapper to represent an HTTP 500 error."""
+
+
+class Py42UserAlreadyAddedError(Py42BadRequestError):
     """An exception raised when the user is already added to group or list, such as the
     Departing Employee list."""
 
@@ -96,7 +116,7 @@ class Py42UserAlreadyAddedError(Py42HTTPError):
         super(Py42UserAlreadyAddedError, self).__init__(exception, msg)
 
 
-class Py42LegalHoldNotFoundOrPermissionDeniedError(Py42HTTPError):
+class Py42LegalHoldNotFoundOrPermissionDeniedError(Py42ForbiddenError):
     """An exception raised when a legal hold matter is inaccessible from your account or
     the matter ID is not valid."""
 
@@ -118,26 +138,6 @@ class Py42InvalidRuleOperationError(Py42HTTPError):
         super(Py42InvalidRuleOperationError, self).__init__(
             exception, msg.format(rule_id, source)
         )
-
-
-class Py42BadRequestError(Py42HTTPError):
-    """A wrapper to represent an HTTP 400 error."""
-
-
-class Py42UnauthorizedError(Py42HTTPError):
-    """A wrapper to represent an HTTP 401 error."""
-
-
-class Py42ForbiddenError(Py42HTTPError):
-    """A wrapper to represent an HTTP 403 error."""
-
-
-class Py42NotFoundError(Py42HTTPError):
-    """A wrapper to represent an HTTP 404 error."""
-
-
-class Py42InternalServerError(Py42HTTPError):
-    """A wrapper to represent an HTTP 500 error."""
 
 
 def raise_py42_error(raised_error):

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -48,15 +48,6 @@ class Py42FeatureUnavailableError(Py42ResponseError):
         )
 
 
-class Py42UserDoesNotExistError(Py42ResponseError):
-    """An exception raised when a username is not in our system."""
-
-    def __init__(self, response, username):
-        super(Py42UserDoesNotExistError, self).__init__(
-            response, message=u"User '{}' does not exist.".format(username),
-        )
-
-
 class Py42HTTPError(Py42ResponseError):
     """A base custom class to manage all HTTP errors raised by an API endpoint."""
 

--- a/src/py42/services/users.py
+++ b/src/py42/services/users.py
@@ -1,6 +1,5 @@
 from py42 import settings
 from py42._compat import quote
-from py42.exceptions import Py42UserDoesNotExistError
 from py42.services import BaseService
 from py42.services.util import get_all_pages
 
@@ -78,8 +77,7 @@ class UserService(BaseService):
         return self._connection.get(uri, params=params)
 
     def get_by_username(self, username, **kwargs):
-        """Gets the user with the given username. Raises :class:`~py42.exceptions.Py42UserDoesNotExistError`
-        when no user is found.
+        """Gets the user with the given username.
         `REST Documentation <https://console.us.code42.com/apidocviewer/#User-get>`__
 
         Args:
@@ -90,10 +88,7 @@ class UserService(BaseService):
         """
         uri = u"/api/User"
         params = dict(username=username, **kwargs)
-        response = self._connection.get(uri, params=params)
-        if not response[u"users"]:
-            raise Py42UserDoesNotExistError(response, username)
-        return response
+        return self._connection.get(uri, params=params)
 
     def get_current(self, **kwargs):
         """Gets the currently signed in user.

--- a/tests/services/test_users.py
+++ b/tests/services/test_users.py
@@ -3,7 +3,6 @@ import pytest
 from requests import Response
 
 import py42.settings
-from py42.exceptions import Py42UserDoesNotExistError
 from py42.response import Py42Response
 from py42.services.users import UserService
 
@@ -96,16 +95,6 @@ class TestUserService(object):
         service.get_by_username(username)
         expected_params = {u"username": username}
         mock_connection.get.assert_called_once_with(USER_URI, params=expected_params)
-
-    def test_get_by_username_when_empty_list_returns_raises_user_not_exists(
-        self, mock_connection, mock_get_users_empty_response
-    ):
-        mock_connection.get.return_value = mock_get_users_empty_response
-        service = UserService(mock_connection)
-        with pytest.raises(Py42UserDoesNotExistError) as err:
-            service.get_by_username("username")
-
-        assert str(err.value) == "User 'username' does not exist."
 
     def test_get_user_by_id_calls_get_with_uri_and_params(
         self, mock_connection, successful_response


### PR DESCRIPTION
### Description of Change ###

- removes `Py42UserNotFoundError`. This would be a breaking change for situations where a username did not exist (normally an empty list is returned).
- makes `Py42UserAlreadyAddedError` an instance of `Py42BadRequestError` in order to make exception handling backwards compatible.
- makes `Py42LegalHoldNotFoundOrPermissionDeniedError` an instance of `Py42ForbiddenError` in order to make exception handling backwards compatible.