### PR TITLE
Chore alert state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - Removed faulty `within_the_last()` method from `sdk.queries.alerts.filters.alert_filter.DateObserved`.
 
+### Changed
+- Updated Alert `resolve-alert` and `reopen-alert` endpoints to `update-state` endpoint.
+
+### Added
+
+- `sdk.alerts` methods to support new alert states `pending` and `in progress`:
+    `sdk.alerts.pending()`
+    `sdk.alerts.in_progress()`
+
 ## 1.8.1 - 2020-08-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Added
 
-- `sdk.alerts` methods to support new alert states `pending` and `in progress`:
-    `sdk.alerts.pending()`
-    `sdk.alerts.in_progress()`
+- `sdk.alerts.update_state()` method to update state, `sdk.alerts.resolve` and `sdk.alerts.reopen` are deprecated and will be removed from version 2.0
 
 ## 1.8.1 - 2020-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,6 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - Removed faulty `within_the_last()` method from `sdk.queries.alerts.filters.alert_filter.DateObserved`.
 
-### Changed
-- Updated Alert `resolve-alert` and `reopen-alert` endpoints to `update-state` endpoint.
-
 ### Added
 
 - `sdk.alerts.update_state()` method to update state, `sdk.alerts.resolve` and `sdk.alerts.reopen` are deprecated and will be removed from version 2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Added
 
-- `sdk.alerts.update_state()` method to update state, `sdk.alerts.resolve` and `sdk.alerts.reopen` are deprecated and will be removed from version 2.0
+- `sdk.alerts.update_state()` method to update state.
 
 ## 1.8.1 - 2020-08-28
 

--- a/docs/methoddocs/alerts.md
+++ b/docs/methoddocs/alerts.md
@@ -1,17 +1,3 @@
-# Alerts
-
-```eval_rst
-.. autoclass:: py42.clients.alerts.AlertsClient
-    :members:
-    :show-inheritance:
-```
-
-```eval_rst
-.. autoclass:: py42.sdk.queries.alerts.alert_query.AlertQuery
-    :members:
-    :show-inheritance:
-```
-
 ## Filter Classes
 
 The following classes construct filters for file event queries. Each filter class corresponds to an alert detail.
@@ -25,5 +11,20 @@ See [Executing Searches](../userguides/searches.md) for more on building search 
 .. automodule:: py42.sdk.queries.alerts.filters.alert_filter
     :members:
     :inherited-members:
+    :show-inheritance:
+```
+
+```eval_rst
+.. autoclass:: py42.sdk.queries.alerts.alert_query.AlertQuery
+    :members:
+    :show-inheritance:
+```
+
+
+# Alerts
+
+```eval_rst
+.. autoclass:: py42.clients.alerts.AlertsClient
+    :members:
     :show-inheritance:
 ```

--- a/src/py42/clients/alerts.py
+++ b/src/py42/clients/alerts.py
@@ -1,3 +1,11 @@
+class AlertState(object):
+
+    IN_PROGRESS = "IN_PROGRESS"
+    OPEN = "OPEN"
+    PENDING = "PENDING"
+    RESOLVED = "RESOLVED"
+
+
 class AlertsClient(object):
     def __init__(self, alert_service, alert_rules_client):
         self._alert_service = alert_service
@@ -49,7 +57,9 @@ class AlertsClient(object):
         Returns:
             :class:`py42.response.Py42Response`
         """
-        return self._alert_service.resolve(alert_ids, reason=reason)
+        return self._alert_service.update_state(
+            AlertState.RESOLVED, alert_ids, reason=reason
+        )
 
     def reopen(self, alert_ids, reason=None):
         """Reopens the resolved alerts with the given IDs.
@@ -61,4 +71,34 @@ class AlertsClient(object):
         Returns:
             :class:`py42.response.Py42Response`
         """
-        return self._alert_service.reopen(alert_ids, reason=reason)
+        return self._alert_service.update_state(
+            AlertState.OPEN, alert_ids, reason=reason
+        )
+
+    def pending(self, alert_ids, reason=None):
+        """Reopens the resolved alerts with the given IDs.
+
+        Args:
+            alert_ids (iter[str]): The identification numbers for the alerts to reopen.
+            reason (str, optional): The reason the alerts are reopened. Defaults to None.
+
+        Returns:
+            :class:`py42.response.Py42Response`
+        """
+        return self._alert_service.update_state(
+            AlertState.PENDING, alert_ids, reason=reason
+        )
+
+    def in_progress(self, alert_ids, reason=None):
+        """Reopens the resolved alerts with the given IDs.
+
+        Args:
+            alert_ids (iter[str]): The identification numbers for the alerts to reopen.
+            reason (str, optional): The reason the alerts are reopened. Defaults to None.
+
+        Returns:
+            :class:`py42.response.Py42Response`
+        """
+        return self._alert_service.update_state(
+            AlertState.IN_PROGRESS, alert_ids, reason=reason
+        )

--- a/src/py42/clients/alerts.py
+++ b/src/py42/clients/alerts.py
@@ -76,11 +76,11 @@ class AlertsClient(object):
         )
 
     def pending(self, alert_ids, reason=None):
-        """Reopens the resolved alerts with the given IDs.
+        """Set the alerts status to pending with the given IDs.
 
         Args:
-            alert_ids (iter[str]): The identification numbers for the alerts to reopen.
-            reason (str, optional): The reason the alerts are reopened. Defaults to None.
+            alert_ids (iter[str]): The identification numbers for the alerts to set to in-progress status.
+            reason (str, optional): The reason the alerts are set to pending status. Defaults to None.
 
         Returns:
             :class:`py42.response.Py42Response`
@@ -90,11 +90,11 @@ class AlertsClient(object):
         )
 
     def in_progress(self, alert_ids, reason=None):
-        """Reopens the resolved alerts with the given IDs.
+        """Sets the alerts status to in-progress with the given IDs.
 
         Args:
-            alert_ids (iter[str]): The identification numbers for the alerts to reopen.
-            reason (str, optional): The reason the alerts are reopened. Defaults to None.
+            alert_ids (iter[str]): The identification numbers for the alerts to set to in-progress status.
+            reason (str, optional): The reason the alerts are set to in-progress status. Defaults to None.
 
         Returns:
             :class:`py42.response.Py42Response`

--- a/src/py42/clients/alerts.py
+++ b/src/py42/clients/alerts.py
@@ -45,7 +45,7 @@ class AlertsClient(object):
     def resolve(self, alert_ids, reason=None):
         """Resolves the alerts with the given IDs.
 
-        Deprecated. Support will be removed from version 2.0.0. Use `update_state` instead.
+        Deprecated. Support will be removed from version 2.0.0. Use :meth:`~py42.clients.alerts.AlertClient.update_state()` instead.
 
         Args:
             alert_ids (iter[str]): The identification numbers for the alerts to resolve.
@@ -61,7 +61,7 @@ class AlertsClient(object):
     def reopen(self, alert_ids, reason=None):
         """Reopens the resolved alerts with the given IDs.
 
-        Deprecated. Support will be removed from version 2.0.0. Use `update_state` instead.
+        Deprecated. Support will be removed from version 2.0.0. Use :meth:`~py42.clients.alerts.AlertClient.update_state()` instead.
 
         Args:
             alert_ids (iter[str]): The identification numbers for the alerts to reopen.

--- a/src/py42/clients/alerts.py
+++ b/src/py42/clients/alerts.py
@@ -55,7 +55,7 @@ class AlertsClient(object):
             :class:`py42.response.Py42Response`
         """
         return self._alert_service.update_state(
-            AlertState.DISMISSED, alert_ids, reason=reason
+            AlertState.DISMISSED, alert_ids, note=reason
         )
 
     def reopen(self, alert_ids, reason=None):
@@ -70,19 +70,17 @@ class AlertsClient(object):
         Returns:
             :class:`py42.response.Py42Response`
         """
-        return self._alert_service.update_state(
-            AlertState.OPEN, alert_ids, reason=reason
-        )
+        return self._alert_service.update_state(AlertState.OPEN, alert_ids, note=reason)
 
-    def update_state(self, status, alert_ids, reason=None):
+    def update_state(self, status, alert_ids, note=None):
         """Update status for given alert IDs.
 
         Args:
             status (str): Status to set from OPEN, RESOLVED, PENDING, IN_PROGRESS
             alert_ids (iter[str]): The identification numbers for the alerts to reopen.
-            reason (str, optional): The reason the alerts are reopened. Defaults to None.
+            note (str, optional): User note regarding the status. Defaults to None.
 
         Returns:
             :class:`py42.response.Py42Response`
         """
-        return self._alert_service.update_state(status, alert_ids, reason=reason)
+        return self._alert_service.update_state(status, alert_ids, note=note)

--- a/src/py42/clients/alerts.py
+++ b/src/py42/clients/alerts.py
@@ -1,9 +1,4 @@
-class AlertState(object):
-
-    IN_PROGRESS = "IN_PROGRESS"
-    OPEN = "OPEN"
-    PENDING = "PENDING"
-    RESOLVED = "RESOLVED"
+from py42.sdk.queries.alerts.filters import AlertState
 
 
 class AlertsClient(object):
@@ -50,6 +45,8 @@ class AlertsClient(object):
     def resolve(self, alert_ids, reason=None):
         """Resolves the alerts with the given IDs.
 
+        Deprecated. Support will be removed from version 2.0.0. Use `update_state` instead.
+
         Args:
             alert_ids (iter[str]): The identification numbers for the alerts to resolve.
             reason (str, optional): The reason the alerts are now resolved. Defaults to None.
@@ -58,11 +55,13 @@ class AlertsClient(object):
             :class:`py42.response.Py42Response`
         """
         return self._alert_service.update_state(
-            AlertState.RESOLVED, alert_ids, reason=reason
+            AlertState.DISMISSED, alert_ids, reason=reason
         )
 
     def reopen(self, alert_ids, reason=None):
         """Reopens the resolved alerts with the given IDs.
+
+        Deprecated. Support will be removed from version 2.0.0. Use `update_state` instead.
 
         Args:
             alert_ids (iter[str]): The identification numbers for the alerts to reopen.
@@ -75,30 +74,15 @@ class AlertsClient(object):
             AlertState.OPEN, alert_ids, reason=reason
         )
 
-    def pending(self, alert_ids, reason=None):
-        """Set the alerts status to pending with the given IDs.
+    def update_state(self, status, alert_ids, reason=None):
+        """Update status for given alert IDs.
 
         Args:
-            alert_ids (iter[str]): The identification numbers for the alerts to set to in-progress status.
-            reason (str, optional): The reason the alerts are set to pending status. Defaults to None.
+            status (str): Status to set from OPEN, RESOLVED, PENDING, IN_PROGRESS
+            alert_ids (iter[str]): The identification numbers for the alerts to reopen.
+            reason (str, optional): The reason the alerts are reopened. Defaults to None.
 
         Returns:
             :class:`py42.response.Py42Response`
         """
-        return self._alert_service.update_state(
-            AlertState.PENDING, alert_ids, reason=reason
-        )
-
-    def in_progress(self, alert_ids, reason=None):
-        """Sets the alerts status to in-progress with the given IDs.
-
-        Args:
-            alert_ids (iter[str]): The identification numbers for the alerts to set to in-progress status.
-            reason (str, optional): The reason the alerts are set to in-progress status. Defaults to None.
-
-        Returns:
-            :class:`py42.response.Py42Response`
-        """
-        return self._alert_service.update_state(
-            AlertState.IN_PROGRESS, alert_ids, reason=reason
-        )
+        return self._alert_service.update_state(status, alert_ids, reason=reason)

--- a/src/py42/clients/alerts.py
+++ b/src/py42/clients/alerts.py
@@ -45,8 +45,6 @@ class AlertsClient(object):
     def resolve(self, alert_ids, reason=None):
         """Resolves the alerts with the given IDs.
 
-        Deprecated. Support will be removed from version 2.0.0. Use :meth:`~py42.clients.alerts.AlertClient.update_state()` instead.
-
         Args:
             alert_ids (iter[str]): The identification numbers for the alerts to resolve.
             reason (str, optional): The reason the alerts are now resolved. Defaults to None.
@@ -60,8 +58,6 @@ class AlertsClient(object):
 
     def reopen(self, alert_ids, reason=None):
         """Reopens the resolved alerts with the given IDs.
-
-        Deprecated. Support will be removed from version 2.0.0. Use :meth:`~py42.clients.alerts.AlertClient.update_state()` instead.
 
         Args:
             alert_ids (iter[str]): The identification numbers for the alerts to reopen.

--- a/src/py42/sdk/queries/alerts/filters/alert_filter.py
+++ b/src/py42/sdk/queries/alerts/filters/alert_filter.py
@@ -171,12 +171,16 @@ class AlertState(QueryFilterStringField):
     Available options are:
         - :attr:`AlertState.OPEN`
         - :attr:`AlertState.DISMISSED`
+        - :attr:`AlertState.PENDING`
+        - :attr:`AlertState.IN_PROGRESS`
     """
 
     _term = u"state"
 
     OPEN = u"OPEN"
     DISMISSED = u"RESOLVED"
+    PENDING = u"PENDING"
+    IN_PROGRESS = u"IN_PROGRESS"
 
     @staticmethod
     def choices():

--- a/src/py42/services/alerts.py
+++ b/src/py42/services/alerts.py
@@ -31,21 +31,18 @@ class AlertService(BaseService):
         results = self._connection.post(uri, json=data)
         return _convert_observation_json_strings_to_objects(results)
 
-    def resolve(self, alert_ids, reason=None):
+    def update_state(self, state, alert_ids, reason=None):
         if not isinstance(alert_ids, (list, tuple)):
             alert_ids = [alert_ids]
+        note = reason or u""
         tenant_id = self._user_context.get_current_tenant_id()
-        reason = reason or u""
-        uri = self._uri_prefix.format(u"resolve-alert")
-        data = {u"tenantId": tenant_id, u"alertIds": alert_ids, u"reason": reason}
-        return self._connection.post(uri, json=data)
-
-    def reopen(self, alert_ids, reason=None):
-        if not isinstance(alert_ids, (list, tuple)):
-            alert_ids = [alert_ids]
-        tenant_id = self._user_context.get_current_tenant_id()
-        uri = self._uri_prefix.format(u"reopen-alert")
-        data = {u"tenantId": tenant_id, u"alertIds": alert_ids, u"reason": reason}
+        uri = self._uri_prefix.format(u"update-state")
+        data = {
+            u"tenantId": tenant_id,
+            u"alertIds": alert_ids,
+            u"note": note,
+            u"state": state,
+        }
         return self._connection.post(uri, json=data)
 
     def _add_tenant_id_if_missing(self, query):

--- a/src/py42/services/alerts.py
+++ b/src/py42/services/alerts.py
@@ -31,10 +31,10 @@ class AlertService(BaseService):
         results = self._connection.post(uri, json=data)
         return _convert_observation_json_strings_to_objects(results)
 
-    def update_state(self, state, alert_ids, reason=None):
+    def update_state(self, state, alert_ids, note=""):
         if not isinstance(alert_ids, (list, tuple)):
             alert_ids = [alert_ids]
-        note = reason or u""
+        note = note or ""
         tenant_id = self._user_context.get_current_tenant_id()
         uri = self._uri_prefix.format(u"update-state")
         data = {

--- a/tests/clients/test_alerts.py
+++ b/tests/clients/test_alerts.py
@@ -44,18 +44,38 @@ class TestAlertsClient(object):
         alert_client.get_details(self._alert_ids)
         mock_alerts_service.get_details.assert_called_once_with(self._alert_ids)
 
-    def test_alerts_client_calls_resolve_with_expected_value(
+    def test_alerts_client_calls_update_state_with_resolve_state_and_expected_value(
         self, mock_alerts_service, mock_alert_rules_service,
     ):
         alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
         alert_client.resolve(self._alert_ids)
-        mock_alerts_service.resolve.assert_called_once_with(
-            self._alert_ids, reason=None
+        mock_alerts_service.update_state.assert_called_once_with(
+            "RESOLVED", self._alert_ids, reason=None
         )
 
-    def test_alerts_client_calls_reopen_with_expected_value(
+    def test_alerts_client_calls_update_state_with_reopen_state_and_expected_value(
         self, mock_alerts_service, mock_alert_rules_service,
     ):
         alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
         alert_client.reopen(self._alert_ids)
-        mock_alerts_service.reopen.assert_called_once_with(self._alert_ids, reason=None)
+        mock_alerts_service.update_state.assert_called_once_with(
+            "OPEN", self._alert_ids, reason=None
+        )
+
+    def test_alerts_client_calls_update_state_with_pending_state_and_expected_value(
+        self, mock_alerts_service, mock_alert_rules_service,
+    ):
+        alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
+        alert_client.pending(self._alert_ids)
+        mock_alerts_service.update_state.assert_called_once_with(
+            "PENDING", self._alert_ids, reason=None
+        )
+
+    def test_alerts_client_calls_update_state_with_in_progress_state_and_expected_value(
+        self, mock_alerts_service, mock_alert_rules_service,
+    ):
+        alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
+        alert_client.in_progress(self._alert_ids)
+        mock_alerts_service.update_state.assert_called_once_with(
+            "IN_PROGRESS", self._alert_ids, reason=None
+        )

--- a/tests/clients/test_alerts.py
+++ b/tests/clients/test_alerts.py
@@ -50,7 +50,7 @@ class TestAlertsClient(object):
         alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
         alert_client.resolve(self._alert_ids)
         mock_alerts_service.update_state.assert_called_once_with(
-            "RESOLVED", self._alert_ids, reason=None
+            "RESOLVED", self._alert_ids, note=None
         )
 
     def test_alerts_client_calls_update_state_with_reopen_state_and_expected_value(
@@ -59,7 +59,7 @@ class TestAlertsClient(object):
         alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
         alert_client.reopen(self._alert_ids)
         mock_alerts_service.update_state.assert_called_once_with(
-            "OPEN", self._alert_ids, reason=None
+            "OPEN", self._alert_ids, note=None
         )
 
     def test_alerts_client_calls_update_state_with_state_and_expected_value(
@@ -68,5 +68,5 @@ class TestAlertsClient(object):
         alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
         alert_client.update_state("RESOLVED", self._alert_ids)
         mock_alerts_service.update_state.assert_called_once_with(
-            "RESOLVED", self._alert_ids, reason=None
+            "RESOLVED", self._alert_ids, note=None
         )

--- a/tests/clients/test_alerts.py
+++ b/tests/clients/test_alerts.py
@@ -62,20 +62,11 @@ class TestAlertsClient(object):
             "OPEN", self._alert_ids, reason=None
         )
 
-    def test_alerts_client_calls_update_state_with_pending_state_and_expected_value(
+    def test_alerts_client_calls_update_state_with_state_and_expected_value(
         self, mock_alerts_service, mock_alert_rules_service,
     ):
         alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
-        alert_client.pending(self._alert_ids)
+        alert_client.update_state("RESOLVED", self._alert_ids)
         mock_alerts_service.update_state.assert_called_once_with(
-            "PENDING", self._alert_ids, reason=None
-        )
-
-    def test_alerts_client_calls_update_state_with_in_progress_state_and_expected_value(
-        self, mock_alerts_service, mock_alert_rules_service,
-    ):
-        alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
-        alert_client.in_progress(self._alert_ids)
-        mock_alerts_service.update_state.assert_called_once_with(
-            "IN_PROGRESS", self._alert_ids, reason=None
+            "RESOLVED", self._alert_ids, reason=None
         )

--- a/tests/sdk/queries/alerts/filters/test_alert_filter.py
+++ b/tests/sdk/queries/alerts/filters/test_alert_filter.py
@@ -360,5 +360,5 @@ def test_severity_choices_returns_set():
 
 def test_alert_state_choices_returns_set():
     choices = AlertState.choices()
-    valid_set = {"OPEN", "RESOLVED"}
+    valid_set = {"OPEN", "RESOLVED", "PENDING", "IN_PROGRESS"}
     assert set(choices) == valid_set

--- a/tests/services/test_alerts.py
+++ b/tests/services/test_alerts.py
@@ -182,88 +182,59 @@ class TestAlertService(object):
         expected_observation_data = '{"invalid_json": ][ }'
         assert observation_data == expected_observation_data
 
-    def test_resolve_when_not_given_tenant_id_posts_expected_data(
+    def test_update_state_when_not_given_tenant_id_posts_expected_data(
         self, mock_connection, user_context, successful_post
     ):
         alert_service = AlertService(mock_connection, user_context)
         alert_ids = ["ALERT_ID_1", "ALERT_ID_2"]
-        alert_service.resolve(alert_ids)
+        alert_service.update_state("RESOLVED", alert_ids, "")
         post_data = mock_connection.post.call_args[1]["json"]
         assert (
             post_data["tenantId"] == TENANT_ID_FROM_RESPONSE
             and post_data["alertIds"][0] == "ALERT_ID_1"
             and post_data["alertIds"][1] == "ALERT_ID_2"
+            and post_data["state"] == "RESOLVED"
+            and post_data["note"] == ""
         )
 
     @pytest.mark.parametrize(
         "alert_id", ["ALERT_ID_1", ("ALERT_ID_1",), ["ALERT_ID_1"]]
     )
-    def test_resolve_when_given_single_alert_id_posts_expected_data(
+    def test_update_state_when_given_single_alert_id_posts_expected_data(
         self, mock_connection, user_context, successful_post, alert_id
     ):
         alert_service = AlertService(mock_connection, user_context)
-        alert_service.resolve(alert_id)
+        alert_service.update_state("PENDING", alert_id)
         post_data = mock_connection.post.call_args[1]["json"]
         assert (
             post_data["tenantId"] == TENANT_ID_FROM_RESPONSE
             and post_data["alertIds"][0] == "ALERT_ID_1"
+            and post_data["state"] == "PENDING"
+            and post_data["note"] == ""
         )
 
-    def test_resolve_posts_expected_data(
+    def test_update_posts_expected_data(
         self, mock_connection, user_context, successful_post
     ):
         alert_service = AlertService(mock_connection, user_context)
         alert_ids = ["ALERT_ID_1", "ALERT_ID_2"]
-        alert_service.resolve(alert_ids,)
+        alert_service.update_state("OPEN", alert_ids, "some-tenant-id")
         post_data = mock_connection.post.call_args[1]["json"]
         assert (
             post_data["tenantId"] == TENANT_ID_FROM_RESPONSE
             and post_data["alertIds"][0] == "ALERT_ID_1"
             and post_data["alertIds"][1] == "ALERT_ID_2"
+            and post_data["state"] == "OPEN"
+            and post_data["note"] == "some-tenant-id"
         )
 
-    def test_resolve_posts_to_expected_url(
+    def test_update_state_posts_to_expected_url(
         self, mock_connection, user_context, successful_post
     ):
         alert_service = AlertService(mock_connection, user_context)
         alert_ids = ["ALERT_ID_1", "ALERT_ID_2"]
-        alert_service.resolve(alert_ids, "some-tenant-id")
-        assert mock_connection.post.call_args[0][0] == "/svc/api/v1/resolve-alert"
-
-    def test_reopen_posts_expected_data(
-        self, mock_connection, user_context, successful_post
-    ):
-        alert_service = AlertService(mock_connection, user_context)
-        alert_ids = ["ALERT_ID_1", "ALERT_ID_2"]
-        alert_service.reopen(alert_ids)
-        post_data = mock_connection.post.call_args[1]["json"]
-        assert (
-            post_data["tenantId"] == TENANT_ID_FROM_RESPONSE
-            and post_data["alertIds"][0] == "ALERT_ID_1"
-            and post_data["alertIds"][1] == "ALERT_ID_2"
-        )
-
-    @pytest.mark.parametrize(
-        "alert_id", ["ALERT_ID_1", ("ALERT_ID_1",), ["ALERT_ID_1"]]
-    )
-    def test_reopen_when_given_single_alert_id_posts_expected_data(
-        self, mock_connection, user_context, successful_post, alert_id
-    ):
-        alert_service = AlertService(mock_connection, user_context)
-        alert_service.reopen(alert_id)
-        post_data = mock_connection.post.call_args[1]["json"]
-        assert (
-            post_data["tenantId"] == TENANT_ID_FROM_RESPONSE
-            and post_data["alertIds"][0] == "ALERT_ID_1"
-        )
-
-    def test_reopen_posts_to_expected_url(
-        self, mock_connection, user_context, successful_post
-    ):
-        alert_service = AlertService(mock_connection, user_context)
-        alert_ids = ["ALERT_ID_1", "ALERT_ID_2"]
-        alert_service.reopen(alert_ids, "some-tenant-id")
-        assert mock_connection.post.call_args[0][0] == "/svc/api/v1/reopen-alert"
+        alert_service.update_state("RESOLVED", alert_ids, "some-tenant-id")
+        assert mock_connection.post.call_args[0][0] == "/svc/api/v1/update-state"
 
     def test_get_all_rules_posts_expected_data(self, mock_connection, user_context):
         alert_service = AlertService(mock_connection, user_context)

--- a/tests/services/test_alerts.py
+++ b/tests/services/test_alerts.py
@@ -213,7 +213,7 @@ class TestAlertService(object):
             and post_data["note"] == ""
         )
 
-    def test_update_posts_expected_data(
+    def test_update_state_posts_expected_data(
         self, mock_connection, user_context, successful_post
     ):
         alert_service = AlertService(mock_connection, user_context)
@@ -235,6 +235,22 @@ class TestAlertService(object):
         alert_ids = ["ALERT_ID_1", "ALERT_ID_2"]
         alert_service.update_state("RESOLVED", alert_ids, "some-tenant-id")
         assert mock_connection.post.call_args[0][0] == "/svc/api/v1/update-state"
+
+    def test_update_state_when_note_passed_none_posts_expected_data(
+        self, mock_connection, user_context, successful_post
+    ):
+        alert_service = AlertService(mock_connection, user_context)
+        alert_ids = ["ALERT_ID_1", "ALERT_ID_2"]
+        alert_service.update_state("RESOLVED", alert_ids, note=None)
+        assert mock_connection.post.call_args[0][0] == "/svc/api/v1/update-state"
+        post_data = mock_connection.post.call_args[1]["json"]
+        assert (
+            post_data["tenantId"] == TENANT_ID_FROM_RESPONSE
+            and post_data["alertIds"][0] == "ALERT_ID_1"
+            and post_data["alertIds"][1] == "ALERT_ID_2"
+            and post_data["state"] == "RESOLVED"
+            and post_data["note"] == ""
+        )
 
     def test_get_all_rules_posts_expected_data(self, mock_connection, user_context):
         alert_service = AlertService(mock_connection, user_context)


### PR DESCRIPTION
### Description of Change ###

Changed `resolve-alert` and `reopen-alert` endpoints to `update-state` endpoint.
Added methods to support `in progress` and `pending` state.

### Issues Resolved ###
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->
fixes #INTEG-1152

- closes # [INTEG-1152](https://jira.corp.code42.com/browse/INTEG-1152)

### Testing Procedure ###
```
sdk.alerts.reopen('b9ac929f-1bc4-4f6f-8103-4674e65edade', "test note ")
sdk.alerts.resolve('b9ac929f-1bc4-4f6f-8103-4674e65edade', "test note 2")
sdk.alerts.in_progress('b9ac929f-1bc4-4f6f-8103-4674e65edade', "test note 4")
sdk.alerts.pending(['b9ac929f-1bc4-4f6f-8103-4674e65edade'], "test note 3")
sdk.alerts.reopen('b9ac929f-1bc4-4f6f-8103-4674e65edade')
```

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
