### PR TITLE
Fix SavedSearchClient.execute() paging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Added
 
+- Added additional user-adjustable setting for security events page size:
+    - `py42.settings.security_events_per_page`
+
+- Page pg_num for saved search queries (pg_num):
+    - `py42.securitydata.savedsearches.get_query()`
+    - `py42.securitydata.savedsearches.execute()`
+
 - Methods for calling the agent-state APIs:
     - `sdk.devices.get_agent_state()`
     - `sdk.devices.get_agent_full_disk_access_state()`
@@ -74,7 +81,6 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Changed
 
-- `py42.securitydata.savedsearches.get_query()` now accepts `pg_num` and `pg_size` arguments.
 - `py42.detectionlists.departing_employee.add()` now raises `Py42UserAlreadyAddedError` when the user is already on the list.
 - `py42.detectionlists.high_risk_employee.add()` now raises `Py42UserAlreadyAddedError` when the user already on the list.
 - `py42.legalhold.add_to_matter()` now raises `Py42UserAlreadyAddedError` when the user is already on the matter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Changed
 
+- `py42.securitydata.savedsearches.get_query()` now accepts `pg_num` and `pg_size` arguments.
 - `py42.detectionlists.departing_employee.add()` now raises `Py42UserAlreadyAddedError` when the user is already on the list.
 - `py42.detectionlists.high_risk_employee.add()` now raises `Py42UserAlreadyAddedError` when the user already on the list.
 - `py42.legalhold.add_to_matter()` now raises `Py42UserAlreadyAddedError` when the user is already on the matter.

--- a/src/py42/clients/savedsearch.py
+++ b/src/py42/clients/savedsearch.py
@@ -32,17 +32,19 @@ class SavedSearchClient(BaseClient):
         uri = u"{}/{}".format(self._resource, search_id)
         return self._session.get(uri)
 
-    def get_query(self, search_id):
+    def get_query(self, search_id, pg_num=1, pg_size=10000):
         """Get the saved search in form of a query(`py42.sdk.queries.fileevents.file_event_query`).
 
         Args:
             search_id (str): Unique search Id of the saved search.
+            pg_num (int, optional): The consecutive group of results of size pg_size in the result set to return. Defaults to 1.
+            pg_size (int, optional): The maximum number of results to be returned. Defaults to 10,000.
         Returns:
             :class:`py42.sdk.queries.fileevents.file_event_query.FileEventQuery`
         """
         response = self.get_by_id(search_id)
         search = response[u"searches"][0]
-        return FileEventQuery.from_dict(search)
+        return FileEventQuery.from_dict(search, page_number=pg_num, page_size=pg_size)
 
     def execute(self, search_id, pg_num=1, pg_size=10000):
         """
@@ -55,5 +57,6 @@ class SavedSearchClient(BaseClient):
         Returns:
             :class:`py42.response.Py42Response`
         """
-        query = self.get_query(search_id)
+        query = self.get_query(search_id, pg_num=pg_num, pg_size=pg_size)
+        print(query)
         return self._file_event_client.search(query)

--- a/src/py42/clients/savedsearch.py
+++ b/src/py42/clients/savedsearch.py
@@ -32,30 +32,28 @@ class SavedSearchClient(BaseClient):
         uri = u"{}/{}".format(self._resource, search_id)
         return self._session.get(uri)
 
-    def get_query(self, search_id, pg_num=1, pg_size=10000):
+    def get_query(self, search_id, pg_num=None):
         """Get the saved search in form of a query(`py42.sdk.queries.fileevents.file_event_query`).
 
         Args:
             search_id (str): Unique search Id of the saved search.
             pg_num (int, optional): The consecutive group of results of size pg_size in the result set to return. Defaults to 1.
-            pg_size (int, optional): The maximum number of results to be returned. Defaults to 10,000.
         Returns:
             :class:`py42.sdk.queries.fileevents.file_event_query.FileEventQuery`
         """
         response = self.get_by_id(search_id)
         search = response[u"searches"][0]
-        return FileEventQuery.from_dict(search, page_number=pg_num, page_size=pg_size)
+        return FileEventQuery.from_dict(search, page_number=pg_num)
 
-    def execute(self, search_id, pg_num=1, pg_size=10000):
+    def execute(self, search_id, pg_num=None):
         """
         Execute a saved search for given search Id and return its results.
 
         Args:
             search_id (str): Unique search Id of the saved search.
             pg_num (int, optional): The consecutive group of results of size pg_size in the result set to return. Defaults to 1.
-            pg_size (int, optional): The maximum number of results to be returned. Defaults to 10,000.
         Returns:
             :class:`py42.response.Py42Response`
         """
-        query = self.get_query(search_id, pg_num=pg_num, pg_size=pg_size)
+        query = self.get_query(search_id, pg_num=pg_num)
         return self._file_event_client.search(query)

--- a/src/py42/clients/savedsearch.py
+++ b/src/py42/clients/savedsearch.py
@@ -58,5 +58,4 @@ class SavedSearchClient(BaseClient):
             :class:`py42.response.Py42Response`
         """
         query = self.get_query(search_id, pg_num=pg_num, pg_size=pg_size)
-        print(query)
         return self._file_event_client.search(query)

--- a/src/py42/sdk/queries/__init__.py
+++ b/src/py42/sdk/queries/__init__.py
@@ -5,17 +5,17 @@ class BaseQuery(object):
     def __init__(self, *args, **kwargs):
         self._filter_group_list = list(args)
         self._group_clause = kwargs.get(u"group_clause", u"AND")
-        self.page_size = 10000
+        self.page_number = kwargs.get(u"page_number", 1)
+        self.page_size = kwargs.get(u"page_size", 10000)
         self.sort_direction = u"asc"
 
         # Override
-        self.page_number = None
         self.sort_key = None
 
     @classmethod
-    def from_dict(cls, _dict, group_clause=u"AND"):
+    def from_dict(cls, _dict, group_clause=u"AND", **kwargs):
         filter_groups = [FilterGroup.from_dict(item) for item in _dict[u"groups"]]
-        return cls(*filter_groups, group_clause=group_clause)
+        return cls(*filter_groups, group_clause=group_clause, **kwargs)
 
     @classmethod
     def any(cls, *args):

--- a/src/py42/sdk/queries/__init__.py
+++ b/src/py42/sdk/queries/__init__.py
@@ -1,12 +1,13 @@
 from py42.sdk.queries.query_filter import FilterGroup
+from py42 import settings
 
 
 class BaseQuery(object):
     def __init__(self, *args, **kwargs):
         self._filter_group_list = list(args)
         self._group_clause = kwargs.get(u"group_clause", u"AND")
-        self.page_number = kwargs.get(u"page_number", 1)
-        self.page_size = kwargs.get(u"page_size", 10000)
+        self.page_number = kwargs.get(u"page_number") or 1
+        self.page_size = settings.security_events_per_page
         self.sort_direction = u"asc"
 
         # Override

--- a/src/py42/sdk/queries/fileevents/file_event_query.py
+++ b/src/py42/sdk/queries/fileevents/file_event_query.py
@@ -27,7 +27,6 @@ class FileEventQuery(BaseQuery):
     def __init__(self, *args, **kwargs):
         super(FileEventQuery, self).__init__(*args, **kwargs)
         self.sort_key = u"eventId"
-        self.page_number = 1
 
     def __str__(self):
         groups_string = u",".join(

--- a/src/py42/sdk/queries/fileevents/file_event_query.py
+++ b/src/py42/sdk/queries/fileevents/file_event_query.py
@@ -1,5 +1,6 @@
 from py42._internal.compat import str
 from py42.sdk.queries import BaseQuery
+from py42.settings import security_events_per_page
 from py42.sdk.queries.query_filter import create_filter_group
 from py42.sdk.queries.query_filter import create_query_filter
 from py42.sdk.queries.query_filter import QueryFilterStringField

--- a/src/py42/settings/__init__.py
+++ b/src/py42/settings/__init__.py
@@ -9,6 +9,7 @@ proxies = None
 verify_ssl_certs = True
 
 items_per_page = 500
+security_events_per_page = 10000
 
 _custom_user_suffix = u""
 _python_version = u"{}.{}.{}".format(

--- a/tests/clients/test_savedsearch.py
+++ b/tests/clients/test_savedsearch.py
@@ -1,5 +1,6 @@
 import json
 
+from py42 import settings
 from py42.clients.file_event import FileEventClient
 from py42.clients.savedsearch import SavedSearchClient
 
@@ -50,8 +51,31 @@ class TestSavedSearchClient(object):
         assert mock_session.post.call_count == 1
         posted_data = json.loads(mock_session.post.call_args[1]["data"])
         assert (
-            posted_data["pgSize"] == 10000
+            posted_data[u"pgSize"] == 10000
             and posted_data[u"pgNum"] == 1
+            and posted_data[u"groups"] == []
+        )
+
+    def test_execute_calls_post_with_expected_page_params(
+        self, mock_session, py42_response
+    ):
+        test_custom_page_num = 2
+        settings.security_events_per_page = 5000
+
+        py42_response.text = SAVED_SEARCH_GET_RESPONSE
+        mock_session.get.return_value = py42_response
+        file_event_client = FileEventClient(mock_session)
+        saved_search_client = SavedSearchClient(mock_session, file_event_client)
+        saved_search_client.execute(
+            u"test-id",
+            pg_num=test_custom_page_num,
+        )
+        assert mock_session.post.call_count == 1
+        posted_data = json.loads(mock_session.post.call_args[1]["data"])
+        settings.security_events_per_page = 10000
+        assert (
+            posted_data[u"pgSize"] == 5000
+            and posted_data[u"pgNum"] == 2
             and posted_data[u"groups"] == []
         )
 


### PR DESCRIPTION
### Description of Change ###

This code fixes #179, and changes the following;

- `py42.sdk.queries.BaseQuery.from_dict` now accepts keyword args, which are included in the returning class object. In this case they are used in `FileEventQuery`
- `SavedSearchClient.get_query` now accepts `pg_num` and `pg_size` keyword arguments.
- `SavedSearchClient.execute` now works with user-defined `pg_num` and `pg_size` arguments

I _believe_ the test `test_execute_calls_post_with_expected_query` covers this change. 

### Issues Resolved ###

- fixes #179 

### Testing Procedure ###

To test pages are returned, and error 400 is handled appropriately (since `SavedSearchClient.execute` doesn't return a generator), the following code can be used to test;

```
import py42.sdk 
import py42.settings as settings
from py42.exceptions import Py42BadRequestError
import urllib3

urllib3.disable_warnings()

settings.verify_ssl_certs = False

sdk = py42.sdk.from_local_account("https://console.us.code42.com", "username", "password")

pg_num = 1
while True:
    try:
        resp = sdk.securitydata.savedsearches.execute("saved-search-id", pg_num=pg_num, pg_size=1000)
    except Py42BadRequestError:
        print("Got all {} pages!".format(pg_num))
        break
    pg_num+=1
```
