### PR TITLE
Bugfix/handle locked settings

### DIFF
--- a/src/py42/clients/settings/__init__.py
+++ b/src/py42/clients/settings/__init__.py
@@ -125,3 +125,20 @@ class TSettingProperty(object):
                 instance.changes.pop(self.name)
         else:
             instance.changes[self.name] = show_change(self.init_val, val)
+
+
+def check_lock(locked_attr):
+    """Decorator for instance methods that enforces a property to be read-only if the
+    `.locked` attribute of the provided `locked_attr` on the instance returns True.
+    """
+
+    def f(method):
+        def func(_self, *args):
+            if getattr(_self, locked_attr).locked:
+                raise AttributeError("Unable to modify locked backup set.")
+            else:
+                return method(_self, *args)
+
+        return func
+
+    return f

--- a/src/py42/clients/settings/device_settings.py
+++ b/src/py42/clients/settings/device_settings.py
@@ -289,7 +289,7 @@ class BackupSet(UserDict, object):
         """Indicates whether the backup set as a whole is locked. If True, individual
         settings for this backup set (except for Destination settings), cannot be modified.
         """
-        return u"@locked" in self.data and self.data[u"@locked"] == u"true"
+        return u"@locked" in self.data and str_to_bool(self.data[u"@locked"])
 
     @property
     def included_files(self):

--- a/src/py42/clients/settings/device_settings.py
+++ b/src/py42/clients/settings/device_settings.py
@@ -29,12 +29,20 @@ class DeviceSettingsDefaults(UserDict, object):
         self.data[u"settings"] = {
             u"serviceBackupConfig": self.data[u"serviceBackupConfig"]
         }
-        self.backup_sets = [
-            BackupSet(self, self.changes, backup_set)
-            for backup_set in self.data[u"serviceBackupConfig"][u"backupConfig"][
-                u"backupSets"
-            ]
-        ]
+        bs = self.data[u"serviceBackupConfig"][u"backupConfig"][u"backupSets"]
+        self.backup_sets = self._extract_backup_sets(bs)
+
+    def _extract_backup_sets(self, backup_sets):
+        if isinstance(backup_sets, dict):  # number of sets are locked
+            backup_sets = backup_sets["backupSet"]
+            if isinstance(backup_sets, dict):  # there's only one set configured
+                return [BackupSet(self, backup_sets)]
+            if isinstance(backup_sets, list):
+                return [BackupSet(self, bs) for bs in backup_sets]
+            else:
+                raise Py42Error("Unable to extract backup sets: {}".format(backup_sets))
+        else:
+            return [BackupSet(self, bs) for bs in backup_sets]
 
     @property
     def available_destinations(self):
@@ -110,12 +118,10 @@ class DeviceSettings(DeviceSettingsDefaults):
         self.changes = {}
         self.data = device_dict
         self._destinations = device_dict[u"availableDestinations"]
-        self.backup_sets = [
-            BackupSet(self, self.changes, backup_set)
-            for backup_set in self.data[u"settings"][u"serviceBackupConfig"][
-                u"backupConfig"
-            ][u"backupSets"]
+        bs = self.data[u"settings"][u"serviceBackupConfig"][u"backupConfig"][
+            u"backupSets"
         ]
+        self.backup_sets = self._extract_backup_sets(bs)
         """List of :class:`BackupSet` objects used to manage this device's backup set configurations."""
 
     @property
@@ -168,9 +174,9 @@ class DeviceSettings(DeviceSettingsDefaults):
 class BackupSet(UserDict, object):
     """Helper class for managing device backup sets and Org device default backup sets."""
 
-    def __init__(self, settings_manager, changes_dict, backup_set_dict):
+    def __init__(self, settings_manager, backup_set_dict):
         self._manager = settings_manager
-        self._changes = changes_dict
+        self._changes = settings_manager.changes
         self.data = backup_set_dict
         includes, excludes = self._extract_file_selection_lists()
         regex_excludes = self._extract_regex_exclusions()
@@ -189,24 +195,31 @@ class BackupSet(UserDict, object):
         """Converts the file selection portion of the settings dict ("pathset") into two
         lists of just paths, `included` and `excluded`.
 
-        The "pathset" object is a different shape depending on how many paths it contains:
-            No paths:   `pathset=[{"@cleared": "true", "@os": "Linux"}]`
-            One path:   `pathset=[{"path": {"@include": "C:/"}, "@os": "Linux"}]`
-            One+ paths: `pathset=[{"path": [{"@include": "C:/Users"},{"@exclude": "C:/Users/Admin"},],"@os": "Linux"}]`
+        The "pathset" object is a different shape depending on how many paths it
+        contains and whether its locked or not:
+            No paths:           `[{"@cleared": "true", "@os": "Linux"}]`
+            No paths locked:    `{'@locked': 'true', 'paths': {'@cleared': 'true', '@os': 'Linux'}}`
+            One path:           `[{"path": {"@include": "C:/"}, "@os": "Linux"}]`
+            One path locked:    `{'@locked': 'true', 'paths': {'@os': 'Linux', 'path': {'@include': 'C:/'}}}`
+            One+ paths:         `[{"path": [{"@include": "C:/Users/"},{"@exclude": "C:/Users/Admin/"},],"@os": "Linux"}]`
+            One+ paths locked:  `{'@locked': 'true', 'paths': {'@os': 'Linux', 'path': [{'@include': 'C:/Users/'}, {'@exclude': 'C:/Users/Admin/'}]}}`
         """
-        pathset = self.data[u"backupPaths"][u"pathset"][0]
-        pathlist = pathset.get(u"path")
+        pathset = self.data[u"backupPaths"][u"pathset"]
+        if isinstance(pathset, dict):  # pathset is locked
+            path_list = pathset[u"paths"].get(u"path")
+        else:
+            path_list = pathset[0].get(u"path")
 
         # no paths selected
-        if pathlist is None:
+        if path_list is None:
             return [], []
 
         # one path selected
-        if isinstance(pathlist, dict):
-            pathlist = [pathlist]
+        if isinstance(path_list, dict):
+            path_list = [path_list]
 
-        includes = [p[u"@include"] for p in pathlist if u"@include" in p]
-        excludes = [p[u"@exclude"] for p in pathlist if u"@exclude" in p]
+        includes = [p[u"@include"] for p in path_list if u"@include" in p]
+        excludes = [p[u"@exclude"] for p in path_list if u"@exclude" in p]
         return includes, excludes
 
     def _extract_regex_exclusions(self):
@@ -214,13 +227,19 @@ class BackupSet(UserDict, object):
         into a simple list of regex patterns.
 
         The "excludeUser" object is a different shape based on the number of exclusion
-        patterns present:
-            No exclusions:   `[{"windows": [], "linux": [], "macintosh": []}]`
-            One exclusion:   `[{"windows": [], "pattern": {"@regex": ".*"}, "linux": [], "macintosh": []}]`
-            One+ exclusions: `[{"windows": [], "pattern": [{"@regex": ".*1"}, {"@regex": ".*2"}],"linux": [],"macintosh": []}]
+        patterns present and whether the setting is locked or not:
+            No exclusions:          `[{"windows": [], "linux": [], "macintosh": []}]`
+            No exclusions locked:   `{'@locked': 'true', 'patternList': {'windows': [], 'macintosh': [], 'linux': []}}`
+            One exclusion:          `[{"windows": [], "pattern": {"@regex": ".*"}, "linux": [], "macintosh": []}]`
+            One exclusion locked:   `{'@locked': 'true', 'patternList': {'pattern': {'@regex': '.*'}, 'windows': [], 'macintosh': [], 'linux': []}}`
+            One+ exclusions:        `[{"windows": [], "pattern": [{"@regex": ".*1"}, {"@regex": ".*2"}],"linux": [],"macintosh": []}]
+            One+ exclusion locked:  `{'@locked': 'true', 'patternList': {'pattern': [{'@regex': '.*1'}, {'@regex': '.*2'}], 'windows': [], 'macintosh': [], 'linux': []}}`
         """
-        exclude_user = self.data[u"backupPaths"][u"excludeUser"][0]
-        pattern_list = exclude_user.get(u"pattern")
+        exclude_user = self.data[u"backupPaths"][u"excludeUser"]
+        if isinstance(exclude_user, dict):  # exclusions are locked
+            pattern_list = exclude_user[u"patternList"].get(u"pattern")
+        else:
+            pattern_list = exclude_user[0].get(u"pattern")
         if not pattern_list:
             return []
         if isinstance(pattern_list, dict):
@@ -263,6 +282,13 @@ class BackupSet(UserDict, object):
             }
         }
         self.data[u"backupPaths"][u"excludeUser"] = user_exclude_dict
+
+    @property
+    def locked(self):
+        """Indicates whether the backup set as a whole is locked. If True, individual
+        settings for this backup set (except for Destination settings), cannot be modified.
+        """
+        return u"@locked" in self.data
 
     @property
     def included_files(self):
@@ -403,9 +429,11 @@ class BackupSet(UserDict, object):
             raise invalid_destination_error
 
     def __repr__(self):
-        return u"<BackupSet: id: {}, name: '{}'>".format(
-            self.data[u"@id"], self.data[u"name"]
-        )
+        if isinstance(self.data[u"name"], dict):  # name setting locked
+            name = self.data[u"name"][u"#text"]
+        else:
+            name = self.data[u"name"]
+        return u"<BackupSet: id: {}, name: '{}'>".format(self.data[u"@id"], name)
 
     def __str__(self):
         return str(dict(self))
@@ -414,42 +442,52 @@ class BackupSet(UserDict, object):
 class TrackedFileSelectionList(UserList, object):
     """Helper class to track modifications to file selection lists."""
 
-    def __init__(self, manager, name, _list, changes_dict):
-        self.manager = manager
+    def __init__(self, backup_set, name, _list, changes_dict):
+        self.backup_set = backup_set
         self.name = name
         self.orig = list(_list)
         self.data = _list
         self._changes = changes_dict
 
+    def check_lock(self):
+        if self.backup_set.locked:
+            raise AttributeError("Unable to modify locked backup set.")
+
     def register_change(self):
-        self.manager._build_file_selection()
-        self.manager._build_regex_exclusions()
+        self.backup_set._build_file_selection()
+        self.backup_set._build_regex_exclusions()
         if set(self.orig) != set(self.data):
             self._changes[self.name] = show_change(self.orig, self.data)
         elif self.name in self._changes:
             del self._changes[self.name]
 
     def append(self, item):
+        self.check_lock()
         self.data.append(item)
         self.register_change()
 
     def clear(self):
+        self.check_lock()
         self.data.clear()
         self.register_change()
 
     def extend(self, other):
+        self.check_lock()
         self.data.extend(other)
         self.register_change()
 
     def insert(self, i, item):
+        self.check_lock()
         self.data.insert(i, item)
         self.register_change()
 
     def pop(self, index=-1):
+        self.check_lock()
         value = self.data.pop(index)
         self.register_change()
         return value
 
     def remove(self, value):
+        self.check_lock()
         self.data.remove(value)
         self.register_change()

--- a/src/py42/clients/settings/device_settings.py
+++ b/src/py42/clients/settings/device_settings.py
@@ -288,7 +288,7 @@ class BackupSet(UserDict, object):
         """Indicates whether the backup set as a whole is locked. If True, individual
         settings for this backup set (except for Destination settings), cannot be modified.
         """
-        return u"@locked" in self.data
+        return u"@locked" in self.data and self.data[u"@locked"] == u"true"
 
     @property
     def included_files(self):

--- a/src/py42/clients/settings/device_settings.py
+++ b/src/py42/clients/settings/device_settings.py
@@ -449,9 +449,14 @@ class TrackedFileSelectionList(UserList, object):
         self.data = _list
         self._changes = changes_dict
 
-    def check_lock(self):
-        if self.backup_set.locked:
-            raise AttributeError("Unable to modify locked backup set.")
+    def check_lock(method):
+        def func(_self, *args):
+            if _self.backup_set.locked:
+                raise AttributeError("Unable to modify locked backup set.")
+            else:
+                return method(_self, *args)
+
+        return func
 
     def register_change(self):
         self.backup_set._build_file_selection()
@@ -461,33 +466,33 @@ class TrackedFileSelectionList(UserList, object):
         elif self.name in self._changes:
             del self._changes[self.name]
 
+    @check_lock
     def append(self, item):
-        self.check_lock()
         self.data.append(item)
         self.register_change()
 
+    @check_lock
     def clear(self):
-        self.check_lock()
         self.data.clear()
         self.register_change()
 
+    @check_lock
     def extend(self, other):
-        self.check_lock()
         self.data.extend(other)
         self.register_change()
 
+    @check_lock
     def insert(self, i, item):
-        self.check_lock()
         self.data.insert(i, item)
         self.register_change()
 
+    @check_lock
     def pop(self, index=-1):
-        self.check_lock()
         value = self.data.pop(index)
         self.register_change()
         return value
 
+    @check_lock
     def remove(self, value):
-        self.check_lock()
         self.data.remove(value)
         self.register_change()

--- a/src/py42/clients/settings/device_settings.py
+++ b/src/py42/clients/settings/device_settings.py
@@ -37,7 +37,7 @@ class DeviceSettingsDefaults(UserDict, object):
             backup_sets = backup_sets["backupSet"]
             if isinstance(backup_sets, dict):  # there's only one set configured
                 return [BackupSet(self, backup_sets)]
-            if isinstance(backup_sets, list):
+            elif isinstance(backup_sets, list):
                 return [BackupSet(self, bs) for bs in backup_sets]
             else:
                 raise Py42Error("Unable to extract backup sets: {}".format(backup_sets))

--- a/src/py42/clients/settings/device_settings.py
+++ b/src/py42/clients/settings/device_settings.py
@@ -1,6 +1,7 @@
 from py42._compat import str
 from py42._compat import UserDict
 from py42._compat import UserList
+from py42.clients.settings import check_lock
 from py42.clients.settings import SettingProperty
 from py42.clients.settings import show_change
 from py42.clients.settings._converters import bool_to_str
@@ -449,15 +450,6 @@ class TrackedFileSelectionList(UserList, object):
         self.data = _list
         self._changes = changes_dict
 
-    def check_lock(method):
-        def func(_self, *args):
-            if _self.backup_set.locked:
-                raise AttributeError("Unable to modify locked backup set.")
-            else:
-                return method(_self, *args)
-
-        return func
-
     def register_change(self):
         self.backup_set._build_file_selection()
         self.backup_set._build_regex_exclusions()
@@ -466,33 +458,33 @@ class TrackedFileSelectionList(UserList, object):
         elif self.name in self._changes:
             del self._changes[self.name]
 
-    @check_lock
+    @check_lock("backup_set")
     def append(self, item):
         self.data.append(item)
         self.register_change()
 
-    @check_lock
+    @check_lock("backup_set")
     def clear(self):
         self.data.clear()
         self.register_change()
 
-    @check_lock
+    @check_lock("backup_set")
     def extend(self, other):
         self.data.extend(other)
         self.register_change()
 
-    @check_lock
+    @check_lock("backup_set")
     def insert(self, i, item):
         self.data.insert(i, item)
         self.register_change()
 
-    @check_lock
+    @check_lock("backup_set")
     def pop(self, index=-1):
         value = self.data.pop(index)
         self.register_change()
         return value
 
-    @check_lock
+    @check_lock("backup_set")
     def remove(self, value):
         self.data.remove(value)
         self.register_change()


### PR DESCRIPTION
### Description of Change ###

Updates `DeviceSettings` class to handle cases where backup sets are locked.

Adds a `.locked` (read only) property on backup sets to indicate if they're locked and also prevents modifications to
non-destination settings on that set if `True`. 

### Issues Resolved ###
Fixes bug found in testing.

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change