### PR TITLE
Refactor/timestamp formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
     - `sdk.auditlogs.get_all()` arguments `begin_time` and `end_time`
     - `sdk.securitydata.get_all_plan_security_events()` arguments `min_timestamp` and `max_timestamp`
     - `sdk.securitydata.get_all_user_security_events()` arguments `min_timestamp` and `max_timestamp`
+    - `sdk.detectionlists.departing_employee.add()` argument `departure_date`
+    - `sdk.detectionlists.departing_employee.update_departure_date()` argument `departure_date`
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Changed
 
-- Timestamp argument accepts input in string type( format `YYYY-MM-DD HH:MM:SS` ), int type(epoch time) as well as a datetime instance for following:
-    - `sdk.auditlogs.get_page`
-    - `sdk.auditlogs.get_all`
-    - `sdk.securitydata.get_all_plan_security_events`
-    - `sdk.securitydata.get_all_user_security_events`
+- Timestamp argument accepts input in string type( format `yyyy-MM-dd HH:MM:SS` ), int or float type( epoch time ) as well as a datetime instance for following:
+    - `sdk.auditlogs.get_page()` arguments `begin_time` and `end_time`
+    - `sdk.auditlogs.get_all()` arguments `begin_time` and `end_time`
+    - `sdk.securitydata.get_all_plan_security_events()` arguments `min_timestamp` and `max_timestamp`
+    - `sdk.securitydata.get_all_user_security_events()` arguments `min_timestamp` and `max_timestamp`
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ## Unreleased
 
+### Changed
+
+- Timestamp argument accepts input in string type( format `YYYY-MM-DD HH:MM:SS` ), int type(epoch time) as well as a datetime instance for following:
+    - `sdk.auditlogs.get_page`
+    - `sdk.auditlogs.get_all`
+    - `sdk.securitydata.get_all_plan_security_events`
+    - `sdk.securitydata.get_all_user_security_events`
+
 ### Removed
 
 - Removed faulty `within_the_last()` method from `sdk.queries.alerts.filters.alert_filter.DateObserved`.

--- a/src/py42/clients/auditlogs.py
+++ b/src/py42/clients/auditlogs.py
@@ -26,10 +26,10 @@ class AuditLogsClient(object):
         Args:
             page_num (int, optional): The page number to get. Defaults to 1.
             page_size (int, optional): The number of items per page. Defaults to `py42.settings.items_per_page`.
-            begin_time (datetime, optional): A datetime instance representing the beginning of the
-                date range of audit logs. Defaults to None.
-            end_time (datetime, optional): A datetime instance representing the beginning of the
-                date range of audit logs. Defaults to None.
+            begin_time (int or str or datetime, optional): Timestamp in milliseconds or
+                str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
+            end_time (int or str or datetime, optional): Timestamp in milliseconds or
+                str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
             event_types (str or list, optional): A str or list of str of valid event types. Defaults to None.
             user_ids (str or list, optional): A str or list of str of Code42 userUids. Defaults to None.
             usernames (str or list, optional): A str or list of str of Code42 usernames. Defaults to None.
@@ -70,9 +70,9 @@ class AuditLogsClient(object):
 
         Args:
             begin_time (int or str or datetime, optional): Timestamp in milliseconds or
-            str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
-            end_time (int or str or datetime, optional): Timestamp in millisecondsor
-            str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
+                str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
+            end_time (int or str or datetime, optional): Timestamp in milliseconds or
+                str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
             event_types (str or list, optional): A str or list of str of valid event types. Defaults to None.
             user_ids (str or list, optional): A str or list of str of Code42 userUids. Defaults to None.
             usernames (str or list, optional): A str or list of str of Code42 usernames. Defaults to None.

--- a/src/py42/clients/auditlogs.py
+++ b/src/py42/clients/auditlogs.py
@@ -67,8 +67,10 @@ class AuditLogsClient(object):
         """Retrieve audit logs, filtered based on given arguments.
 
         Args:
-            begin_time (int, optional): Timestamp in milliseconds. Defaults to None.
-            end_time (int, optional): Timestamp in milliseconds. Defaults to None.
+            begin_time (int or str or datetime, optional): Timestamp in milliseconds or
+            str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
+            end_time (int or str or datetime, optional): Timestamp in millisecondsor
+            str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
             event_types (str or list, optional): A str or list of str of valid event types. Defaults to None.
             user_ids (str or list, optional): A str or list of str of Code42 userUids. Defaults to None.
             usernames (str or list, optional): A str or list of str of Code42 usernames. Defaults to None.

--- a/src/py42/clients/auditlogs.py
+++ b/src/py42/clients/auditlogs.py
@@ -26,9 +26,9 @@ class AuditLogsClient(object):
         Args:
             page_num (int, optional): The page number to get. Defaults to 1.
             page_size (int, optional): The number of items per page. Defaults to `py42.settings.items_per_page`.
-            begin_time (int or str or datetime, optional): Timestamp in milliseconds or
+            begin_time (int or float or str or datetime, optional): Timestamp in milliseconds or
                 str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
-            end_time (int or str or datetime, optional): Timestamp in milliseconds or
+            end_time (int or float or str or datetime, optional): Timestamp in milliseconds or
                 str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
             event_types (str or list, optional): A str or list of str of valid event types. Defaults to None.
             user_ids (str or list, optional): A str or list of str of Code42 userUids. Defaults to None.
@@ -69,9 +69,9 @@ class AuditLogsClient(object):
         """Retrieve audit logs, filtered based on given arguments.
 
         Args:
-            begin_time (int or str or datetime, optional): Timestamp in milliseconds or
+            begin_time (int or float or str or datetime, optional): Timestamp in milliseconds or
                 str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
-            end_time (int or str or datetime, optional): Timestamp in milliseconds or
+            end_time (int or float or str or datetime, optional): Timestamp in milliseconds or
                 str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
             event_types (str or list, optional): A str or list of str of valid event types. Defaults to None.
             user_ids (str or list, optional): A str or list of str of Code42 userUids. Defaults to None.

--- a/src/py42/clients/auditlogs.py
+++ b/src/py42/clients/auditlogs.py
@@ -26,8 +26,10 @@ class AuditLogsClient(object):
         Args:
             page_num (int, optional): The page number to get. Defaults to 1.
             page_size (int, optional): The number of items per page. Defaults to `py42.settings.items_per_page`.
-            begin_time (int, optional): Timestamp in milliseconds. Defaults to None.
-            end_time (int, optional): Timestamp in milliseconds. Defaults to None.
+            begin_time (datetime, optional): A datetime instance representing the beginning of the
+                date range of audit logs. Defaults to None.
+            end_time (datetime, optional): A datetime instance representing the beginning of the
+                date range of audit logs. Defaults to None.
             event_types (str or list, optional): A str or list of str of valid event types. Defaults to None.
             user_ids (str or list, optional): A str or list of str of Code42 userUids. Defaults to None.
             usernames (str or list, optional): A str or list of str of Code42 usernames. Defaults to None.

--- a/src/py42/clients/auditlogs.py
+++ b/src/py42/clients/auditlogs.py
@@ -27,9 +27,9 @@ class AuditLogsClient(object):
             page_num (int, optional): The page number to get. Defaults to 1.
             page_size (int, optional): The number of items per page. Defaults to `py42.settings.items_per_page`.
             begin_time (int or float or str or datetime, optional): Timestamp in milliseconds or
-                str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
+                str format "yyyy-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
             end_time (int or float or str or datetime, optional): Timestamp in milliseconds or
-                str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
+                str format "yyyy-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
             event_types (str or list, optional): A str or list of str of valid event types. Defaults to None.
             user_ids (str or list, optional): A str or list of str of Code42 userUids. Defaults to None.
             usernames (str or list, optional): A str or list of str of Code42 usernames. Defaults to None.
@@ -70,9 +70,9 @@ class AuditLogsClient(object):
 
         Args:
             begin_time (int or float or str or datetime, optional): Timestamp in milliseconds or
-                str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
+                str format "yyyy-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
             end_time (int or float or str or datetime, optional): Timestamp in milliseconds or
-                str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
+                str format "yyyy-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
             event_types (str or list, optional): A str or list of str of valid event types. Defaults to None.
             user_ids (str or list, optional): A str or list of str of Code42 userUids. Defaults to None.
             usernames (str or list, optional): A str or list of str of Code42 usernames. Defaults to None.

--- a/src/py42/clients/securitydata.py
+++ b/src/py42/clients/securitydata.py
@@ -103,9 +103,9 @@ class SecurityDataClient(object):
 
                     Defaults to None.
             min_timestamp (int or str or datetime, optional): Timestamp in milliseconds or
-            str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
+                str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
             max_timestamp (int or str or datetime, optional): Timestamp in milliseconds or
-            str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
+                str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
 
         Returns:
             generator: An object that iterates over :class:`py42.response.Py42Response` objects
@@ -153,9 +153,9 @@ class SecurityDataClient(object):
 
                     Defaults to None.
             min_timestamp (int or str or datetime, optional): Timestamp in milliseconds or
-            str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
+                str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
             max_timestamp (int or str or datetime, optional): Timestamp in milliseconds or
-            str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
+                str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
 
         Returns:
             generator: An object that iterates over :class:`py42.response.Py42Response` objects

--- a/src/py42/clients/securitydata.py
+++ b/src/py42/clients/securitydata.py
@@ -102,10 +102,10 @@ class SecurityDataClient(object):
                         - ``PERSONAL_CLOUD_SCAN_RESULT``
 
                     Defaults to None.
-            min_timestamp (float, optional): A POSIX timestamp representing the beginning of the
-                date range of events to get. Defaults to None.
-            max_timestamp (float, optional): A POSIX timestamp representing the end of the date
-                range of events to get. Defaults to None.
+            min_timestamp (int or str or datetime, optional): Timestamp in milliseconds or
+            str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
+            max_timestamp (int or str or datetime, optional): Timestamp in milliseconds or
+            str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
 
         Returns:
             generator: An object that iterates over :class:`py42.response.Py42Response` objects
@@ -152,10 +152,10 @@ class SecurityDataClient(object):
                         - ``PERSONAL_CLOUD_SCAN_RESULT``
 
                     Defaults to None.
-            min_timestamp (float, optional): A POSIX timestamp representing the beginning of the
-                date range of events to get. Defaults to None.
-            max_timestamp (float, optional): A POSIX timestamp representing the end of the date
-                range of events to get. Defaults to None.
+            min_timestamp (int or str or datetime, optional): Timestamp in milliseconds or
+            str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
+            max_timestamp (int or str or datetime, optional): Timestamp in milliseconds or
+            str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
 
         Returns:
             generator: An object that iterates over :class:`py42.response.Py42Response` objects

--- a/src/py42/clients/securitydata.py
+++ b/src/py42/clients/securitydata.py
@@ -102,9 +102,9 @@ class SecurityDataClient(object):
                         - ``PERSONAL_CLOUD_SCAN_RESULT``
 
                     Defaults to None.
-            min_timestamp (int or str or datetime, optional): Timestamp in milliseconds or
+            min_timestamp (int or float or str or datetime, optional): Timestamp in milliseconds or
                 str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
-            max_timestamp (int or str or datetime, optional): Timestamp in milliseconds or
+            max_timestamp (int or float or str or datetime, optional): Timestamp in milliseconds or
                 str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
 
         Returns:
@@ -152,9 +152,9 @@ class SecurityDataClient(object):
                         - ``PERSONAL_CLOUD_SCAN_RESULT``
 
                     Defaults to None.
-            min_timestamp (int or str or datetime, optional): Timestamp in milliseconds or
+            min_timestamp (int or float or str or datetime, optional): Timestamp in milliseconds or
                 str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
-            max_timestamp (int or str or datetime, optional): Timestamp in milliseconds or
+            max_timestamp (int or float or str or datetime, optional): Timestamp in milliseconds or
                 str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
 
         Returns:

--- a/src/py42/clients/securitydata.py
+++ b/src/py42/clients/securitydata.py
@@ -103,9 +103,9 @@ class SecurityDataClient(object):
 
                     Defaults to None.
             min_timestamp (int or float or str or datetime, optional): Timestamp in milliseconds or
-                str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
+                str format "yyyy-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
             max_timestamp (int or float or str or datetime, optional): Timestamp in milliseconds or
-                str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
+                str format "yyyy-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
 
         Returns:
             generator: An object that iterates over :class:`py42.response.Py42Response` objects
@@ -153,9 +153,9 @@ class SecurityDataClient(object):
 
                     Defaults to None.
             min_timestamp (int or float or str or datetime, optional): Timestamp in milliseconds or
-                str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
+                str format "yyyy-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
             max_timestamp (int or float or str or datetime, optional): Timestamp in milliseconds or
-                str format "YYYY-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
+                str format "yyyy-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
 
         Returns:
             generator: An object that iterates over :class:`py42.response.Py42Response` objects

--- a/src/py42/sdk/queries/query_filter.py
+++ b/src/py42/sdk/queries/query_filter.py
@@ -316,7 +316,7 @@ class QueryFilterTimestampField(object):
         """
         if isinstance(value, str):
             value = convert_datetime_to_epoch(datetime.strptime(value, DATE_STR_FORMAT))
-        if isinstance(value, datetime):
+        elif isinstance(value, datetime):
             value = convert_datetime_to_epoch(value)
         date_from_value = datetime.utcfromtimestamp(value)
         start_time = datetime(

--- a/src/py42/sdk/queries/query_filter.py
+++ b/src/py42/sdk/queries/query_filter.py
@@ -3,8 +3,10 @@ from datetime import datetime
 
 from py42._compat import str
 from py42._compat import string_type
+from py42.util import convert_datetime_to_epoch
 from py42.util import convert_datetime_to_timestamp_str
-from py42.util import convert_timestamp_to_str
+from py42.util import DATE_STR_FORMAT
+from py42.util import parse_timestamp_to_milliseconds_precision
 
 
 def create_query_filter(term, operator, value=None):
@@ -258,12 +260,12 @@ class QueryFilterTimestampField(object):
         provided ``value``.
 
         Args:
-            value (str or int or float): The value used to filter results.
+            value (str or int or float or datetime): The value used to filter results.
 
         Returns:
             :class:`~py42.sdk.queries.query_filter.FilterGroup`
         """
-        formatted_timestamp = convert_timestamp_to_str(value)
+        formatted_timestamp = parse_timestamp_to_milliseconds_precision(value)
         return create_on_or_after_filter_group(cls._term, formatted_timestamp)
 
     @classmethod
@@ -273,12 +275,12 @@ class QueryFilterTimestampField(object):
         provided ``value``.
 
         Args:
-            value (str or int or float): The value used to filter results.
+            value (str or int or float or datetime): The value used to filter results.
 
         Returns:
             :class:`~py42.sdk.queries.query_filter.FilterGroup`
         """
-        formatted_timestamp = convert_timestamp_to_str(value)
+        formatted_timestamp = parse_timestamp_to_milliseconds_precision(value)
         return create_on_or_before_filter_group(cls._term, formatted_timestamp)
 
     @classmethod
@@ -288,14 +290,14 @@ class QueryFilterTimestampField(object):
         the provided ``start_value`` and ``end_value``.
 
         Args:
-            start_value (str or int or float): The start value used to filter results.
-            end_value (str or int or float): The end value used to filter results.
+            start_value (str or int or float or datetime): The start value used to filter results.
+            end_value (str or int or float or datetime): The end value used to filter results.
 
         Returns:
             :class:`~py42.sdk.queries.query_filter.FilterGroup`
         """
-        formatted_start_time = convert_timestamp_to_str(start_value)
-        formatted_end_time = convert_timestamp_to_str(end_value)
+        formatted_start_time = parse_timestamp_to_milliseconds_precision(start_value)
+        formatted_end_time = parse_timestamp_to_milliseconds_precision(end_value)
         return create_in_range_filter_group(
             cls._term, formatted_start_time, formatted_end_time
         )
@@ -307,11 +309,15 @@ class QueryFilterTimestampField(object):
         calendar day as the provided ``value``.
 
         Args:
-            value (str or int or float): The value used to filter results.
+            value (str or int or float or datetime): The value used to filter results.
 
         Returns:
             :class:`~py42.sdk.queries.query_filter.FilterGroup`
         """
+        if isinstance(value, str):
+            value = convert_datetime_to_epoch(datetime.strptime(value, DATE_STR_FORMAT))
+        if isinstance(value, datetime):
+            value = convert_datetime_to_epoch(value)
         date_from_value = datetime.utcfromtimestamp(value)
         start_time = datetime(
             date_from_value.year, date_from_value.month, date_from_value.day, 0, 0, 0

--- a/src/py42/services/auditlogs.py
+++ b/src/py42/services/auditlogs.py
@@ -1,7 +1,7 @@
 from py42 import settings
 from py42.services import BaseService
 from py42.services.util import get_all_pages
-from py42.util import convert_timestamp_to_str
+from py42.util import parse_timestamp
 from py42.util import to_list
 
 _FILTER_PARAMS = (
@@ -39,9 +39,9 @@ class AuditLogsService(BaseService):
 
         date_range = {}
         if begin_time:
-            date_range["startTime"] = convert_timestamp_to_str(begin_time)
+            date_range["startTime"] = parse_timestamp(begin_time)
         if end_time:
-            date_range["endTime"] = convert_timestamp_to_str(end_time)
+            date_range["endTime"] = parse_timestamp(end_time)
 
         uri = u"/rpc/search/search-audit-log"
         page_size = page_size or settings.items_per_page

--- a/src/py42/services/auditlogs.py
+++ b/src/py42/services/auditlogs.py
@@ -1,7 +1,7 @@
 from py42 import settings
 from py42.services import BaseService
 from py42.services.util import get_all_pages
-from py42.util import parse_timestamp
+from py42.util import parse_timestamp_to_milliseconds_precision
 from py42.util import to_list
 
 _FILTER_PARAMS = (
@@ -39,9 +39,11 @@ class AuditLogsService(BaseService):
 
         date_range = {}
         if begin_time:
-            date_range["startTime"] = parse_timestamp(begin_time)
+            date_range["startTime"] = parse_timestamp_to_milliseconds_precision(
+                begin_time
+            )
         if end_time:
-            date_range["endTime"] = parse_timestamp(end_time)
+            date_range["endTime"] = parse_timestamp_to_milliseconds_precision(end_time)
 
         uri = u"/rpc/search/search-audit-log"
         page_size = page_size or settings.items_per_page

--- a/src/py42/services/detectionlists/departing_employee.py
+++ b/src/py42/services/detectionlists/departing_employee.py
@@ -8,7 +8,7 @@ from py42.services.detectionlists import handle_user_already_added_error
 from py42.services.util import get_all_pages
 from py42.util import get_attribute_keys_from_class
 
-DATE_FORMAT = "%Y-%m-%d"
+_DATE_FORMAT = "%Y-%m-%d"
 
 
 class DepartingEmployeeFilters(_DetectionListFilters):
@@ -44,13 +44,14 @@ class DepartingEmployeeService(BaseService):
         Args:
             user_id (str or int): The Code42 userUid of the user you want to add to the departing \
                 employees list.
-            departure_date (str or datetime instance, optional): Date in yyyy-MM-dd format. Date is treated as UTC. Defaults to None.
+            departure_date (str or datetime, optional): Date in yyyy-MM-dd format or instance of datetime.
+                Date is treated as UTC. Defaults to None.
 
         Returns:
             :class:`py42.response.Py42Response`
         """
         if isinstance(departure_date, datetime):
-            departure_date = departure_date.strftime(DATE_FORMAT)
+            departure_date = departure_date.strftime(_DATE_FORMAT)
         if self._user_profile_service.create_if_not_exists(user_id):
             tenant_id = self._user_context.get_current_tenant_id()
             data = {
@@ -184,7 +185,8 @@ class DepartingEmployeeService(BaseService):
 
         Args:
             user_id (str): The Code42 userUid of the user.
-            departure_date (str or datetime instance): Date in yyyy-MM-dd format. Date is treated as UTC.
+            departure_date (str or datetime): Date in yyyy-MM-dd format or instance of datetime.
+                Date is treated as UTC.
 
         Returns:
             :class:`py42.sdk.response.Py42Response`
@@ -192,7 +194,7 @@ class DepartingEmployeeService(BaseService):
 
         tenant_id = self._user_context.get_current_tenant_id()
         if isinstance(departure_date, datetime):
-            departure_date = departure_date.strftime(DATE_FORMAT)
+            departure_date = departure_date.strftime(_DATE_FORMAT)
         uri = self._uri_prefix.format(u"update")
         data = {
             u"tenantId": tenant_id,

--- a/src/py42/services/detectionlists/departing_employee.py
+++ b/src/py42/services/detectionlists/departing_employee.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from py42.exceptions import Py42BadRequestError
 from py42.services import BaseService
 from py42.services.detectionlists import _DetectionListFilters
@@ -5,6 +7,8 @@ from py42.services.detectionlists import _PAGE_SIZE
 from py42.services.detectionlists import handle_user_already_added_error
 from py42.services.util import get_all_pages
 from py42.util import get_attribute_keys_from_class
+
+DATE_FORMAT = "%Y-%m-%d"
 
 
 class DepartingEmployeeFilters(_DetectionListFilters):
@@ -40,11 +44,13 @@ class DepartingEmployeeService(BaseService):
         Args:
             user_id (str or int): The Code42 userUid of the user you want to add to the departing \
                 employees list.
-            departure_date (str, optional): Date in yyyy-MM-dd format. Date is treated as UTC. Defaults to None.
+            departure_date (str or datetime instance, optional): Date in yyyy-MM-dd format. Date is treated as UTC. Defaults to None.
 
         Returns:
             :class:`py42.response.Py42Response`
         """
+        if isinstance(departure_date, datetime):
+            departure_date = departure_date.strftime(DATE_FORMAT)
         if self._user_profile_service.create_if_not_exists(user_id):
             tenant_id = self._user_context.get_current_tenant_id()
             data = {
@@ -178,14 +184,15 @@ class DepartingEmployeeService(BaseService):
 
         Args:
             user_id (str): The Code42 userUid of the user.
-            departure_date (date): Date in yyyy-MM-dd format. Date is treated as UTC.
+            departure_date (str or datetime instance): Date in yyyy-MM-dd format. Date is treated as UTC.
 
         Returns:
             :class:`py42.sdk.response.Py42Response`
         """
 
         tenant_id = self._user_context.get_current_tenant_id()
-
+        if isinstance(departure_date, datetime):
+            departure_date = departure_date.strftime(DATE_FORMAT)
         uri = self._uri_prefix.format(u"update")
         data = {
             u"tenantId": tenant_id,

--- a/src/py42/services/storage/securitydata.py
+++ b/src/py42/services/storage/securitydata.py
@@ -1,6 +1,5 @@
-from datetime import datetime
-
 from py42.services import BaseService
+from py42.util import parse_timestamp_to_microseconds_precision
 
 
 class StorageSecurityDataService(BaseService):
@@ -20,16 +19,11 @@ class StorageSecurityDataService(BaseService):
         min_time_str = None
         max_time_str = None
 
-        def get_time_str_from_timestamp(timestamp):
-            return datetime.utcfromtimestamp(timestamp).strftime(
-                u"%Y-%m-%dT%H:%M:%S.%fZ"
-            )
-
         if min_timestamp:
-            min_time_str = get_time_str_from_timestamp(min_timestamp)
+            min_time_str = parse_timestamp_to_microseconds_precision(min_timestamp)
 
         if max_timestamp:
-            max_time_str = get_time_str_from_timestamp(max_timestamp)
+            max_time_str = parse_timestamp_to_microseconds_precision(max_timestamp)
 
         params = {
             u"userUid": user_uid,

--- a/src/py42/util.py
+++ b/src/py42/util.py
@@ -3,6 +3,8 @@ from __future__ import print_function
 import json
 from datetime import datetime
 
+MICROSECOND_FORMAT = u"%Y-%m-%dT%H:%M:%S.%fZ"
+
 
 def format_json(json_string):
     """Converts a minified JSON str to a prettified JSON str.
@@ -98,7 +100,7 @@ def to_list(value):
     return value
 
 
-def parse_timestamp(timestamp):
+def parse_timestamp_to_milliseconds_precision(timestamp):
     if isinstance(timestamp, int):
         return convert_timestamp_to_str(timestamp)
 
@@ -107,5 +109,18 @@ def parse_timestamp(timestamp):
 
     if isinstance(timestamp, str):
         return convert_datetime_to_timestamp_str(
-            datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S")
+            datetime.strptime(timestamp, u"%Y-%m-%d %H:%M:%S")
+        )
+
+
+def parse_timestamp_to_microseconds_precision(timestamp):
+    if isinstance(timestamp, int):
+        return datetime.utcfromtimestamp(timestamp).strftime(MICROSECOND_FORMAT)
+
+    if isinstance(timestamp, datetime):
+        return timestamp.strftime(MICROSECOND_FORMAT)
+
+    if isinstance(timestamp, str):
+        return datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S").strftime(
+            MICROSECOND_FORMAT
         )

--- a/src/py42/util.py
+++ b/src/py42/util.py
@@ -101,7 +101,7 @@ def to_list(value):
 
 
 def parse_timestamp_to_milliseconds_precision(timestamp):
-    if isinstance(timestamp, int):
+    if isinstance(timestamp, int) or isinstance(timestamp, float):
         return convert_timestamp_to_str(timestamp)
 
     if isinstance(timestamp, datetime):
@@ -114,7 +114,7 @@ def parse_timestamp_to_milliseconds_precision(timestamp):
 
 
 def parse_timestamp_to_microseconds_precision(timestamp):
-    if isinstance(timestamp, int):
+    if isinstance(timestamp, int) or isinstance(timestamp, float):
         return datetime.utcfromtimestamp(timestamp).strftime(MICROSECOND_FORMAT)
 
     if isinstance(timestamp, datetime):

--- a/src/py42/util.py
+++ b/src/py42/util.py
@@ -96,3 +96,16 @@ def to_list(value):
     if not isinstance(value, (list, tuple)):
         return [value]
     return value
+
+
+def parse_timestamp(timestamp):
+    if isinstance(timestamp, int):
+        return convert_timestamp_to_str(timestamp)
+
+    if isinstance(timestamp, datetime):
+        return convert_datetime_to_timestamp_str(timestamp)
+
+    if isinstance(timestamp, str):
+        return convert_datetime_to_timestamp_str(
+            datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S")
+        )

--- a/src/py42/util.py
+++ b/src/py42/util.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from py42._compat import str
 
-MICROSECOND_FORMAT = u"%Y-%m-%dT%H:%M:%S.%fZ"
+_MICROSECOND_FORMAT = u"%Y-%m-%dT%H:%M:%S.%fZ"
 DATE_STR_FORMAT = u"%Y-%m-%d %H:%M:%S"
 
 
@@ -106,11 +106,9 @@ def to_list(value):
 def parse_timestamp_to_milliseconds_precision(timestamp):
     if isinstance(timestamp, int) or isinstance(timestamp, float):
         return convert_timestamp_to_str(timestamp)
-
-    if isinstance(timestamp, datetime):
+    elif isinstance(timestamp, datetime):
         return convert_datetime_to_timestamp_str(timestamp)
-
-    if isinstance(timestamp, str):
+    elif isinstance(timestamp, str):
         return convert_datetime_to_timestamp_str(
             datetime.strptime(timestamp, DATE_STR_FORMAT)
         )
@@ -118,12 +116,10 @@ def parse_timestamp_to_milliseconds_precision(timestamp):
 
 def parse_timestamp_to_microseconds_precision(timestamp):
     if isinstance(timestamp, int) or isinstance(timestamp, float):
-        return datetime.utcfromtimestamp(timestamp).strftime(MICROSECOND_FORMAT)
-
-    if isinstance(timestamp, datetime):
-        return timestamp.strftime(MICROSECOND_FORMAT)
-
-    if isinstance(timestamp, str):
+        return datetime.utcfromtimestamp(timestamp).strftime(_MICROSECOND_FORMAT)
+    elif isinstance(timestamp, datetime):
+        return timestamp.strftime(_MICROSECOND_FORMAT)
+    elif isinstance(timestamp, str):
         return datetime.strptime(timestamp, DATE_STR_FORMAT).strftime(
-            MICROSECOND_FORMAT
+            _MICROSECOND_FORMAT
         )

--- a/src/py42/util.py
+++ b/src/py42/util.py
@@ -4,6 +4,7 @@ import json
 from datetime import datetime
 
 MICROSECOND_FORMAT = u"%Y-%m-%dT%H:%M:%S.%fZ"
+DATE_STR_FORMAT = u"%Y-%m-%d %H:%M:%S"
 
 
 def format_json(json_string):
@@ -40,7 +41,7 @@ def convert_timestamp_to_str(timestamp):
     directives %Y-%m-%dT%H:%M:%S.%f.
 
     Args:
-        timestamp (float): A POSIX timestamp.
+        timestamp (float or int): A POSIX timestamp.
 
     Returns:
         (str): A str representing the given timestamp. Example output looks like
@@ -109,7 +110,7 @@ def parse_timestamp_to_milliseconds_precision(timestamp):
 
     if isinstance(timestamp, str):
         return convert_datetime_to_timestamp_str(
-            datetime.strptime(timestamp, u"%Y-%m-%d %H:%M:%S")
+            datetime.strptime(timestamp, DATE_STR_FORMAT)
         )
 
 
@@ -121,6 +122,6 @@ def parse_timestamp_to_microseconds_precision(timestamp):
         return timestamp.strftime(MICROSECOND_FORMAT)
 
     if isinstance(timestamp, str):
-        return datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S").strftime(
+        return datetime.strptime(timestamp, DATE_STR_FORMAT).strftime(
             MICROSECOND_FORMAT
         )

--- a/src/py42/util.py
+++ b/src/py42/util.py
@@ -3,6 +3,8 @@ from __future__ import print_function
 import json
 from datetime import datetime
 
+from py42._compat import str
+
 MICROSECOND_FORMAT = u"%Y-%m-%dT%H:%M:%S.%fZ"
 DATE_STR_FORMAT = u"%Y-%m-%d %H:%M:%S"
 

--- a/tests/sdk/queries/test_query_filter.py
+++ b/tests/sdk/queries/test_query_filter.py
@@ -528,3 +528,56 @@ class TestQueryFilterTimestampField:
             ],
         }
         assert dict(QueryFilterTimestampField.on_same_day(timestamp)) == filter_query
+
+    def test_on_or_after_with_decimals(self):
+        filter_query = {
+            "filterClause": "AND",
+            "filters": [
+                {
+                    "operator": "ON_OR_AFTER",
+                    "term": "override_timestamp_field_name",
+                    "value": "2020-09-10T11:12:13.123Z",
+                }
+            ],
+        }
+
+        qf = QueryFilterTimestampField.on_or_after(1599736333.123456)
+        assert dict(qf) == filter_query
+
+    def test_on_or_before_with_decimals(self):
+        filter_query = {
+            "filterClause": "AND",
+            "filters": [
+                {
+                    "operator": "ON_OR_BEFORE",
+                    "term": "override_timestamp_field_name",
+                    "value": "2020-09-10T11:12:13.123Z",
+                }
+            ],
+        }
+        assert (
+            dict(QueryFilterTimestampField.on_or_before(1599736333.123456))
+            == filter_query
+        )
+
+    def test_in_range_with_decimals(self):
+        filter_query = {
+            "filterClause": "AND",
+            "filters": [
+                {
+                    "operator": "ON_OR_AFTER",
+                    "term": "override_timestamp_field_name",
+                    "value": "2020-09-10T11:12:13.123Z",
+                },
+                {
+                    "operator": "ON_OR_BEFORE",
+                    "term": "override_timestamp_field_name",
+                    "value": "2020-09-10T12:13:14.678Z",
+                },
+            ],
+        }
+
+        assert (
+            dict(QueryFilterTimestampField.in_range(1599736333.123456, 1599739994.6789))
+            == filter_query
+        )

--- a/tests/sdk/queries/test_query_filter.py
+++ b/tests/sdk/queries/test_query_filter.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from datetime import datetime
+
 import pytest
 
 from py42._compat import str
@@ -13,11 +15,14 @@ from py42.sdk.queries.query_filter import create_on_or_before_filter_group
 from py42.sdk.queries.query_filter import create_query_filter
 from py42.sdk.queries.query_filter import FilterGroup
 from py42.sdk.queries.query_filter import QueryFilter
+from py42.sdk.queries.query_filter import QueryFilterTimestampField
+
 
 EVENT_FILTER_FIELD_NAME = "filter_field_name"
 OPERATOR_STRING = "IS_IN"
 VALUE_STRING = "value_example"
 VALUE_UNICODE = u"您已经发现了秘密信息"
+TEST_TIMESTAMP = "2020-09-10 11:12:13"
 
 JSON_QUERY_FILTER = '{{"operator":"{0}", "term":"{1}", "value":"{2}"}}'.format(
     OPERATOR_STRING, EVENT_FILTER_FIELD_NAME, VALUE_STRING
@@ -414,3 +419,112 @@ def test_filter_group_when_changed_filter_clause_has_correct_json_representation
         '{"operator":"IS", "term":"term", "value":"value2"},'
         '{"operator":"IS", "term":"term", "value":"value3"}]}'
     )
+
+
+class TestQueryFilterTimestampField:
+    @pytest.mark.parametrize(
+        "timestamp",
+        [
+            (TEST_TIMESTAMP),
+            (1599736333.0),
+            (1599736333),
+            datetime.strptime("2020-09-10 11:12:13", "%Y-%m-%d %H:%M:%S"),
+        ],
+    )
+    def test_on_or_after(self, timestamp):
+        filter_query = {
+            "filterClause": "AND",
+            "filters": [
+                {
+                    "operator": "ON_OR_AFTER",
+                    "term": "override_timestamp_field_name",
+                    "value": "2020-09-10T11:12:13.000Z",
+                }
+            ],
+        }
+
+        qf = QueryFilterTimestampField.on_or_after(timestamp)
+        assert dict(qf) == filter_query
+
+    @pytest.mark.parametrize(
+        "timestamp",
+        [
+            (TEST_TIMESTAMP),
+            (1599736333.0),
+            (1599736333),
+            datetime.strptime("2020-09-10 11:12:13", "%Y-%m-%d %H:%M:%S"),
+        ],
+    )
+    def test_on_or_before(self, timestamp):
+        filter_query = {
+            "filterClause": "AND",
+            "filters": [
+                {
+                    "operator": "ON_OR_BEFORE",
+                    "term": "override_timestamp_field_name",
+                    "value": "2020-09-10T11:12:13.000Z",
+                }
+            ],
+        }
+        assert dict(QueryFilterTimestampField.on_or_before(timestamp)) == filter_query
+
+    @pytest.mark.parametrize(
+        "start_timestamp, end_timestamp",
+        [
+            (TEST_TIMESTAMP, "2020-09-10 12:13:14"),
+            (1599736333.0, 1599739994.0),
+            (1599736333, 1599739994),
+            (
+                datetime.strptime(TEST_TIMESTAMP, "%Y-%m-%d %H:%M:%S"),
+                datetime.strptime("2020-09-10 12:13:14", "%Y-%m-%d %H:%M:%S"),
+            ),
+        ],
+    )
+    def test_in_range(self, start_timestamp, end_timestamp):
+        filter_query = {
+            "filterClause": "AND",
+            "filters": [
+                {
+                    "operator": "ON_OR_AFTER",
+                    "term": "override_timestamp_field_name",
+                    "value": "2020-09-10T11:12:13.000Z",
+                },
+                {
+                    "operator": "ON_OR_BEFORE",
+                    "term": "override_timestamp_field_name",
+                    "value": "2020-09-10T12:13:14.000Z",
+                },
+            ],
+        }
+
+        assert (
+            dict(QueryFilterTimestampField.in_range(start_timestamp, end_timestamp))
+            == filter_query
+        )
+
+    @pytest.mark.parametrize(
+        "timestamp",
+        [
+            (TEST_TIMESTAMP),
+            (1599736333.0),
+            (1599736333),
+            datetime.strptime("2020-09-10 11:12:13", "%Y-%m-%d %H:%M:%S"),
+        ],
+    )
+    def test_on_same_day(self, timestamp):
+        filter_query = {
+            "filterClause": "AND",
+            "filters": [
+                {
+                    "operator": "ON_OR_AFTER",
+                    "term": "override_timestamp_field_name",
+                    "value": "2020-09-10T00:00:00.000Z",
+                },
+                {
+                    "operator": "ON_OR_BEFORE",
+                    "term": "override_timestamp_field_name",
+                    "value": "2020-09-10T23:59:59.000Z",
+                },
+            ],
+        }
+        assert dict(QueryFilterTimestampField.on_same_day(timestamp)) == filter_query

--- a/tests/sdk/queries/test_query_filter.py
+++ b/tests/sdk/queries/test_query_filter.py
@@ -22,7 +22,7 @@ EVENT_FILTER_FIELD_NAME = "filter_field_name"
 OPERATOR_STRING = "IS_IN"
 VALUE_STRING = "value_example"
 VALUE_UNICODE = u"您已经发现了秘密信息"
-TEST_TIMESTAMP = "2020-09-10 11:12:13"
+TEST_TIMESTAMP = u"2020-09-10 11:12:13"
 
 JSON_QUERY_FILTER = '{{"operator":"{0}", "term":"{1}", "value":"{2}"}}'.format(
     OPERATOR_STRING, EVENT_FILTER_FIELD_NAME, VALUE_STRING
@@ -428,7 +428,7 @@ class TestQueryFilterTimestampField:
             (TEST_TIMESTAMP),
             (1599736333.0),
             (1599736333),
-            datetime.strptime("2020-09-10 11:12:13", "%Y-%m-%d %H:%M:%S"),
+            datetime.strptime(TEST_TIMESTAMP, "%Y-%m-%d %H:%M:%S"),
         ],
     )
     def test_on_or_after(self, timestamp):
@@ -452,7 +452,7 @@ class TestQueryFilterTimestampField:
             (TEST_TIMESTAMP),
             (1599736333.0),
             (1599736333),
-            datetime.strptime("2020-09-10 11:12:13", "%Y-%m-%d %H:%M:%S"),
+            datetime.strptime(TEST_TIMESTAMP, "%Y-%m-%d %H:%M:%S"),
         ],
     )
     def test_on_or_before(self, timestamp):
@@ -471,12 +471,12 @@ class TestQueryFilterTimestampField:
     @pytest.mark.parametrize(
         "start_timestamp, end_timestamp",
         [
-            (TEST_TIMESTAMP, "2020-09-10 12:13:14"),
+            (TEST_TIMESTAMP, u"2020-09-10 12:13:14"),
             (1599736333.0, 1599739994.0),
             (1599736333, 1599739994),
             (
                 datetime.strptime(TEST_TIMESTAMP, "%Y-%m-%d %H:%M:%S"),
-                datetime.strptime("2020-09-10 12:13:14", "%Y-%m-%d %H:%M:%S"),
+                datetime.strptime(u"2020-09-10 12:13:14", "%Y-%m-%d %H:%M:%S"),
             ),
         ],
     )
@@ -508,7 +508,7 @@ class TestQueryFilterTimestampField:
             (TEST_TIMESTAMP),
             (1599736333.0),
             (1599736333),
-            datetime.strptime("2020-09-10 11:12:13", "%Y-%m-%d %H:%M:%S"),
+            datetime.strptime(TEST_TIMESTAMP, "%Y-%m-%d %H:%M:%S"),
         ],
     )
     def test_on_same_day(self, timestamp):

--- a/tests/services/detectionlists/test_departing_employee.py
+++ b/tests/services/detectionlists/test_departing_employee.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from datetime import datetime
+
 import pytest
 from requests import HTTPError
 from requests import Response
@@ -105,12 +107,17 @@ class TestDepartingEmployeeClient(object):
 
         return py42_response
 
+    @pytest.mark.parametrize(
+        "departing_date",
+        [("2022-12-20"), (datetime.strptime("2022-12-20", "%Y-%m-%d"))],
+    )
     def test_add_posts_expected_data_and_to_expected_url(
         self,
         mock_connection,
         user_context,
         mock_get_all_cases_response,
         mock_detection_list_user_client,
+        departing_date,
     ):
         client = DepartingEmployeeService(
             mock_connection, user_context, mock_detection_list_user_client
@@ -119,7 +126,7 @@ class TestDepartingEmployeeClient(object):
         # Return value should have been set based on the arguments passed
         # in add, here however as we are mocking it, it doesn't matter. Can be refactored
         mock_connection.post.return_value = mock_get_all_cases_response
-        client.add(_USER_ID, "2022-12-20")
+        client.add(_USER_ID, departing_date)
 
         # Have to convert the request data to a dict because
         # older versions of Python don't have deterministic order.
@@ -345,4 +352,27 @@ class TestDepartingEmployeeClient(object):
         assert (
             mock_connection.post.call_args[0][0]
             == "/svc/api/v2/departingemployee/update"
+        )
+
+    def test_update_posts_expected_data_with_datetime_instance(
+        self,
+        mock_connection,
+        user_context,
+        mock_get_all_cases_response,
+        mock_detection_list_user_client,
+    ):
+        client = DepartingEmployeeService(
+            mock_connection, user_context, mock_detection_list_user_client
+        )
+        mock_connection.post.return_value = mock_get_all_cases_response
+        dt = datetime.strptime("2020-12-20", "%Y-%m-%d")
+        client.update_departure_date(_USER_ID, dt)
+
+        # Have to convert the request data to a dict because
+        # older versions of Python don't have deterministic order.
+        posted_data = mock_connection.post.call_args[1]["json"]
+        assert (
+            posted_data["userId"] == _USER_ID
+            and posted_data["tenantId"] == TENANT_ID_FROM_RESPONSE
+            and posted_data["departureDate"] == "2020-12-20"
         )

--- a/tests/services/storage/test_securitydata.py
+++ b/tests/services/storage/test_securitydata.py
@@ -9,6 +9,9 @@ uri = u"/api/SecurityDetectionEvent"
 mock_min_ts = 1000000
 mock_max_ts = 2000000
 
+min_ts_string_format = "1970-01-12 13:46:40"
+max_ts_string_format = "1970-01-24 03:33:20"
+
 
 @pytest.fixture
 def py42session(mocker):
@@ -87,8 +90,8 @@ class TestStorageSecurityService(object):
             cursor=params[u"cursor"],
             include_files=params[u"incFiles"],
             event_types=params[u"eventType"],
-            min_timestamp=mock_min_ts,
-            max_timestamp=mock_max_ts,
+            min_timestamp=datetime.utcfromtimestamp(mock_min_ts),
+            max_timestamp=datetime.utcfromtimestamp(mock_max_ts),
         )
         py42session.get.assert_called_once_with(uri, params=params)
 
@@ -104,8 +107,8 @@ class TestStorageSecurityService(object):
             cursor=params[u"cursor"],
             include_files=params[u"incFiles"],
             event_types=params[u"eventType"],
-            min_timestamp=mock_min_ts,
-            max_timestamp=mock_max_ts,
+            min_timestamp=datetime.utcfromtimestamp(mock_min_ts),
+            max_timestamp=datetime.utcfromtimestamp(mock_max_ts),
         )
         py42session.get.assert_called_once_with(uri, params=params)
 
@@ -119,7 +122,37 @@ class TestStorageSecurityService(object):
         storage_security_service.get_security_detection_event_summary(
             user_uid=params[u"userUid"],
             cursor=params[u"cursor"],
-            min_timestamp=mock_min_ts,
-            max_timestamp=mock_max_ts,
+            min_timestamp=datetime.utcfromtimestamp(mock_min_ts),
+            max_timestamp=datetime.utcfromtimestamp(mock_max_ts),
+        )
+        py42session.get.assert_called_once_with(uri, params=params)
+
+    def test_get_security_detection_event_summary_calls_get_with_correct_date_params_for_str_format(
+        self,
+        storage_security_service,
+        py42session,
+        security_detection_event_summary_params,
+    ):
+        params = security_detection_event_summary_params
+        storage_security_service.get_security_detection_event_summary(
+            user_uid=params[u"userUid"],
+            cursor=params[u"cursor"],
+            min_timestamp=min_ts_string_format,
+            max_timestamp=max_ts_string_format,
+        )
+        py42session.get.assert_called_once_with(uri, params=params)
+
+    def test_get_security_detection_event_summary_calls_get_with_correct_date_params_for_datetime_format(
+        self,
+        storage_security_service,
+        py42session,
+        security_detection_event_summary_params,
+    ):
+        params = security_detection_event_summary_params
+        storage_security_service.get_security_detection_event_summary(
+            user_uid=params[u"userUid"],
+            cursor=params[u"cursor"],
+            min_timestamp=datetime.strptime(min_ts_string_format, "%Y-%m-%d %H:%M:%S"),
+            max_timestamp=datetime.strptime(max_ts_string_format, "%Y-%m-%d %H:%M:%S"),
         )
         py42session.get.assert_called_once_with(uri, params=params)

--- a/tests/services/storage/test_securitydata.py
+++ b/tests/services/storage/test_securitydata.py
@@ -9,8 +9,8 @@ uri = u"/api/SecurityDetectionEvent"
 mock_min_ts = 1000000
 mock_max_ts = 2000000
 
-min_ts_string_format = "1970-01-12 13:46:40"
-max_ts_string_format = "1970-01-24 03:33:20"
+min_ts_string_format = u"1970-01-12 13:46:40"
+max_ts_string_format = u"1970-01-24 03:33:20"
 
 
 @pytest.fixture

--- a/tests/services/test_auditlogs.py
+++ b/tests/services/test_auditlogs.py
@@ -1,3 +1,5 @@
+from datetime import datetime as dt
+
 from py42.services.auditlogs import AuditLogsService
 
 
@@ -26,8 +28,8 @@ class TestAuditLogService(object):
     ):
         service = AuditLogsService(mock_connection)
 
-        start_time = 1591401600  # 2020-06-06 00:00:00"
-        end_time = 1599653541  # 2020-09-09 12:12:21"
+        start_time = dt.strptime("2020-06-06 00:00:00", "%Y-%m-%d %H:%M:%S")
+        end_time = dt.strptime("2020-09-09 12:12:21", "%Y-%m-%d %H:%M:%S")
         for _ in service.get_all(begin_time=start_time, end_time=end_time):
             pass
         expected_data = {
@@ -299,6 +301,60 @@ class TestAuditLogService(object):
             "actorIpAddresses": ["127.0.0.1", "0.0.0.0"],
             "affectedUserIds": [],
             "affectedUserNames": ["test_user@name.com"],
+        }
+        mock_connection.post.assert_called_once_with(
+            "/rpc/search/search-audit-log", json=expected_data, headers=None
+        )
+
+    def test_get_all_passes_valid_date_range_param_when_begin_and_end_time_are_string_type(
+        self, mock_connection
+    ):
+        service = AuditLogsService(mock_connection)
+
+        start_time = "2020-06-06 00:00:00"
+        end_time = "2020-09-09 12:12:21"
+        for _ in service.get_all(begin_time=start_time, end_time=end_time):
+            pass
+        expected_data = {
+            "page": 0,
+            "pageSize": 500,
+            "dateRange": {
+                "startTime": "2020-06-06T00:00:00.000Z",
+                "endTime": "2020-09-09T12:12:21.000Z",
+            },
+            "eventTypes": [],
+            "actorIds": [],
+            "actorNames": [],
+            "actorIpAddresses": [],
+            "affectedUserIds": [],
+            "affectedUserNames": [],
+        }
+        mock_connection.post.assert_called_once_with(
+            "/rpc/search/search-audit-log", json=expected_data, headers=None
+        )
+
+    def test_get_all_passes_valid_date_range_param_when_begin_and_end_time_are_epoch(
+        self, mock_connection
+    ):
+        service = AuditLogsService(mock_connection)
+
+        start_time = 1591401600  # 2020-06-06 00:00:00"
+        end_time = 1599653541  # 2020-09-09 12:12:21"
+        for _ in service.get_all(begin_time=start_time, end_time=end_time):
+            pass
+        expected_data = {
+            "page": 0,
+            "pageSize": 500,
+            "dateRange": {
+                "startTime": "2020-06-06T00:00:00.000Z",
+                "endTime": "2020-09-09T12:12:21.000Z",
+            },
+            "eventTypes": [],
+            "actorIds": [],
+            "actorNames": [],
+            "actorIpAddresses": [],
+            "affectedUserIds": [],
+            "affectedUserNames": [],
         }
         mock_connection.post.assert_called_once_with(
             "/rpc/search/search-audit-log", json=expected_data, headers=None

--- a/tests/services/test_auditlogs.py
+++ b/tests/services/test_auditlogs.py
@@ -311,8 +311,8 @@ class TestAuditLogService(object):
     ):
         service = AuditLogsService(mock_connection)
 
-        start_time = "2020-06-06 00:00:00"
-        end_time = "2020-09-09 12:12:21"
+        start_time = u"2020-06-06 00:00:00"
+        end_time = u"2020-09-09 12:12:21"
         for _ in service.get_all(begin_time=start_time, end_time=end_time):
             pass
         expected_data = {

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -78,13 +78,13 @@ def test_parse_timestamp_to_microseconds_precision_returns_expected_timestamp_wi
 
 def test_parse_timestamp_to_microseconds_precision_returns_expected_timestamp_with_float_time():
     assert (
-        util.parse_timestamp_to_microseconds_precision(1599653541.00)
-        == "2020-09-09T12:12:21.000000Z"
+        util.parse_timestamp_to_microseconds_precision(1599653541.001002)
+        == "2020-09-09T12:12:21.001002Z"
     )
 
 
 def test_parse_timestamp_to_milliseconds_precision_returns_expected_timestamp_with_float_time():
     assert (
-        util.parse_timestamp_to_milliseconds_precision(1599653541.00)
-        == "2020-09-09T12:12:21.000Z"
+        util.parse_timestamp_to_milliseconds_precision(1599653541.001002)
+        == "2020-09-09T12:12:21.001Z"
     )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -33,14 +33,43 @@ def test_to_list():
     assert util.to_list("a") == ["a"]
 
 
-def test_parse_timestamp_returns_expected_timestamp_with_epoch_time():
-    assert util.parse_timestamp(1599653541) == "2020-09-09T12:12:21.000Z"
+def test_parse_timestamp_to_milliseconds_precision_returns_expected_timestamp_with_epoch_time():
+    assert (
+        util.parse_timestamp_to_milliseconds_precision(1599653541)
+        == "2020-09-09T12:12:21.000Z"
+    )
 
 
-def test_parse_timestamp_returns_expected_timestamp_with_str_format_time():
-    assert util.parse_timestamp("2020-09-09 12:12:21") == "2020-09-09T12:12:21.000Z"
+def test_parse_timestamp_to_milliseconds_precision_returns_expected_timestamp_with_str_format_time():
+    assert (
+        util.parse_timestamp_to_milliseconds_precision("2020-09-09 12:12:21")
+        == "2020-09-09T12:12:21.000Z"
+    )
 
 
-def test_parse_timestamp_returns_expected_timestamp_with_datetime_time():
+def test_parse_timestamp_to_milliseconds_precision_returns_expected_timestamp_with_datetime_time():
     dt = datetime.strptime("2020-09-09 12:12:21", "%Y-%m-%d %H:%M:%S")
-    assert util.parse_timestamp(dt) == "2020-09-09T12:12:21.000Z"
+    assert (
+        util.parse_timestamp_to_milliseconds_precision(dt) == "2020-09-09T12:12:21.000Z"
+    )
+
+
+def test_parse_timestamp_to_microseconds_precision_returns_expected_timestamp_with_epoch_time():
+    assert (
+        util.parse_timestamp_to_milliseconds_precision(1599653541)
+        == "2020-09-09T12:12:21.000Z"
+    )
+
+
+def test_parse_timestamp_to_microseconds_precision_returns_expected_timestamp_with_str_format_time():
+    assert (
+        util.parse_timestamp_to_milliseconds_precision("2020-09-09 12:12:21")
+        == "2020-09-09T12:12:21.000Z"
+    )
+
+
+def test_parse_timestamp_to_microseconds_precision_returns_expected_timestamp_with_datetime_time():
+    dt = datetime.strptime("2020-09-09 12:12:21", "%Y-%m-%d %H:%M:%S")
+    assert (
+        util.parse_timestamp_to_milliseconds_precision(dt) == "2020-09-09T12:12:21.000Z"
+    )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -31,3 +31,16 @@ def test_to_list():
     assert util.to_list("") == []
     assert util.to_list(["a"]) == ["a"]
     assert util.to_list("a") == ["a"]
+
+
+def test_parse_timestamp_returns_expected_timestamp_with_epoch_time():
+    assert util.parse_timestamp(1599653541) == "2020-09-09T12:12:21.000Z"
+
+
+def test_parse_timestamp_returns_expected_timestamp_with_str_format_time():
+    assert util.parse_timestamp("2020-09-09 12:12:21") == "2020-09-09T12:12:21.000Z"
+
+
+def test_parse_timestamp_returns_expected_timestamp_with_datetime_time():
+    dt = datetime.strptime("2020-09-09 12:12:21", "%Y-%m-%d %H:%M:%S")
+    assert util.parse_timestamp(dt) == "2020-09-09T12:12:21.000Z"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -73,3 +73,17 @@ def test_parse_timestamp_to_microseconds_precision_returns_expected_timestamp_wi
     assert (
         util.parse_timestamp_to_milliseconds_precision(dt) == "2020-09-09T12:12:21.000Z"
     )
+
+
+def test_parse_timestamp_to_microseconds_precision_returns_expected_timestamp_with_float_time():
+    assert (
+        util.parse_timestamp_to_milliseconds_precision(1599653541.00)
+        == "2020-09-09T12:12:21.000Z"
+    )
+
+
+def test_parse_timestamp_to_milliseconds_precision_returns_expected_timestamp_with_float_time():
+    assert (
+        util.parse_timestamp_to_milliseconds_precision(1599653541.00)
+        == "2020-09-09T12:12:21.000Z"
+    )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -56,29 +56,30 @@ def test_parse_timestamp_to_milliseconds_precision_returns_expected_timestamp_wi
 
 def test_parse_timestamp_to_microseconds_precision_returns_expected_timestamp_with_epoch_time():
     assert (
-        util.parse_timestamp_to_milliseconds_precision(1599653541)
-        == "2020-09-09T12:12:21.000Z"
+        util.parse_timestamp_to_microseconds_precision(1599653541)
+        == "2020-09-09T12:12:21.000000Z"
     )
 
 
 def test_parse_timestamp_to_microseconds_precision_returns_expected_timestamp_with_str_format_time():
     assert (
-        util.parse_timestamp_to_milliseconds_precision("2020-09-09 12:12:21")
-        == "2020-09-09T12:12:21.000Z"
+        util.parse_timestamp_to_microseconds_precision("2020-09-09 12:12:21")
+        == "2020-09-09T12:12:21.000000Z"
     )
 
 
 def test_parse_timestamp_to_microseconds_precision_returns_expected_timestamp_with_datetime_time():
     dt = datetime.strptime("2020-09-09 12:12:21", "%Y-%m-%d %H:%M:%S")
     assert (
-        util.parse_timestamp_to_milliseconds_precision(dt) == "2020-09-09T12:12:21.000Z"
+        util.parse_timestamp_to_microseconds_precision(dt)
+        == "2020-09-09T12:12:21.000000Z"
     )
 
 
 def test_parse_timestamp_to_microseconds_precision_returns_expected_timestamp_with_float_time():
     assert (
-        util.parse_timestamp_to_milliseconds_precision(1599653541.00)
-        == "2020-09-09T12:12:21.000Z"
+        util.parse_timestamp_to_microseconds_precision(1599653541.00)
+        == "2020-09-09T12:12:21.000000Z"
     )
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -42,7 +42,7 @@ def test_parse_timestamp_to_milliseconds_precision_returns_expected_timestamp_wi
 
 def test_parse_timestamp_to_milliseconds_precision_returns_expected_timestamp_with_str_format_time():
     assert (
-        util.parse_timestamp_to_milliseconds_precision("2020-09-09 12:12:21")
+        util.parse_timestamp_to_milliseconds_precision(u"2020-09-09 12:12:21")
         == "2020-09-09T12:12:21.000Z"
     )
 
@@ -63,7 +63,7 @@ def test_parse_timestamp_to_microseconds_precision_returns_expected_timestamp_wi
 
 def test_parse_timestamp_to_microseconds_precision_returns_expected_timestamp_with_str_format_time():
     assert (
-        util.parse_timestamp_to_microseconds_precision("2020-09-09 12:12:21")
+        util.parse_timestamp_to_microseconds_precision(u"2020-09-09 12:12:21")
         == "2020-09-09T12:12:21.000000Z"
     )
 


### PR DESCRIPTION
### Description of Change ###

Change `timestamp` fields to accept timestamp in string, integer or datetime instance.

- closes #
 #INTEG-304

### Testing Procedure ###
`sdk.auditlogs.get_page(begin_time=100000000)`

`sdk.auditlogs.get_page(begin_time="2020-02-02 10:10:10")`

```
from datetime import datetime
dt = datetime(2020, 2, 2, 10, 10, 10)
sdk.auditlogs.get_page(end_time=dt)

```
Similarly test for 
```
sdk.auditlogs.get_all
sdk.securitydata.get_all_plan_security_events
sdk.securitydata.get_all_user_security_events
```
### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
