### PR TITLE
Implementing Py42ActiveLegalHoldError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Added
 
+- Added `Py42ActiveLegalHoldError` exception when attempting to deactivate a user or device in an active legal hold.
+
 - Added additional user-adjustable setting for security events page size:
     - `py42.settings.security_events_per_page`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 ### Added
 
 - Added `Py42ActiveLegalHoldError` exception when attempting to deactivate a user or device in an active legal hold.
+    - `py42.sdk.users.deactivate()`
+    - `py42.sdk.devices.deactivate()`
 
 - Added additional user-adjustable setting for security events page size:
     - `py42.settings.security_events_per_page`

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -1,5 +1,6 @@
-from py42._compat import str
 import json
+
+from py42._compat import str
 
 
 class Py42Error(Exception):
@@ -165,7 +166,7 @@ def raise_py42_error(raised_error):
     if raised_error.response.status_code == 400:
         if json.loads(raised_error.response.text)[0]["name"] in [
             "USER_IN_ACTIVE_LEGAL_HOLD",
-            "ACTIVE_LEGAL_HOLD"
+            "ACTIVE_LEGAL_HOLD",
         ]:
             raise Py42ActiveLegalHoldError(raised_error)
         else:

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -113,8 +113,10 @@ class Py42ActiveLegalHoldError(Py42BadRequestError):
     """An exception raised when attempting to deactivate a user or device that is in an
     active legal hold."""
 
-    def __init__(self, exception):
-        msg = u"Cannot deactivate from user in an active legal hold."
+    def __init__(self, exception, resource, id):
+        msg = u"Cannot deactivate the {0} with ID {1} as the {0} is involved in a legal hold matter.".format(
+            resource, id,
+        )
         super(Py42ActiveLegalHoldError, self).__init__(exception, msg)
 
 
@@ -164,13 +166,7 @@ def raise_py42_error(raised_error):
     HTTPError's response status code.
     """
     if raised_error.response.status_code == 400:
-        if json.loads(raised_error.response.text)[0]["name"] in [
-            "USER_IN_ACTIVE_LEGAL_HOLD",
-            "ACTIVE_LEGAL_HOLD",
-        ]:
-            raise Py42ActiveLegalHoldError(raised_error)
-        else:
-            raise Py42BadRequestError(raised_error)
+        raise Py42BadRequestError(raised_error)
     elif raised_error.response.status_code == 401:
         if raised_error.response.text:
             if (

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -1,5 +1,3 @@
-import json
-
 from py42._compat import str
 
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -111,9 +111,9 @@ class Py42ActiveLegalHoldError(Py42BadRequestError):
     """An exception raised when attempting to deactivate a user or device that is in an
     active legal hold."""
 
-    def __init__(self, exception, resource, id):
+    def __init__(self, exception, resource, resource_id):
         msg = u"Cannot deactivate the {0} with ID {1} as the {0} is involved in a legal hold matter.".format(
-            resource, id,
+            resource, resource_id,
         )
         super(Py42ActiveLegalHoldError, self).__init__(exception, msg)
 

--- a/src/py42/services/__init__.py
+++ b/src/py42/services/__init__.py
@@ -1,5 +1,12 @@
 from collections import namedtuple
 
+from py42.exceptions import Py42ActiveLegalHoldError
+
+
+def handle_active_legal_hold_error(bad_request_err, resource, resource_id):
+    if u"ACTIVE_LEGAL_HOLD" in bad_request_err.response.text:
+        raise Py42ActiveLegalHoldError(bad_request_err, resource, resource_id)
+
 
 class BaseService(object):
 

--- a/src/py42/services/devices.py
+++ b/src/py42/services/devices.py
@@ -4,8 +4,9 @@ from time import time
 from py42 import settings
 from py42._compat import str
 from py42.clients.settings.device_settings import DeviceSettings
-from py42.exceptions import Py42ActiveLegalHoldError
+from py42.exceptions import Py42BadRequestError
 from py42.services import BaseService
+from py42.services import handle_active_legal_hold_error
 from py42.services.util import get_all_pages
 
 DeviceSettingsResponse = namedtuple(
@@ -203,10 +204,10 @@ class DeviceService(BaseService):
         uri = u"/api/v4/computer-deactivation/update"
         data = {u"id": device_id}
         try:
-            device_deactivate_response = self._connection.post(uri, json=data)
-        except Py42ActiveLegalHoldError as ex:
-            device_deactivate_response = ex
-        return device_deactivate_response
+            return self._connection.post(uri, json=data)
+        except Py42BadRequestError as ex:
+            handle_active_legal_hold_error(ex, "device", device_id)
+            raise
 
     def reactivate(self, device_id):
         """Activates a previously deactivated device.

--- a/src/py42/services/devices.py
+++ b/src/py42/services/devices.py
@@ -206,7 +206,7 @@ class DeviceService(BaseService):
         try:
             return self._connection.post(uri, json=data)
         except Py42BadRequestError as ex:
-            handle_active_legal_hold_error(ex, "device", device_id)
+            handle_active_legal_hold_error(ex, u"device", device_id)
             raise
 
     def reactivate(self, device_id):

--- a/src/py42/services/devices.py
+++ b/src/py42/services/devices.py
@@ -4,6 +4,7 @@ from time import time
 from py42 import settings
 from py42._compat import str
 from py42.clients.settings.device_settings import DeviceSettings
+from py42.exceptions import Py42ActiveLegalHoldError
 from py42.services import BaseService
 from py42.services.util import get_all_pages
 
@@ -201,7 +202,11 @@ class DeviceService(BaseService):
         """
         uri = u"/api/v4/computer-deactivation/update"
         data = {u"id": device_id}
-        return self._connection.post(uri, json=data)
+        try:
+            device_deactivate_response = self._connection.post(uri, json=data)
+        except Py42ActiveLegalHoldError as ex:
+            device_deactivate_response = ex
+        return device_deactivate_response
 
     def reactivate(self, device_id):
         """Activates a previously deactivated device.

--- a/src/py42/services/users.py
+++ b/src/py42/services/users.py
@@ -1,7 +1,8 @@
 from py42 import settings
 from py42._compat import quote
-from py42.exceptions import Py42ActiveLegalHoldError
+from py42.exceptions import Py42BadRequestError
 from py42.services import BaseService
+from py42.services import handle_active_legal_hold_error
 from py42.services.util import get_all_pages
 
 
@@ -236,10 +237,10 @@ class UserService(BaseService):
         uri = u"/api/UserDeactivation/{}".format(user_id)
         data = {u"blockUser": block_user}
         try:
-            user_deactivate_response = self._connection.put(uri, json=data)
-        except Py42ActiveLegalHoldError as ex:
-            user_deactivate_response = ex
-        return user_deactivate_response
+            return self._connection.put(uri, json=data)
+        except Py42BadRequestError as ex:
+            handle_active_legal_hold_error(ex, "user", user_id)
+            raise
 
     def reactivate(self, user_id, unblock_user=None):
         """Reactivates the user with the given ID.

--- a/src/py42/services/users.py
+++ b/src/py42/services/users.py
@@ -239,7 +239,7 @@ class UserService(BaseService):
         try:
             return self._connection.put(uri, json=data)
         except Py42BadRequestError as ex:
-            handle_active_legal_hold_error(ex, "user", user_id)
+            handle_active_legal_hold_error(ex, u"user", user_id)
             raise
 
     def reactivate(self, user_id, unblock_user=None):

--- a/src/py42/services/users.py
+++ b/src/py42/services/users.py
@@ -1,9 +1,8 @@
 from py42 import settings
 from py42._compat import quote
+from py42.exceptions import Py42ActiveLegalHoldError
 from py42.services import BaseService
 from py42.services.util import get_all_pages
-from py42.exceptions import Py42ActiveLegalHoldError
-
 
 
 class UserService(BaseService):

--- a/src/py42/services/users.py
+++ b/src/py42/services/users.py
@@ -2,6 +2,8 @@ from py42 import settings
 from py42._compat import quote
 from py42.services import BaseService
 from py42.services.util import get_all_pages
+from py42.exceptions import Py42ActiveLegalHoldError
+
 
 
 class UserService(BaseService):
@@ -234,7 +236,11 @@ class UserService(BaseService):
         """
         uri = u"/api/UserDeactivation/{}".format(user_id)
         data = {u"blockUser": block_user}
-        return self._connection.put(uri, json=data)
+        try:
+            user_deactivate_response = self._connection.put(uri, json=data)
+        except Py42ActiveLegalHoldError as ex:
+            user_deactivate_response = ex
+        return user_deactivate_response
 
     def reactivate(self, user_id, unblock_user=None):
         """Reactivates the user with the given ID.

--- a/tests/services/test_devices.py
+++ b/tests/services/test_devices.py
@@ -140,7 +140,7 @@ class TestDeviceService(object):
         self, mocker, mock_connection
     ):
         def side_effect(url, json):
-            if "computer-deactivation" in url:
+            if u"computer-deactivation" in url:
                 base_err = mocker.MagicMock(spec=HTTPError)
                 base_err.response = mocker.MagicMock(spec=Response)
                 base_err.response.text = u"ACTIVE_LEGAL_HOLD"
@@ -151,5 +151,5 @@ class TestDeviceService(object):
         with pytest.raises(Py42ActiveLegalHoldError) as err:
             client.deactivate(1234)
 
-        expected = "Cannot deactivate the device with ID 1234 as the device is involved in a legal hold matter."
+        expected = u"Cannot deactivate the device with ID 1234 as the device is involved in a legal hold matter."
         assert str(err.value) == expected

--- a/tests/services/test_users.py
+++ b/tests/services/test_users.py
@@ -180,7 +180,7 @@ class TestUserService(object):
         self, mocker, mock_connection
     ):
         def side_effect(url, json):
-            if "UserDeactivation" in url:
+            if u"UserDeactivation" in url:
                 base_err = mocker.MagicMock(spec=HTTPError)
                 base_err.response = mocker.MagicMock(spec=Response)
                 base_err.response.text = u"ACTIVE_LEGAL_HOLD"
@@ -191,5 +191,5 @@ class TestUserService(object):
         with pytest.raises(Py42ActiveLegalHoldError) as err:
             client.deactivate(1234)
 
-        expected = "Cannot deactivate the user with ID 1234 as the user is involved in a legal hold matter."
+        expected = u"Cannot deactivate the user with ID 1234 as the user is involved in a legal hold matter."
         assert str(err.value) == expected

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,6 +1,5 @@
 import pytest
 
-from py42.exceptions import Py42ActiveLegalHoldError
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42ForbiddenError
 from py42.exceptions import Py42HTTPError

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -14,14 +14,7 @@ from py42.exceptions import raise_py42_error
 class TestPy42Errors(object):
     def test_raise_py42_error_raises_bad_request_error(self, error_response):
         error_response.response.status_code = 400
-        error_response.response.text = '[{"name": "test"}]'
         with pytest.raises(Py42BadRequestError):
-            raise_py42_error(error_response)
-
-    def test_raise_py42_error_raises_active_legal_hold_error(self, error_response):
-        error_response.response.status_code = 400
-        error_response.response.text = '[{"name": "ACTIVE_LEGAL_HOLD"}]'
-        with pytest.raises(Py42ActiveLegalHoldError):
             raise_py42_error(error_response)
 
     def test_raise_py42_error_raises_unauthorized_error(self, error_response):
@@ -62,7 +55,6 @@ class TestPy42Errors(object):
         self, error_response, status_code
     ):
         error_response.response.status_code = status_code
-        error_response.response.text = '[{"name": "test"}]'
         try:
             raise_py42_error(error_response)
         except Exception as e:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,5 +1,6 @@
 import pytest
 
+from py42.exceptions import Py42ActiveLegalHoldError
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42ForbiddenError
 from py42.exceptions import Py42HTTPError
@@ -13,7 +14,14 @@ from py42.exceptions import raise_py42_error
 class TestPy42Errors(object):
     def test_raise_py42_error_raises_bad_request_error(self, error_response):
         error_response.response.status_code = 400
+        error_response.response.text = '[{"name": "test"}]'
         with pytest.raises(Py42BadRequestError):
+            raise_py42_error(error_response)
+
+    def test_raise_py42_error_raises_active_legal_hold_error(self, error_response):
+        error_response.response.status_code = 400
+        error_response.response.text = '[{"name": "ACTIVE_LEGAL_HOLD"}]'
+        with pytest.raises(Py42ActiveLegalHoldError):
             raise_py42_error(error_response)
 
     def test_raise_py42_error_raises_unauthorized_error(self, error_response):
@@ -54,6 +62,7 @@ class TestPy42Errors(object):
         self, error_response, status_code
     ):
         error_response.response.status_code = status_code
+        error_response.response.text = '[{"name": "test"}]'
         try:
             raise_py42_error(error_response)
         except Exception as e:


### PR DESCRIPTION
### Description of Change ###

Added `Py42ActiveLegalHoldError` exception. Raised when attempting to deactivate user/device that is in an active legal hold. 

### Issues Resolved ###

- Fixes #169 

### Testing Procedure ###

1. Use `py42.sdk.devices.deactivate()` or `py42.sdk.users.deactivate()` to deactivate a user in an active legal hold.
2. Observe message `Cannot deactivate from user in an active legal hold.`

### Notes ###

- Create draft PR as I suspect messaging for this exception will need to be updated, and I want to clarify the approach I've taken with this is acceptable before it's reviewed proper. 
