### PR TITLE
Correct and pretty up changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,18 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Changed
 
-- Timestamp argument accepts input in string type( format `yyyy-MM-dd HH:MM:SS` ), int or float type( epoch time ) as well as a datetime instance for following:
-    - `sdk.auditlogs.get_page()` arguments `begin_time` and `end_time`
-    - `sdk.auditlogs.get_all()` arguments `begin_time` and `end_time`
-    - `sdk.securitydata.get_all_plan_security_events()` arguments `min_timestamp` and `max_timestamp`
-    - `sdk.securitydata.get_all_user_security_events()` arguments `min_timestamp` and `max_timestamp`
-    - `sdk.detectionlists.departing_employee.add()` argument `departure_date`
-    - `sdk.detectionlists.departing_employee.update_departure_date()` argument `departure_date`
+- The following methods now support string timestamp formats (`yyyy-MM-dd HH:MM:SS`) as well as a `datetime` instance:
+    - `sdk.auditlogs.get_page()`, arguments `begin_time` and `end_time`.
+    - `sdk.auditlogs.get_all()`, arguments `begin_time` and `end_time`.
+    - `sdk.securitydata.get_all_plan_security_events()`, arguments `min_timestamp` and `max_timestamp`.
+    - `sdk.securitydata.get_all_user_security_events()`, arguments `min_timestamp` and `max_timestamp`.
+
+- The `departure_date` parameter for methods:
+    - `sdk.detectionlists.departing_employee.add()`
+    - `sdk.detectionlists.departing_employee.update_departure_date()`
+    now support a `datetime` instance.
+
+- Timestamp based query filters now support string timestamp format (`yyyy-MM-dd HH:MM:SS`) as well as a `datetime` instance.
 
 ### Removed
 


### PR DESCRIPTION
### Description of Change ###

The changelog falsely suggested floats were supported for departure date.
Also cleans up the latest entry.
Also, there was no mention of the query filter changes

### Issues Resolved ###
na/

### Testing Procedure ###
Look at the changelog

### PR Checklist ###
Did you remember to do the below?

- [n/a] Add unit tests to verify this change
- [ x] Add an entry to CHANGELOG.md describing this change
- [n/a] Add docstrings for any new public parameters / methods / classes
