### PR TITLE
Adding duplicate user error type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 - Removed faulty `within_the_last()` method from `sdk.queries.alerts.filters.alert_filter.DateObserved`.
 
 ### Added
+- Added new exception `Py42UserAlreadyExistsError` to throw if `add_user()` throws `500` and body contains
+`USER_DUPLICATE`
 
 - Added additional user-adjustable setting for security events page size:
     - `py42.settings.security_events_per_page`

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -60,7 +60,8 @@ class Py42SecurityPlanConnectionError(Py42HTTPError):
     """An exception raised when the user is not authorized to access the requested resource."""
 
     def __init__(self, exception, error_message):
-        super(Py42SecurityPlanConnectionError, self).__init__(exception, error_message)
+        super(Py42SecurityPlanConnectionError, self).__init__(
+            exception, error_message)
 
 
 class Py42StorageSessionInitializationError(Py42HTTPError):
@@ -82,9 +83,11 @@ class Py42SessionInitializationError(Py42Error):
     def __init__(self, exception):
         error_message = (
             u"An error occurred while requesting "
-            u"server environment information, caused by {}".format(str(exception))
+            u"server environment information, caused by {}".format(
+                str(exception))
         )
-        super(Py42SessionInitializationError, self).__init__(exception, error_message)
+        super(Py42SessionInitializationError, self).__init__(
+            exception, error_message)
 
 
 class Py42BadRequestError(Py42HTTPError):
@@ -112,7 +115,8 @@ class Py42UserAlreadyAddedError(Py42BadRequestError):
     Departing Employee list."""
 
     def __init__(self, exception, user_id, list_name):
-        msg = u"User with ID {} is already on the {}.".format(user_id, list_name)
+        msg = u"User with ID {} is already on the {}.".format(
+            user_id, list_name)
         super(Py42UserAlreadyAddedError, self).__init__(exception, msg)
 
 
@@ -148,6 +152,14 @@ class Py42MFARequiredError(Py42UnauthorizedError):
         super(Py42MFARequiredError, self).__init__(exception, message)
 
 
+class Py42UserAlreadyExistsError(Py42InternalServerError):
+    """An exception raised when a user already exists"""
+
+    def __init__(self, exception, message=None):
+        message = message or u"User already exists."
+        super(Py42UserAlreadyExistsError, self).__init__(exception, message)
+
+
 def raise_py42_error(raised_error):
     """Raises the appropriate :class:`py42.exceptions.Py42HttpError` based on the given
     HTTPError's response status code.
@@ -157,8 +169,8 @@ def raise_py42_error(raised_error):
     elif raised_error.response.status_code == 401:
         if raised_error.response.text:
             if (
-                "TOTP_AUTH_CONFIGURATION_REQUIRED_FOR_USER"
-                or "TIME_BASED_ONE_TIME_PASSWORD_REQUIRED" in raised_error.response.text
+                "TOTP_AUTH_CONFIGURATION_REQUIRED_FOR_USER" or
+                "TIME_BASED_ONE_TIME_PASSWORD_REQUIRED" in raised_error.response.text
             ):
                 raise Py42MFARequiredError(raised_error)
         raise Py42UnauthorizedError(raised_error)
@@ -166,6 +178,8 @@ def raise_py42_error(raised_error):
         raise Py42ForbiddenError(raised_error)
     elif raised_error.response.status_code == 404:
         raise Py42NotFoundError(raised_error)
+    elif raised_error.response.status_code == 500 and raised_error.response.text == "USER_DUPLICATE":
+        raise Py42UserAlreadyExistsError(raised_error)
     elif 500 <= raised_error.response.status_code < 600:
         raise Py42InternalServerError(raised_error)
     else:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -7,6 +7,7 @@ from py42.exceptions import Py42InternalServerError
 from py42.exceptions import Py42MFARequiredError
 from py42.exceptions import Py42NotFoundError
 from py42.exceptions import Py42UnauthorizedError
+from py42.exceptions import Py42UserAlreadyExistsError
 from py42.exceptions import raise_py42_error
 
 
@@ -42,6 +43,12 @@ class TestPy42Errors(object):
     def test_raise_py42_error_raises_internal_server_error(self, error_response):
         error_response.response.status_code = 500
         with pytest.raises(Py42InternalServerError):
+            raise_py42_error(error_response)
+
+    def test_raise_py42_error_raises_duplicate_user_error(self, error_response):
+        error_response.response.status_code = 500
+        error_response.response.text = "USER_DUPLICATE"
+        with pytest.raises(Py42UserAlreadyExistsError):
             raise_py42_error(error_response)
 
     def test_raise_py42_error_raises_py42_http_error(self, error_response):


### PR DESCRIPTION
### Description of Change ###

Adding `Py42UserAlreadyExistsError` exception method and test.

### Issues Resolved ###

- closes #214

### Testing Procedure ###
Trying to add a user with the `sdk.users.create_user()` API. If the user already exists, this exception should be raised.

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
