### PR TITLE
Update documentation for sdk.devices.deactivate

### DIFF
--- a/src/py42/services/devices.py
+++ b/src/py42/services/devices.py
@@ -191,7 +191,7 @@ class DeviceService(BaseService):
 
     def deactivate(self, device_id):
         """Deactivates a device, causing backups to stop and archives to go to cold storage.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#ComputerDeactivation>`__
+        `REST Documentation <https://console.us.code42.com/swagger/index.html?urls.primaryName=v4#/computer-deactivation/ComputerDeactivation_Update>`__
 
         Args:
             device_id (int): The identification number of the device.


### PR DESCRIPTION
Update the REST documentation link for the deactivate method to point to the API actually used by that method.

### Description of Change ###

The sdk.devices.deactivate documentation links to https://console.us.code42.com/apidocviewer/#ComputerDeactivation, but the method actually calls a newer endpoint. This change updates the URL to the correct REST documentation.

### Issues Resolved ###

n/a

### Testing Procedure ###

n/a

### PR Checklist ###
Did you remember to do the below?

- [] Add unit tests to verify this change - n/a, documentation only
- [] Add an entry to CHANGELOG.md describing this change - n/a, documentation only
- [x] Add docstrings for any new public parameters / methods / classes
