### PR TITLE
Fix/cloud alias limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - Bug where an empty destination list in a device's backup set broke creation of DeviceSettings objects for that device.
 
+### Added
+
+- Added new exception `Py42CloudAliasLimitExceeded` to throw if `add_cloud_alias` throws `400` and body contains reason
+`Cloud usernames must be less than or equal to 2`.
+
 ## 1.9.0 - 2020-10-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Added
 
-- Added new exception `Py42CloudAliasLimitExceeded` to throw if `add_cloud_alias` throws `400` and body contains reason
-`Cloud usernames must be less than or equal to 2`.
+- Added new exception `Py42CloudAliasLimitExceededError` to throw if `add_cloud_alias()` throws `400` and body contains
+reason `Cloud usernames must be less than or equal to`.
 
 ## 1.9.0 - 2020-10-02
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -168,7 +168,8 @@ class Py42UserAlreadyExistsError(Py42InternalServerError):
 
 
 class Py42CloudAliasLimitExceeded(Py42BadRequestError):
-    """An exception raised when a user already has 2 cloud aliases set."""
+    """An exception raised when max limit exceeds number of cloud aliases against
+     a user account."""
 
     def __init__(self, exception, message=None):
         message = message or u"Cloud alias limit exceeded."

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -167,9 +167,9 @@ class Py42UserAlreadyExistsError(Py42InternalServerError):
         super(Py42UserAlreadyExistsError, self).__init__(exception, message)
 
 
-class Py42CloudAliasLimitExceeded(Py42BadRequestError):
-    """An exception raised when number of cloud aliases exceeds against max allowed
-    limit."""
+class Py42CloudAliasLimitExceededError(Py42BadRequestError):
+    """An Exception raised when trying to add a cloud alias to a user when that user
+    already has the max amount of supported cloud aliases."""
 
     def __init__(self, exception, message=None):
         message = message or u"Cloud alias limit exceeded."

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -167,6 +167,14 @@ class Py42UserAlreadyExistsError(Py42InternalServerError):
         super(Py42UserAlreadyExistsError, self).__init__(exception, message)
 
 
+class Py42CloudAliasLimitExceeded(Py42BadRequestError):
+    """An exception raised when a user already has 2 cloud aliases set."""
+
+    def __init__(self, exception, message=None):
+        message = message or u"Cloud alias limit exceeded."
+        super(Py42BadRequestError, self).__init__(exception, message)
+
+
 def raise_py42_error(raised_error):
     """Raises the appropriate :class:`py42.exceptions.Py42HttpError` based on the given
     HTTPError's response status code.

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -168,8 +168,8 @@ class Py42UserAlreadyExistsError(Py42InternalServerError):
 
 
 class Py42CloudAliasLimitExceeded(Py42BadRequestError):
-    """An exception raised when max limit exceeds number of cloud aliases against
-     a user account."""
+    """An exception raised when number of cloud aliases exceeds against max allowed
+    limit."""
 
     def __init__(self, exception, message=None):
         message = message or u"Cloud alias limit exceeded."

--- a/src/py42/services/detectionlists/user_profile.py
+++ b/src/py42/services/detectionlists/user_profile.py
@@ -1,5 +1,5 @@
 from py42.exceptions import Py42BadRequestError
-from py42.exceptions import Py42CloudAliasLimitExceeded
+from py42.exceptions import Py42CloudAliasLimitExceededError
 from py42.exceptions import Py42NotFoundError
 from py42.services import BaseService
 
@@ -174,7 +174,7 @@ class DetectionListUserService(BaseService):
             return self._connection.post(uri, json=data)
         except Py42BadRequestError as err:
             if "Cloud usernames must be less than or equal to" in err.response.text:
-                raise Py42CloudAliasLimitExceeded(err)
+                raise Py42CloudAliasLimitExceededError(err)
             raise err
 
     def remove_cloud_alias(self, user_id, alias):

--- a/src/py42/services/detectionlists/user_profile.py
+++ b/src/py42/services/detectionlists/user_profile.py
@@ -173,9 +173,7 @@ class DetectionListUserService(BaseService):
         try:
             return self._connection.post(uri, json=data)
         except Py42BadRequestError as err:
-            if str(err.response.text).__contains__(
-                "Cloud usernames must be less than or equal to 2"
-            ):
+            if "Cloud usernames must be less than or equal to 2" in err.response.text:
                 raise Py42CloudAliasLimitExceeded(err)
             raise err
 

--- a/src/py42/services/detectionlists/user_profile.py
+++ b/src/py42/services/detectionlists/user_profile.py
@@ -1,4 +1,5 @@
 from py42.exceptions import Py42BadRequestError
+from py42.exceptions import Py42CloudAliasLimitExceeded
 from py42.exceptions import Py42NotFoundError
 from py42.services import BaseService
 
@@ -169,7 +170,14 @@ class DetectionListUserService(BaseService):
             u"cloudUsernames": [alias],
         }
         uri = self._make_uri(u"/addcloudusernames")
-        return self._connection.post(uri, json=data)
+        try:
+            return self._connection.post(uri, json=data)
+        except Py42BadRequestError as err:
+            if str(err.response.text).__contains__(
+                "Cloud usernames must be less than or equal to 2"
+            ):
+                raise Py42CloudAliasLimitExceeded(err)
+            raise err
 
     def remove_cloud_alias(self, user_id, alias):
         """Remove one or more cloud alias.

--- a/src/py42/services/detectionlists/user_profile.py
+++ b/src/py42/services/detectionlists/user_profile.py
@@ -173,7 +173,7 @@ class DetectionListUserService(BaseService):
         try:
             return self._connection.post(uri, json=data)
         except Py42BadRequestError as err:
-            if "Cloud usernames must be less than or equal to 2" in err.response.text:
+            if "Cloud usernames must be less than or equal to" in err.response.text:
                 raise Py42CloudAliasLimitExceeded(err)
             raise err
 

--- a/tests/services/detectionlists/test_user_profile.py
+++ b/tests/services/detectionlists/test_user_profile.py
@@ -3,8 +3,19 @@ from requests import Response
 from requests.exceptions import HTTPError
 
 from py42.exceptions import Py42BadRequestError
+from py42.exceptions import Py42CloudAliasLimitExceeded
 from py42.services.detectionlists.user_profile import DetectionListUserService
 from py42.services.users import UserService
+
+
+CLOUD_ALIAS_LIMIT_EXCEEDED_ERROR_MESSAGE = """{
+"pop-bulletin": {
+"type$": "com.code42.detectionlistmanagement.DetectionListMessages.ValidationError",
+"text$": "Command or Query is invalid: Cloud usernames must be less than or equal to 2",
+"details": [],
+"reason": "Cloud usernames must be less than or equal to 2"
+}
+}"""
 
 
 class TestDetectionListUserClient(object):
@@ -31,6 +42,19 @@ class TestDetectionListUserClient(object):
         user_client = UserService(mock_connection)
         response = mocker.MagicMock(spec=Response)
         response.status_code = 400
+        exception = mocker.MagicMock(spec=HTTPError)
+        exception.response = response
+        mock_connection.post.side_effect = Py42BadRequestError(exception)
+        return user_client
+
+    @pytest.fixture
+    def mock_user_client_error_on_adding_cloud_aliases(
+        self, mocker, mock_connection, user_context, py42_response
+    ):
+        user_client = UserService(mock_connection)
+        response = mocker.MagicMock(spec=Response)
+        response.status_code = 400
+        response.text = CLOUD_ALIAS_LIMIT_EXCEEDED_ERROR_MESSAGE
         exception = mocker.MagicMock(spec=HTTPError)
         exception.response = response
         mock_connection.post.side_effect = Py42BadRequestError(exception)
@@ -235,3 +259,17 @@ class TestDetectionListUserClient(object):
             posted_data["tenantId"] == user_context.get_current_tenant_id()
             and posted_data["userId"] == "942897397520289999"
         )
+
+    def test_add_cloud_alias_limit_raises_custom_error_on_limit(
+        self,
+        mock_connection,
+        user_context,
+        mock_user_client_error_on_adding_cloud_aliases,
+    ):
+        detection_list_user_client = DetectionListUserService(
+            mock_connection,
+            user_context,
+            mock_user_client_error_on_adding_cloud_aliases,
+        )
+        with pytest.raises(Py42CloudAliasLimitExceeded):
+            detection_list_user_client.add_cloud_alias("942897397520289999", "Test")

--- a/tests/services/detectionlists/test_user_profile.py
+++ b/tests/services/detectionlists/test_user_profile.py
@@ -271,5 +271,6 @@ class TestDetectionListUserClient(object):
             user_context,
             mock_user_client_error_on_adding_cloud_aliases,
         )
-        with pytest.raises(Py42CloudAliasLimitExceeded):
+        with pytest.raises(Py42CloudAliasLimitExceeded) as err:
             detection_list_user_client.add_cloud_alias("942897397520289999", "Test")
+        assert "Cloud alias limit exceeded." in str(err.value)

--- a/tests/services/detectionlists/test_user_profile.py
+++ b/tests/services/detectionlists/test_user_profile.py
@@ -3,7 +3,7 @@ from requests import Response
 from requests.exceptions import HTTPError
 
 from py42.exceptions import Py42BadRequestError
-from py42.exceptions import Py42CloudAliasLimitExceeded
+from py42.exceptions import Py42CloudAliasLimitExceededError
 from py42.services.detectionlists.user_profile import DetectionListUserService
 from py42.services.users import UserService
 
@@ -271,6 +271,6 @@ class TestDetectionListUserClient(object):
             user_context,
             mock_user_client_error_on_adding_cloud_aliases,
         )
-        with pytest.raises(Py42CloudAliasLimitExceeded) as err:
+        with pytest.raises(Py42CloudAliasLimitExceededError) as err:
             detection_list_user_client.add_cloud_alias("942897397520289999", "Test")
         assert "Cloud alias limit exceeded." in str(err.value)


### PR DESCRIPTION
### Description of Change ###
Added custom exception, when adding cloud alias fails with alias limit exceeded error.

### Issues Resolved ###
- closes #1190

### Testing Procedure ###
```
try:
   sdk.detectionlists.add_cloud_alias()
except Py42CloudAliasLimitExceeded as err:
```

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
