### PR TITLE
Update docs to fix bug

### DIFF
--- a/docs/userguides/searches.md
+++ b/docs/userguides/searches.md
@@ -102,7 +102,7 @@ To execute the search, use the `alerts.AlertClient.search()` method:
 
 ```python
 # Prints the actor property from each search result
-response = sdk.securitydata.alerts.search(query)
+response = sdk.alerts.search(query)
 alerts = response["alerts"]
 for alert in alerts:
     print(alert["actor"])


### PR DESCRIPTION
### Description of Change ###

securitydata doesn't have an alerts attribute, likely the alerts attribute that was mean to be used here belongs to sdk.

I confirmed the following works for me nicely

```
filters = [AlertState.eq(AlertState.OPEN), Severity.is_in([Severity.HIGH, Severity.MEDIUM])]
query = AlertQuery(*filters)
# Prints the actor property from each search result
response = sdk.alerts.search(query)
alerts = response["alerts"]
for alert in alerts:
    print(alert["actor"])
```

### Issues Resolved ###
N/A

- closes #

### Testing Procedure ###
Documentation change, code snippet suggested has been tested

### PR Checklist ###
Did you remember to do the below?

- [X] Add unit tests to verify this change
- [] Add an entry to CHANGELOG.md describing this change 
- [X] Add docstrings for any new public parameters / methods / classes

Not sure if CHANGELOG modification is needed for documentation updates.