### PR TITLE
Add Py42TooManyRequestsError exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 - Added new exception `Py42CloudAliasLimitExceededError` to throw if `add_cloud_alias()` throws `400` and body contains
 reason `Cloud usernames must be less than or equal to`.
 
+- Added new exception `Py42TooManyRequestsError` to raise errors with 429 HTTP status code.
+
 ## 1.9.0 - 2020-10-02
 
 ### Changed

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -107,6 +107,10 @@ class Py42InternalServerError(Py42HTTPError):
     """A wrapper to represent an HTTP 500 error."""
 
 
+class Py42TooManyRequestsError(Py42HTTPError):
+    """A wrapper to represent an HTTP 429 error."""
+
+
 class Py42ActiveLegalHoldError(Py42BadRequestError):
     """An exception raised when attempting to deactivate a user or device that is in an
     active legal hold."""
@@ -194,6 +198,8 @@ def raise_py42_error(raised_error):
         raise Py42ForbiddenError(raised_error)
     elif raised_error.response.status_code == 404:
         raise Py42NotFoundError(raised_error)
+    elif raised_error.response.status_code == 429:
+        raise Py42TooManyRequestsError(raised_error)
     elif 500 <= raised_error.response.status_code < 600:
         raise Py42InternalServerError(raised_error)
     else:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -6,6 +6,7 @@ from py42.exceptions import Py42HTTPError
 from py42.exceptions import Py42InternalServerError
 from py42.exceptions import Py42MFARequiredError
 from py42.exceptions import Py42NotFoundError
+from py42.exceptions import Py42TooManyRequestsError
 from py42.exceptions import Py42UnauthorizedError
 from py42.exceptions import raise_py42_error
 
@@ -49,7 +50,12 @@ class TestPy42Errors(object):
         with pytest.raises(Py42HTTPError):
             raise_py42_error(error_response)
 
-    @pytest.mark.parametrize("status_code", [400, 401, 403, 404, 500, 600])
+    def test_raise_py42_error_raises_too_many_requests_error(self, error_response):
+        error_response.response.status_code = 429
+        with pytest.raises(Py42TooManyRequestsError):
+            raise_py42_error(error_response)
+
+    @pytest.mark.parametrize("status_code", [400, 401, 403, 404, 429, 500, 600])
     def test_raise_py42_http_error_has_correct_response_type(
         self, error_response, status_code
     ):


### PR DESCRIPTION
### Description of Change ###

Added new exception `Py42TooManyRequestsError` to handle HTTP 429 errors.

### Issues Resolved ###
- closes #1285

### Testing Procedure ###
```
from py42.sdk.queries.fileevents.file_event_query import FileEventQuery
from py42.sdk.queries.fileevents.filters import *
query = FileEventQuery.all(MD5.eq("e804d1eb229298b04522c5504b8131f0"))

for _ in range(1,200):
      file_events = sdk.securitydata.search_file_events(query)
```
Did not observe the error,  may be because the above call is a blocking call, need to generate above calls asynchronously 

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
