### PR TITLE
fix MFAError response check logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 ### Fixed
 
 - Bug where an empty destination list in a device's backup set broke creation of DeviceSettings objects for that device.
+- Bug where all 401 Unauthorized error responses were being raised as Py42MFARequired exceptions.
 
 ### Added
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -1,3 +1,5 @@
+import re
+
 from py42._compat import str
 
 
@@ -194,12 +196,11 @@ def raise_py42_error(raised_error):
     if raised_error.response.status_code == 400:
         raise Py42BadRequestError(raised_error)
     elif raised_error.response.status_code == 401:
-        if raised_error.response.text:
-            if (
-                "TOTP_AUTH_CONFIGURATION_REQUIRED_FOR_USER"
-                or "TIME_BASED_ONE_TIME_PASSWORD_REQUIRED" in raised_error.response.text
-            ):
-                raise Py42MFARequiredError(raised_error)
+        if raised_error.response.text and re.search(
+            "(TOTP_AUTH_CONFIGURATION_REQUIRED_FOR_USER|TIME_BASED_ONE_TIME_PASSWORD_REQUIRED)",
+            raised_error.response.text,
+        ):
+            raise Py42MFARequiredError(raised_error)
         raise Py42UnauthorizedError(raised_error)
     elif raised_error.response.status_code == 403:
         raise Py42ForbiddenError(raised_error)

--- a/tests/clients/settings/test_org_settings.py
+++ b/tests/clients/settings/test_org_settings.py
@@ -588,24 +588,25 @@ class TestOrgDeviceSettingsDefaultsBackupSets(object):
         self, org_settings_dict
     ):
         org_settings = OrgSettings(org_settings_dict, TEST_T_SETTINGS_DICT)
-        org_settings.device_defaults.backup_sets[0].add_destination(632540230984925185)
+        org_settings.device_defaults.backup_sets[1].add_destination(632540230984925185)
         expected_destinations_property = {
             "43": "PROe Cloud, US <LOCKED>",
             "673679195225718785": "PROe Cloud, AMS",
+            "632540230984925185": "PROe Cloud, US - West",
         }
         expected_destinations_list = [
             {"@id": "43", "@locked": "true"},
-            {"@id": "632540230984925185"},
             {"@id": "673679195225718785"},
+            {"@id": "632540230984925185"},
         ]
         assert (
             org_settings.device_defaults.backup_sets[1].destinations
             == expected_destinations_property
         )
-        for destination in expected_destinations_list:
-            destination in org_settings.device_defaults["settings"][
-                "serviceBackupConfig"
-            ]["backupConfig"]["backupSets"]["backupSet"][1]["destinations"]
+        assert (
+            org_settings.device_defaults.backup_sets[1]["destinations"]
+            == expected_destinations_list
+        )
 
     def test_backup_set_add_destination_when_destination_not_available_raises(
         self, org_settings_dict

--- a/tests/services/storage/test_service_factory.py
+++ b/tests/services/storage/test_service_factory.py
@@ -50,8 +50,8 @@ class TestStorageServiceFactory(object):
         factory = StorageServiceFactory(
             mock_successful_connection, mock_device_service, mock_connection_manager
         )
-        service = factory.create_archive_service("testguid")
-        mock_device_service.get_by_guid.call_count == 0
+        service = factory.create_archive_service("testguid", destination_guid=42)
+        assert mock_device_service.get_by_guid.call_count == 0
         assert type(service) == StorageArchiveService
 
     def test_create_archive_service_when_device_has_no_destination_raises_exception(

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,4 +1,5 @@
 import pytest
+from tests.conftest import REQUEST_EXCEPTION_MESSAGE
 
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42ForbiddenError
@@ -19,7 +20,7 @@ class TestPy42Errors(object):
 
     def test_raise_py42_error_raises_unauthorized_error(self, error_response):
         error_response.response.status_code = 401
-        with pytest.raises(Py42UnauthorizedError):
+        with pytest.raises(Py42UnauthorizedError, match=REQUEST_EXCEPTION_MESSAGE):
             raise_py42_error(error_response)
 
     def test_raise_py42_error_raises_MFA_required_error(self, error_response):
@@ -27,6 +28,10 @@ class TestPy42Errors(object):
         error_response.response.text = (
             '{"error":[{"primaryErrorKey":"TIME_BASED_ONE_TIME_PASSWORD_REQUIRED"}]}'
         )
+        with pytest.raises(Py42MFARequiredError):
+            raise_py42_error(error_response)
+
+        error_response.response.text = '{"error":[{"primaryErrorKey":"TOTP_AUTH_CONFIGURATION_REQUIRED_FOR_USER"}]}'
         with pytest.raises(Py42MFARequiredError):
             raise_py42_error(error_response)
 


### PR DESCRIPTION
The logic for Py42MFARequiredError has a bad "or" clause that always returns true, so any 401 error raises a MFARequiredError: 

```
elif raised_error.response.status_code == 401:
    if raised_error.response.text:
        if (
            "TOTP_AUTH_CONFIGURATION_REQUIRED_FOR_USER"
            or "TIME_BASED_ONE_TIME_PASSWORD_REQUIRED" in raised_error.response.text
        ):
            raise Py42MFARequiredError(raised_error) 
```

This change fixes that. 