### PR TITLE
Bugfix: storage login tokens > auth tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - Bug where an empty destination list in a device's backup set broke creation of DeviceSettings objects for that device.
 - Bug where all 401 Unauthorized error responses were being raised as Py42MFARequired exceptions.
+- Bug where requests to storage nodes were only using single-use tokens for authentication, causing many extraneous requests.
 
 ### Added
 

--- a/src/py42/services/storage/_service_factory.py
+++ b/src/py42/services/storage/_service_factory.py
@@ -71,6 +71,5 @@ class ConnectionManager(object):
             message = u"Failed to create or retrieve connection, caused by: {}".format(
                 str(ex)
             )
-            print(ex)
             raise Py42StorageSessionInitializationError(ex, message)
         return connection

--- a/src/py42/services/storage/_service_factory.py
+++ b/src/py42/services/storage/_service_factory.py
@@ -3,8 +3,8 @@ from threading import Lock
 from py42._compat import str
 from py42.exceptions import Py42StorageSessionInitializationError
 from py42.services._connection import Connection
-from py42.services.storage._auth import FileArchiveTmpAuth
-from py42.services.storage._auth import SecurityArchiveTmpAuth
+from py42.services.storage._auth import FileArchiveAuth
+from py42.services.storage._auth import SecurityArchiveAuth
 from py42.services.storage.archive import StorageArchiveService
 from py42.services.storage.preservationdata import StoragePreservationDataService
 from py42.services.storage.securitydata import StorageSecurityDataService
@@ -20,14 +20,12 @@ class StorageServiceFactory(object):
         if destination_guid is None:
             destination_guid = self._auto_select_destination_guid(device_guid)
 
-        auth = FileArchiveTmpAuth(
-            self._connection, u"my", device_guid, destination_guid
-        )
+        auth = FileArchiveAuth(self._connection, u"my", device_guid, destination_guid)
         connection = self._connection_manager.get_storage_connection(auth)
         return StorageArchiveService(connection)
 
     def create_security_data_service(self, plan_uid, destination_guid):
-        auth = SecurityArchiveTmpAuth(self._connection, plan_uid, destination_guid)
+        auth = SecurityArchiveAuth(self._connection, plan_uid, destination_guid)
         connection = self._connection_manager.get_storage_connection(auth)
         return StorageSecurityDataService(connection)
 
@@ -57,19 +55,22 @@ class ConnectionManager(object):
     def get_saved_connection_for_url(self, url):
         return self._session_cache.get(url.lower())
 
-    def get_storage_connection(self, tmp_auth):
+    def get_storage_connection(self, storage_auth):
         try:
-            url = tmp_auth.get_storage_url()
+            url = storage_auth.get_storage_url()
             connection = self.get_saved_connection_for_url(url)
             if connection is None:
                 with self._list_update_lock:
                     connection = self.get_saved_connection_for_url(url)
                     if connection is None:
-                        connection = Connection.from_host_address(url, auth=tmp_auth)
+                        connection = Connection.from_host_address(
+                            url, auth=storage_auth
+                        )
                         self._session_cache[url.lower()] = connection
         except Exception as ex:
             message = u"Failed to create or retrieve connection, caused by: {}".format(
                 str(ex)
             )
+            print(ex)
             raise Py42StorageSessionInitializationError(ex, message)
         return connection

--- a/tests/services/storage/test_auth.py
+++ b/tests/services/storage/test_auth.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 from requests import Request
 
@@ -32,22 +30,16 @@ def mock_tmp_auth_conn(mock_connection, py42_response):
 
 @pytest.fixture
 def mock_storage_auth_token_conn(mocker):
-    response = mocker.MagicMock(spec=Py42Response)
-    response.status_code = 200
-    response.encoding = None
-    response.__getitem__ = lambda _, key: json.loads(response.text)[key]
-    response.text = '["TEST_V1", "TOKEN_VALUE"]'
-    response.data = json.loads(response.text)
-
-    connection = mocker.MagicMock(spec=Connection)
-    connection.headers = {}
-    connection.post.return_value = response
-
+    mock_request = mocker.MagicMock(spec=Request)
+    mock_request.text = '["TEST_V1", "TOKEN_VALUE"]'
+    mock_connection = mocker.MagicMock(spec=Connection)
+    mock_connection.headers = {}
+    mock_connection.post.return_value = Py42Response(mock_request)
     mocker.patch(
         "py42.services.storage._auth._get_new_storage_connection",
-        return_value=connection,
+        return_value=mock_connection,
     )
-    return connection
+    return mock_connection
 
 
 class TestFileArchiveTmpAuth(object):

--- a/tests/services/storage/test_service_factory.py
+++ b/tests/services/storage/test_service_factory.py
@@ -5,7 +5,7 @@ from py42.exceptions import Py42HTTPError
 from py42.exceptions import Py42StorageSessionInitializationError
 from py42.services._connection import Connection
 from py42.services.devices import DeviceService
-from py42.services.storage._auth import StorageTmpAuth
+from py42.services.storage._auth import StorageAuth
 from py42.services.storage._service_factory import ConnectionManager
 from py42.services.storage._service_factory import StorageServiceFactory
 from py42.services.storage.archive import StorageArchiveService
@@ -15,7 +15,7 @@ from py42.services.storage.securitydata import StorageSecurityDataService
 
 @pytest.fixture
 def mock_tmp_auth(mocker):
-    mock = mocker.MagicMock(spec=StorageTmpAuth)
+    mock = mocker.MagicMock(spec=StorageAuth)
     mock.get_storage_url.return_value = "testhost.com"
     return mock
 


### PR DESCRIPTION
### Description of Change ###

This change refactors the StorageTmpAuth classes to use AuthTokens rather than the single-use LoginTokens for all storage node authentication. This greatly reduces the number of requests py42 needs to make when interacting with storage nodes, as previously each storage node request after the very first would fail, causing a new LoginToken request to be made to the authority, then back to the storage node to retry the failed request. 

### Issues Resolved ###
- fixes #230 

### Testing Procedure ###
On a pre-fix version, enable debug logging and call a py42 function that makes more than one request to a storage node (e.x. a web restore function that collects multiple files and thus needs to make many file metadata calls). 

Notice in the logging how most calls to the storage node are duplicated (with calls to "api/LoginToken" in between each duplicate). 

Then upgrade to fixed version, and make the exact same function call with debug logging. Notice only a single call to "api/LoginToken" and each storage node call is not duplicated. 

### PR Checklist ###
Did you remember to do the below?

- [X] Add unit tests to verify this change
- [X] Add an entry to CHANGELOG.md describing this change
