### PR TITLE
dont sort

### DIFF
--- a/src/py42/clients/securitydata.py
+++ b/src/py42/clients/securitydata.py
@@ -192,9 +192,9 @@ class SecurityDataClient(object):
         Args:
             query query (`:class:`py42.sdk.queries.fileevents.file_event_query.FileEventQuery` or str): The file event query
                 to filter search results.
-            page_token (str, optional): A token used to indicate the starting point for additional page results. Defaults to empty string.
+            page_token (str, optional): A token used to indicate the starting point for additional page results.
                 For the first page, do not pass page_token. For all consecutive pages, pass the token from the previous response
-                from field `nextPgToken`.
+                from field `nextPgToken`. When using page_token, any sorting parameters will be ignored. Defaults to empty string.
 
         Returns:
             :class:`py42.response.Py42Response`: A response containing page of events.

--- a/src/py42/clients/securitydata.py
+++ b/src/py42/clients/securitydata.py
@@ -194,9 +194,9 @@ class SecurityDataClient(object):
             query (str or :class:`py42.sdk.queries.fileevents.file_event_query.FileEventQuery`):
                 The file event query to filter search results.
             page_token (str, optional): A token used to indicate the starting point for
-                additional page results. For the first page, do not pass page_token. For
+                additional page results. For the first page, do not pass ``page_token``. For
                 all consecutive pages, pass the token from the previous response from
-                field `nextPgToken`. When using page_token, any sorting parameters from
+                field ``nextPgToken``. When using ``page_token``, any sorting parameters from
                 the `FileEventQuery` will be ignored. Defaults to empty string.
 
         Returns:

--- a/src/py42/clients/securitydata.py
+++ b/src/py42/clients/securitydata.py
@@ -176,7 +176,8 @@ class SecurityDataClient(object):
         `REST Documentation <https://support.code42.com/Administrator/Cloud/Monitoring_and_managing/Forensic_File_Search_API>`__
 
         Args:
-            query query (`:class:`py42.sdk.queries.fileevents.file_event_query.FileEventQuery` or str): The file event query to filter search results.
+            query (str or :class:`py42.sdk.queries.fileevents.file_event_query.FileEventQuery`):
+                The file event query to filter search results.
 
         Returns:
             :class:`py42.response.Py42Response`: A response containing the first 10,000
@@ -190,11 +191,13 @@ class SecurityDataClient(object):
         `REST Documentation <https://support.code42.com/Administrator/Cloud/Monitoring_and_managing/Forensic_File_Search_API>`__
 
         Args:
-            query query (`:class:`py42.sdk.queries.fileevents.file_event_query.FileEventQuery` or str): The file event query
-                to filter search results.
-            page_token (str, optional): A token used to indicate the starting point for additional page results.
-                For the first page, do not pass page_token. For all consecutive pages, pass the token from the previous response
-                from field `nextPgToken`. When using page_token, any sorting parameters will be ignored. Defaults to empty string.
+            query (str or :class:`py42.sdk.queries.fileevents.file_event_query.FileEventQuery`):
+                The file event query to filter search results.
+            page_token (str, optional): A token used to indicate the starting point for
+                additional page results. For the first page, do not pass page_token. For
+                all consecutive pages, pass the token from the previous response from
+                field `nextPgToken`. When using page_token, any sorting parameters from
+                the `FileEventQuery` will be ignored. Defaults to empty string.
 
         Returns:
             :class:`py42.response.Py42Response`: A response containing page of events.

--- a/src/py42/sdk/queries/fileevents/file_event_query.py
+++ b/src/py42/sdk/queries/fileevents/file_event_query.py
@@ -34,19 +34,17 @@ class FileEventQuery(BaseQuery):
         groups_string = u",".join(
             str(group_item) for group_item in self._filter_group_list
         )
-
         if self.page_token is not None:
             paging_prop = u'"pgToken":"{}"'.format(self.page_token)
-        else:
-            paging_prop = u'"pgNum":{}'.format(self.page_number)
 
+        else:
+            paging_prop = u'"srtDir":"{0}", "srtKey":"{1}", "pgNum":{2}'.format(
+                self.sort_direction, self.sort_key, self.page_number,
+            )
         json = (
-            u'{{"groupClause":"{0}", "groups":[{1}], "srtDir":"{2}", '
-            u'"srtKey":"{3}", {5}, "pgSize":{4}}}'.format(
+            u'{{"groupClause":"{0}", "groups":[{1}], {3}, "pgSize":{2}}}'.format(
                 self._group_clause,
                 groups_string,
-                self.sort_direction,
-                self.sort_key,
                 self.page_size,
                 paging_prop,
             )

--- a/src/py42/sdk/queries/fileevents/file_event_query.py
+++ b/src/py42/sdk/queries/fileevents/file_event_query.py
@@ -38,16 +38,11 @@ class FileEventQuery(BaseQuery):
             paging_prop = u'"pgToken":"{}"'.format(self.page_token)
 
         else:
-            paging_prop = u'"srtDir":"{0}", "srtKey":"{1}", "pgNum":{2}'.format(
+            paging_prop = u'"srtDir":"{}", "srtKey":"{}", "pgNum":{}'.format(
                 self.sort_direction, self.sort_key, self.page_number,
             )
-        json = (
-            u'{{"groupClause":"{0}", "groups":[{1}], {3}, "pgSize":{2}}}'.format(
-                self._group_clause,
-                groups_string,
-                self.page_size,
-                paging_prop,
-            )
+        json = u'{{"groupClause":"{0}", "groups":[{1}], {3}, "pgSize":{2}}}'.format(
+            self._group_clause, groups_string, self.page_size, paging_prop,
         )
         return json
 

--- a/src/py42/sdk/queries/fileevents/file_event_query.py
+++ b/src/py42/sdk/queries/fileevents/file_event_query.py
@@ -41,8 +41,8 @@ class FileEventQuery(BaseQuery):
             paging_prop = u'"srtDir":"{}", "srtKey":"{}", "pgNum":{}'.format(
                 self.sort_direction, self.sort_key, self.page_number,
             )
-        json = u'{{"groupClause":"{0}", "groups":[{1}], {3}, "pgSize":{2}}}'.format(
-            self._group_clause, groups_string, self.page_size, paging_prop,
+        json = u'{{"groupClause":"{0}", "groups":[{1}], {2}, "pgSize":{3}}}'.format(
+            self._group_clause, groups_string, paging_prop, self.page_size
         )
         return json
 

--- a/tests/clients/test_securitydata.py
+++ b/tests/clients/test_securitydata.py
@@ -1349,7 +1349,7 @@ class TestSecurityClient(object):
         response = security_client.search_all_file_events(query)
         connection.post.assert_called_once_with(
             FILE_EVENT_URI,
-            data='{"groupClause":"AND", "groups":[], "srtDir":"asc", "srtKey":"eventId", "pgToken":"", "pgSize":10000}',
+            data='{"groupClause":"AND", "groups":[], "pgToken":"", "pgSize":10000}',
         )
         assert response is successful_response
 
@@ -1381,6 +1381,6 @@ class TestSecurityClient(object):
         response = security_client.search_all_file_events(query, "abc")
         connection.post.assert_called_once_with(
             FILE_EVENT_URI,
-            data='{"groupClause":"AND", "groups":[], "srtDir":"asc", "srtKey":"eventId", "pgToken":"abc", "pgSize":10000}',
+            data='{"groupClause":"AND", "groups":[], "pgToken":"abc", "pgSize":10000}',
         )
         assert response is successful_response

--- a/tests/sdk/queries/fileevents/test_file_event_query.py
+++ b/tests/sdk/queries/fileevents/test_file_event_query.py
@@ -159,5 +159,5 @@ def test_file_event_str_gives_correct_json_representation_when_pg_token_is_set(
     query.page_token = "abc"
     assert (
         str(query)
-        == u'{"groupClause":"AND", "groups":[], "srtDir":"asc", "srtKey":"eventId", "pgToken":"abc", "pgSize":10000}'
+        == u'{"groupClause":"AND", "groups":[], "pgToken":"abc", "pgSize":10000}'
     )


### PR DESCRIPTION
### Description of Change ###

Makes nextPgToken work by removing sorting parameters from the query when using it.

### Issues Resolved ###

- closes #

### Testing Procedure ###
Use next page token and verify that it works in py42

```
    file_events = response["fileEvents"]
    for event in file_events:
        print(event["md5Checksum"])
    while response["nextPgToken"] is not None:
        print("\n\n NEXT PAGE \n\n")
        response = sdk.securitydata.search_all_file_events(query, page_token=response["nextPgToken"])
        file_events = response["fileEvents"]
        for event in file_events:
            print(event["md5Checksum"])
```

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [n/a] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
