### PR TITLE
Fix/page token error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,25 +10,29 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ## Unreleased
 
-### Added
-
-- `sdk.archive.stream_to_device()` for pushing a restore to another device.
-
 ### Fixed
 
 - Bug where an empty destination list in a device's backup set broke creation of DeviceSettings objects for that device.
+
 - Bug where all 401 Unauthorized error responses were being raised as Py42MFARequired exceptions.
+
 - Bug where requests to storage nodes were only using single-use tokens for authentication, causing many extraneous requests.
 
 ### Added
 
+- `sdk.archive.stream_to_device()` for pushing a restore to another device.
+
 - Added new exception `Py42CloudAliasLimitExceededError` to throw if `add_cloud_alias()` throws `400` and body contains
 reason `Cloud usernames must be less than or equal to`.
+
 - Added new exception `Py42UserNotOnListError` to throw error if `remove()` throws `404` when the user is not on a detection list.
 
 - Added new exception `Py42TooManyRequestsError` to raise errors with 429 HTTP status code.
 
 - Added new method `sdk.securitydata.search_all_file_events()` to retrieve all events when events are more than 10,000.
+
+- Added new custom exception `sdk.exceptions.Py42InvalidPageToken` that gets raised when the page token from
+  `sdk.securitydata.search_all_file_events()` causes a specific bad request error.
 
 ## 1.9.0 - 2020-10-02
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -214,9 +214,17 @@ class Py42BadRestoreRequestError(Py42BadRequestError):
     """An error raised when the given restore arguments are not compatible and cause
     a bad request."""
 
-    def __init__(self, exception, additional_message=None):
+    def __init__(self, exception):
         message = u"Unable to create restore session."
         super(Py42BadRestoreRequestError, self).__init__(exception, message)
+
+
+class Py42InvalidPageTokenError(Py42BadRequestError):
+    """An error raise when the page token given is invalid."""
+
+    def __init__(self, exception, page_token):
+        message = "Invalid page token: {}".format(page_token)
+        super(Py42InvalidPageTokenError, self).__init__(exception, message)
 
 
 class Py42UserNotOnListError(Py42NotFoundError):

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -223,7 +223,7 @@ class Py42InvalidPageTokenError(Py42BadRequestError):
     """An error raised when the page token given is invalid."""
 
     def __init__(self, exception, page_token):
-        message = "Invalid page token: {}".format(page_token)
+        message = u"Invalid page token: {}".format(page_token)
         super(Py42InvalidPageTokenError, self).__init__(exception, message)
 
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -220,7 +220,7 @@ class Py42BadRestoreRequestError(Py42BadRequestError):
 
 
 class Py42InvalidPageTokenError(Py42BadRequestError):
-    """An error raise when the page token given is invalid."""
+    """An error raised when the page token given is invalid."""
 
     def __init__(self, exception, page_token):
         message = "Invalid page token: {}".format(page_token)

--- a/src/py42/services/fileevent.py
+++ b/src/py42/services/fileevent.py
@@ -1,4 +1,6 @@
 from py42._compat import str
+from py42.exceptions import Py42BadRequestError
+from py42.exceptions import Py42InvalidPageTokenError
 from py42.services import BaseService
 
 
@@ -21,9 +23,16 @@ class FileEventService(BaseService):
         Returns:
             :class:`py42.response.Py42Response`: A response containing the query results.
         """
-        query = str(query)
-        uri = u"/forensic-search/queryservice/api/v1/fileevent"
-        return self._connection.post(uri, data=query)
+        try:
+            query_str = str(query)
+            uri = u"/forensic-search/queryservice/api/v1/fileevent"
+            return self._connection.post(uri, data=query_str)
+        except Py42BadRequestError as err:
+            if u"INVALID_PAGE_TOKEN" in str(err.response.text):
+                page_token = query.page_token
+                if page_token:
+                    raise Py42InvalidPageTokenError(err, page_token)
+            raise
 
     def get_file_location_detail_by_sha256(self, checksum):
         """Get file location details based on SHA256 hash.

--- a/tests/services/test_file_event.py
+++ b/tests/services/test_file_event.py
@@ -3,6 +3,7 @@ import pytest
 from requests import HTTPError
 from requests import Response
 
+from py42._compat import str
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42InvalidPageTokenError
 from py42.sdk.queries.fileevents.file_event_query import FileEventQuery
@@ -13,7 +14,7 @@ from py42.services.fileevent import FileEventService
 FILE_EVENT_URI = u"/forensic-search/queryservice/api/v1/fileevent"
 
 
-def _create_test_query(test_filename="*"):
+def _create_test_query(test_filename=u"*"):
     return FileEventQuery(FileName.eq(test_filename))
 
 
@@ -87,8 +88,9 @@ class TestFileEventService(object):
         service = FileEventService(connection)
         connection.post.return_value = successful_response
         query = _create_test_query(u"我能吞")
+        expected = str(query)
         service.search(query)
-        connection.post.assert_called_once_with(FILE_EVENT_URI, data=str(query))
+        connection.post.assert_called_once_with(FILE_EVENT_URI, data=expected)
 
     def test_get_file_location_detail_by_sha256_calls_get_with_hash(
         self, connection, successful_response

--- a/tests/services/test_file_event.py
+++ b/tests/services/test_file_event.py
@@ -64,7 +64,6 @@ class TestFileEventService(object):
         with pytest.raises(Py42BadRequestError):
             service.search(query)
 
-
     def test_search_when_bad_request_raised_with_token_but_has_not_invalid_token_text_raises_bad_request(
         self, mocker, connection
     ):
@@ -81,7 +80,6 @@ class TestFileEventService(object):
         service = FileEventService(connection)
         with pytest.raises(Py42BadRequestError):
             service.search(query)
-
 
     def test_unicode_query_search_calls_post_with_query(
         self, connection, successful_response

--- a/tests/services/test_file_event.py
+++ b/tests/services/test_file_event.py
@@ -1,12 +1,33 @@
 # -*- coding: utf-8 -*-
 import pytest
+from requests import HTTPError
+from requests import Response
 
+from py42.exceptions import Py42BadRequestError
+from py42.exceptions import Py42InvalidPageTokenError
+from py42.sdk.queries.fileevents.file_event_query import FileEventQuery
+from py42.sdk.queries.fileevents.filters import FileName
 from py42.services._connection import Connection
 from py42.services.fileevent import FileEventService
 
-FILE_EVENT_URI = "/forensic-search/queryservice/api/v1/fileevent"
-RAW_QUERY = "RAW JSON QUERY"
-RAW_UNICODE_QUERY = u"RAW UNICODE JSON QUERY 我能吞"
+FILE_EVENT_URI = u"/forensic-search/queryservice/api/v1/fileevent"
+
+
+def _create_test_query(test_filename="*"):
+    return FileEventQuery(FileName.eq(test_filename))
+
+
+@pytest.fixture()
+def mock_invalid_page_token_connection(mocker, connection):
+    def side_effect(*args, **kwargs):
+        http_error = mocker.MagicMock(spec=HTTPError)
+        response = mocker.MagicMock(spec=Response)
+        response.text = "INVALID_PAGE_TOKEN"
+        http_error.response = response
+        raise Py42BadRequestError(http_error)
+
+    connection.post.side_effect = side_effect
+    return connection
 
 
 class TestFileEventService(object):
@@ -19,16 +40,57 @@ class TestFileEventService(object):
     ):
         service = FileEventService(connection)
         connection.post.return_value = successful_response
-        service.search(RAW_QUERY)
-        connection.post.assert_called_once_with(FILE_EVENT_URI, data=RAW_QUERY)
+        query = _create_test_query()
+        service.search(query)
+        connection.post.assert_called_once_with(FILE_EVENT_URI, data=str(query))
+
+    def test_search_when_given_page_token_and_bad_request_with_invalid_page_token_occurs_raises_invalid_page_token_error(
+        self, mock_invalid_page_token_connection
+    ):
+        query = _create_test_query()
+        query.page_token = "test_page_token"
+        service = FileEventService(mock_invalid_page_token_connection)
+        with pytest.raises(Py42InvalidPageTokenError) as err:
+            service.search(query)
+
+        assert str(err.value) == "Invalid page token: {}".format(query.page_token)
+
+    def test_search_when_bad_request_raised_and_token_not_in_query_raises_bad_request(
+        self, mock_invalid_page_token_connection
+    ):
+        query = _create_test_query()
+        query.page_token = None
+        service = FileEventService(mock_invalid_page_token_connection)
+        with pytest.raises(Py42BadRequestError):
+            service.search(query)
+
+
+    def test_search_when_bad_request_raised_with_token_but_has_not_invalid_token_text_raises_bad_request(
+        self, mocker, connection
+    ):
+        def side_effect(*args, **kwargs):
+            http_error = mocker.MagicMock(spec=HTTPError)
+            response = mocker.MagicMock(spec=Response)
+            response.text = "DIFFERENT_ERROR"
+            http_error.response = response
+            raise Py42BadRequestError(http_error)
+
+        connection.post.side_effect = side_effect
+        query = _create_test_query()
+        query.page_token = "test_page_token"
+        service = FileEventService(connection)
+        with pytest.raises(Py42BadRequestError):
+            service.search(query)
+
 
     def test_unicode_query_search_calls_post_with_query(
         self, connection, successful_response
     ):
         service = FileEventService(connection)
         connection.post.return_value = successful_response
-        service.search(RAW_UNICODE_QUERY)
-        connection.post.assert_called_once_with(FILE_EVENT_URI, data=RAW_UNICODE_QUERY)
+        query = _create_test_query(u"我能吞")
+        service.search(query)
+        connection.post.assert_called_once_with(FILE_EVENT_URI, data=str(query))
 
     def test_get_file_location_detail_by_sha256_calls_get_with_hash(
         self, connection, successful_response


### PR DESCRIPTION
### Description of Change ###

Custom exception for invalid tokens. I like this because this helps ensure that when we get that weird 500 error (when including sorting), that we further know that it is unrelated to the token because of the existence of this token.
This was something I found during my QA testing of this feature.

### Issues Resolved ###
Improve file event paging.

### Testing Procedure ###

```
    query = FileEventQuery(FileName.eq("*"))
    response = sdk.securitydata.search_all_file_events(query, "asfas")
    file_events = response["fileEvents"]
    for event in file_events:
        print(event["md5Checksum"])
    while response["nextPgToken"] is not None:
        print("\n\n NEXT PAGE \n\n")
        response = sdk.securitydata.search_all_file_events(query, page_token=response["nextPgToken"])
        file_events = response["fileEvents"]
        for event in file_events:
            print(event["md5Checksum"])
```

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
