### PR TITLE
Replace set-env with new format

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,12 +24,12 @@ jobs:
       run: |
           src_file=( ./dist/*.tar.gz )
           wheel_file=( ./dist/*.whl )
-          echo "::set-env name=RELEASE_ID::$(jq --raw-output '.release.id' $GITHUB_EVENT_PATH)"
-          echo "::set-env name=SOURCE_DIST_FILE::$(basename $src_file)"
-          echo "::set-env name=WHEEL_FILE::$(basename $wheel_file)"
+          echo "RELEASE_ID=$(jq --raw-output '.release.id' $GITHUB_EVENT_PATH)" >> $GITHUB_ENV
+          echo "SOURCE_DIST_FILE=$(basename $src_file)" >> $GITHUB_ENV
+          echo "WHEEL_FILE=$(basename $wheel_file)" >> $GITHUB_ENV
     - name: Set Upload Url
       run: |
-          echo "::set-env name=UPLOAD_URL::https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets{?name,label}"
+          echo "UPLOAD_URL=https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets{?name,label}" >> $GITHUB_ENV
     - name: Output Variables For Uploading
       id: get_upload_vars
       run: |


### PR DESCRIPTION
### Description of Change ###

Fixs deploy
Removes use of set-env and replaced it with env files, as it is no longer allowed in github actions.

### Issues Resolved ###
The issue of it not deploying

### Testing Procedure ###
Will try creating a new release after this
