### PR TITLE
Do not expose legal hold backup sets in DeviceSettings objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## 1.10.1 - 2020-12-15
+
+### Fixed
+
+- Bug where trying to retrieve device settings for a device on legal holds caused an exception to be raised.
+
 ## 1.10.0 - 2020-12-14
 
 ### Fixed


### PR DESCRIPTION
### Description of Change ###

The `py42.clients.settings.device_settings.BackupSet` object has a bug where it fails to handle the destinations object for legal hold backup sets, because the resolution of the `BackupSet.destinations` property is expecting a list and a legal hold set turns it into a dict so it can add the `@locked: true` property to it. 

Since legal hold backup sets are hidden from every part of the Code42 UI (both console and client), and since they should never be individually modified via API (even if some API changes are _technically_ possible to make), because of the confusion a mismatch between an individual device and the legal hold matter policy that device is part of would create, this change just hides the legal hold backup set(s) altogether from the `DeviceSettings` object's public interfaces. 

### Issues Resolved ###
- closes #248

### Testing Procedure ###
- Add a Code42 user/device to a legal hold matter
- Create a py42 `DeviceSettings` object for the device
- Verify `DeviceSettings` object creation does not throw exception like previous versions
- Verify `DeviceSettings.backup_sets` property only shows the backup set(s) visible in the console for that device

### PR Checklist ###
Did you remember to do the below?

- [X] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [X] Add docstrings for any new public parameters / methods / classes
