### PR TITLE
Bugfix: Alert rules service should not be dependent on detectionlists, change dependency 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 ## Unreleased
 
 ### Fixed
+- Bug that occurs when trying to add a user to an alert rule who had never been on any detection list before.
 
 - Bug where an empty destination list in a device's backup set broke creation of DeviceSettings objects for that device.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 ## Unreleased
 
 ### Fixed
+
 - Bug that occurs when trying to add a user to an alert rule who had never been on any detection list before.
 
 - Bug where an empty destination list in a device's backup set broke creation of DeviceSettings objects for that device.

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -237,6 +237,14 @@ class Py42UserNotOnListError(Py42NotFoundError):
         super(Py42NotFoundError, self).__init__(exception, message)
 
 
+class Py42InvalidRule(Py42NotFoundError):
+    """An exception raised when the user is not on a detection list."""
+
+    def __init__(self, exception, rule_id):
+        message = u"Invalid Observer Rule ID '{}'.".format(rule_id)
+        super(Py42NotFoundError, self).__init__(exception, message)
+
+
 def raise_py42_error(raised_error):
     """Raises the appropriate :class:`py42.exceptions.Py42HttpError` based on the given
     HTTPError's response status code.

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -237,8 +237,8 @@ class Py42UserNotOnListError(Py42NotFoundError):
         super(Py42NotFoundError, self).__init__(exception, message)
 
 
-class Py42InvalidRule(Py42NotFoundError):
-    """An exception raised when the user is not on a detection list."""
+class Py42InvalidRuleError(Py42NotFoundError):
+    """An exception raised when the observer rule ID does not exist."""
 
     def __init__(self, exception, rule_id):
         message = u"Invalid Observer Rule ID '{}'.".format(rule_id)

--- a/src/py42/services/alertrules.py
+++ b/src/py42/services/alertrules.py
@@ -1,6 +1,6 @@
+from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42InvalidRule
 from py42.exceptions import Py42NotFoundError
-from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42UserNotOnListError
 from py42.services import BaseService
 

--- a/src/py42/services/alertrules.py
+++ b/src/py42/services/alertrules.py
@@ -1,5 +1,5 @@
 from py42.exceptions import Py42BadRequestError
-from py42.exceptions import Py42InvalidRule
+from py42.exceptions import Py42InvalidRuleError
 from py42.exceptions import Py42NotFoundError
 from py42.exceptions import Py42UserNotOnListError
 from py42.services import BaseService
@@ -62,7 +62,7 @@ class AlertRulesService(BaseService):
         try:
             return self._connection.post(uri, json=data)
         except Py42NotFoundError as err:
-            raise Py42InvalidRule(err, rule_id)
+            raise Py42InvalidRuleError(err, rule_id)
 
     def remove_user(self, rule_id, user_id):
         user_ids = [user_id]

--- a/src/py42/services/alertrules.py
+++ b/src/py42/services/alertrules.py
@@ -41,6 +41,7 @@ class AlertRulesService(BaseService):
 
     def add_user(self, rule_id, user_id):
         tenant_id = self._user_context.get_current_tenant_id()
+        self._user_profile_service.create_if_not_exists(user_id)
         user_details = self._user_profile_service.get_by_id(user_id)
         user_aliases = user_details.data.get(u"cloudUsernames") or []
         data = {

--- a/src/py42/services/alertrules.py
+++ b/src/py42/services/alertrules.py
@@ -1,3 +1,7 @@
+from py42.exceptions import Py42InvalidRule
+from py42.exceptions import Py42NotFoundError
+from py42.exceptions import Py42BadRequestError
+from py42.exceptions import Py42UserNotOnListError
 from py42.services import BaseService
 
 
@@ -41,8 +45,11 @@ class AlertRulesService(BaseService):
 
     def add_user(self, rule_id, user_id):
         tenant_id = self._user_context.get_current_tenant_id()
-        self._user_profile_service.create_if_not_exists(user_id)
-        user_details = self._user_profile_service.get_by_id(user_id)
+        try:
+            self._user_profile_service.create_if_not_exists(user_id)
+            user_details = self._user_profile_service.get_by_id(user_id)
+        except (Py42BadRequestError, Py42NotFoundError) as err:
+            raise Py42UserNotOnListError(err, user_id, "user profile")
         user_aliases = user_details.data.get(u"cloudUsernames") or []
         data = {
             u"tenantId": tenant_id,
@@ -52,7 +59,10 @@ class AlertRulesService(BaseService):
             ],
         }
         uri = u"{}{}".format(self._api_prefix, u"add-users")
-        return self._connection.post(uri, json=data)
+        try:
+            return self._connection.post(uri, json=data)
+        except Py42NotFoundError as err:
+            raise Py42InvalidRule(err, rule_id)
 
     def remove_user(self, rule_id, user_id):
         user_ids = [user_id]

--- a/src/py42/services/detectionlists/user_profile.py
+++ b/src/py42/services/detectionlists/user_profile.py
@@ -60,10 +60,10 @@ class DetectionListUserService(BaseService):
         return self._connection.post(uri, json=data)
 
     def get_by_id(self, user_id):
-        """Get user details by user id.
+        """Get user details by user UID.
 
         Args:
-            user_id (str or int): Id of the user.
+            user_id (str or int): UID of the user.
 
         Returns:
             :class:`py42.response.Py42Response`

--- a/tests/services/test_alert_rules.py
+++ b/tests/services/test_alert_rules.py
@@ -2,7 +2,6 @@ import json
 
 import pytest
 from requests import Response
-from requests.exceptions import HTTPError
 
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42InvalidRule
@@ -33,19 +32,27 @@ def mock_detection_list_user_service(mocker, py42_response):
     detection_list_user_service.get_by_id.return_value = py42_response
     return detection_list_user_service
 
+
 @pytest.fixture
-def mock_detection_list_get_by_id_failure_when_invalid_id(mocker, mock_connection, py42_response):
+def mock_detection_list_get_by_id_failure_when_invalid_id(
+    mocker, mock_connection, py42_response
+):
     response = mocker.MagicMock(spec=Response)
     response.status_code = 400
     exception = mocker.MagicMock(spec=Py42BadRequestError)
     exception.response = response
     detection_list_user_service = mocker.MagicMock(spec=DetectionListUserService)
     detection_list_user_service.create_if_not_exists.return_value = False
-    detection_list_user_service.get_by_id.side_effect = Py42BadRequestError(exception, "")
+    detection_list_user_service.get_by_id.side_effect = Py42BadRequestError(
+        exception, ""
+    )
     return detection_list_user_service
 
+
 @pytest.fixture
-def mock_detection_list_post_failure_when_invalid_rule_id(mocker, mock_connection, py42_response):
+def mock_detection_list_post_failure_when_invalid_rule_id(
+    mocker, mock_connection, py42_response
+):
     response = mocker.MagicMock(spec=Response)
     response.status_code = 400
     exception = mocker.MagicMock(spec=Py42NotFoundError)
@@ -58,7 +65,9 @@ def mock_detection_list_post_failure_when_invalid_rule_id(mocker, mock_connectio
 
 
 @pytest.fixture
-def mock_detection_list_user_service_create_user(mocker, py42_response, http_error, mock_connection):
+def mock_detection_list_user_service_create_user(
+    mocker, py42_response, http_error, mock_connection
+):
     py42_response.text = MOCK_DETECTION_LIST_GET_RESPONSE
     py42_response.data = json.loads(MOCK_DETECTION_LIST_GET_RESPONSE)
     response = mocker.MagicMock(spec=Response)
@@ -134,11 +143,16 @@ class TestAlertRulesService(object):
         mock_detection_list_get_by_id_failure_when_invalid_id,
     ):
         alert_rule_service = AlertRulesService(
-            mock_connection, user_context, mock_detection_list_get_by_id_failure_when_invalid_id
+            mock_connection,
+            user_context,
+            mock_detection_list_get_by_id_failure_when_invalid_id,
         )
         with pytest.raises(Py42UserNotOnListError) as e:
             alert_rule_service.add_user("rule-id", "invalid-user-id")
-        assert "'invalid-user-id' is not currently on the user profile list." in e.value.args[0] 
+        assert (
+            "'invalid-user-id' is not currently on the user profile list."
+            in e.value.args[0]
+        )
 
     def test_add_user_raises_valid_exception_when_rule_id_is_invalid(
         self,
@@ -147,10 +161,12 @@ class TestAlertRulesService(object):
         mock_detection_list_post_failure_when_invalid_rule_id,
     ):
         alert_rule_service = AlertRulesService(
-            mock_connection, user_context, mock_detection_list_post_failure_when_invalid_rule_id
+            mock_connection,
+            user_context,
+            mock_detection_list_post_failure_when_invalid_rule_id,
         )
         with pytest.raises(Py42InvalidRule) as e:
-            alert_rule_service.add_user("invalid-rule-id", 'user-id')
+            alert_rule_service.add_user("invalid-rule-id", "user-id")
         assert "Invalid Observer Rule ID 'invalid-rule-id'." in e.value.args[0]
 
     def test_add_user_posts_expected_data_when_user_does_not_exist_in_detectionlist(

--- a/tests/services/test_alert_rules.py
+++ b/tests/services/test_alert_rules.py
@@ -4,9 +4,9 @@ import pytest
 from requests import Response
 from requests.exceptions import HTTPError
 
+from py42.exceptions import Py42BadRequestError
 from py42.services.alertrules import AlertRulesService
 from py42.services.detectionlists.user_profile import DetectionListUserService
-from py42.exceptions import Py42BadRequestError
 
 
 MOCK_DETECTION_LIST_GET_RESPONSE = """
@@ -93,10 +93,13 @@ class TestAlertRulesService(object):
             posted_data["tenantId"] == user_context.get_current_tenant_id()
             and posted_data["ruleId"] == u"rule-id"
         )
-    
+
     def test_add_user_posts_expected_data_when_user_does_not_exist_in_detectionlist(
-            self, mock_connection, user_context, mock_detection_list_user_service_create_user
-        ):
+        self,
+        mock_connection,
+        user_context,
+        mock_detection_list_user_service_create_user,
+    ):
         alert_rule_service = AlertRulesService(
             mock_connection, user_context, mock_detection_list_user_service_create_user
         )

--- a/tests/services/test_alert_rules.py
+++ b/tests/services/test_alert_rules.py
@@ -5,6 +5,9 @@ from requests import Response
 from requests.exceptions import HTTPError
 
 from py42.exceptions import Py42BadRequestError
+from py42.exceptions import Py42InvalidRule
+from py42.exceptions import Py42NotFoundError
+from py42.exceptions import Py42UserNotOnListError
 from py42.services.alertrules import AlertRulesService
 from py42.services.detectionlists.user_profile import DetectionListUserService
 
@@ -30,12 +33,42 @@ def mock_detection_list_user_service(mocker, py42_response):
     detection_list_user_service.get_by_id.return_value = py42_response
     return detection_list_user_service
 
+@pytest.fixture
+def mock_detection_list_get_by_id_failure_when_invalid_id(mocker, mock_connection, py42_response):
+    response = mocker.MagicMock(spec=Response)
+    response.status_code = 400
+    exception = mocker.MagicMock(spec=Py42BadRequestError)
+    exception.response = response
+    detection_list_user_service = mocker.MagicMock(spec=DetectionListUserService)
+    detection_list_user_service.create_if_not_exists.return_value = False
+    detection_list_user_service.get_by_id.side_effect = Py42BadRequestError(exception, "")
+    return detection_list_user_service
 
 @pytest.fixture
-def mock_detection_list_user_service_create_user(mocker, py42_response, http_error):
+def mock_detection_list_post_failure_when_invalid_rule_id(mocker, mock_connection, py42_response):
+    response = mocker.MagicMock(spec=Response)
+    response.status_code = 400
+    exception = mocker.MagicMock(spec=Py42NotFoundError)
+    exception.response = response
+    mock_connection.post.side_effect = Py42NotFoundError(exception, "")
     detection_list_user_service = mocker.MagicMock(spec=DetectionListUserService)
-    detection_list_user_service.get_by_id.side_effect = [http_error, py42_response]
-    detection_list_user_service.create_if_not_exists.return_value = py42_response
+    detection_list_user_service.create_if_not_exists.return_value = True
+    detection_list_user_service.get_by_id.return_value = py42_response
+    return detection_list_user_service
+
+
+@pytest.fixture
+def mock_detection_list_user_service_create_user(mocker, py42_response, http_error, mock_connection):
+    py42_response.text = MOCK_DETECTION_LIST_GET_RESPONSE
+    py42_response.data = json.loads(MOCK_DETECTION_LIST_GET_RESPONSE)
+    response = mocker.MagicMock(spec=Response)
+    response.status_code = 400
+    exception = mocker.MagicMock(spec=Py42BadRequestError)
+    exception.response = response
+    detection_list_user_service = mocker.MagicMock(spec=DetectionListUserService)
+    detection_list_user_service.get_by_id.return_value = py42_response
+    detection_list_user_service.create_if_not_exists.return_value = False
+    mock_connection.post.return_value = py42_response
     return detection_list_user_service
 
 
@@ -93,6 +126,32 @@ class TestAlertRulesService(object):
             posted_data["tenantId"] == user_context.get_current_tenant_id()
             and posted_data["ruleId"] == u"rule-id"
         )
+
+    def test_add_user_raises_valid_exception_when_user_id_is_invalid(
+        self,
+        mock_connection,
+        user_context,
+        mock_detection_list_get_by_id_failure_when_invalid_id,
+    ):
+        alert_rule_service = AlertRulesService(
+            mock_connection, user_context, mock_detection_list_get_by_id_failure_when_invalid_id
+        )
+        with pytest.raises(Py42UserNotOnListError) as e:
+            alert_rule_service.add_user("rule-id", "invalid-user-id")
+        assert "'invalid-user-id' is not currently on the user profile list." in e.value.args[0] 
+
+    def test_add_user_raises_valid_exception_when_rule_id_is_invalid(
+        self,
+        mock_connection,
+        user_context,
+        mock_detection_list_post_failure_when_invalid_rule_id,
+    ):
+        alert_rule_service = AlertRulesService(
+            mock_connection, user_context, mock_detection_list_post_failure_when_invalid_rule_id
+        )
+        with pytest.raises(Py42InvalidRule) as e:
+            alert_rule_service.add_user("invalid-rule-id", 'user-id')
+        assert "Invalid Observer Rule ID 'invalid-rule-id'." in e.value.args[0]
 
     def test_add_user_posts_expected_data_when_user_does_not_exist_in_detectionlist(
         self,

--- a/tests/services/test_alert_rules.py
+++ b/tests/services/test_alert_rules.py
@@ -4,7 +4,7 @@ import pytest
 from requests import Response
 
 from py42.exceptions import Py42BadRequestError
-from py42.exceptions import Py42InvalidRule
+from py42.exceptions import Py42InvalidRuleError
 from py42.exceptions import Py42NotFoundError
 from py42.exceptions import Py42UserNotOnListError
 from py42.services.alertrules import AlertRulesService
@@ -165,7 +165,7 @@ class TestAlertRulesService(object):
             user_context,
             mock_detection_list_post_failure_when_invalid_rule_id,
         )
-        with pytest.raises(Py42InvalidRule) as e:
+        with pytest.raises(Py42InvalidRuleError) as e:
             alert_rule_service.add_user("invalid-rule-id", "user-id")
         assert "Invalid Observer Rule ID 'invalid-rule-id'." in e.value.args[0]
 


### PR DESCRIPTION
### Description of Change ###

As `alertrules` service was dependent on `detectionlists` for `user-profile`, `rules.add_user` failed whenever a user existed but was not added to `detectionlists`.

EDIT:
   Added custom exceptions when
    -  user-id is invalid
    -  rule-id is invalid

The fix  changes dependency to `user service`. 

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test that this change works as intended. What functions should be run? How can testers obtain valid parameters to test those functions? Where in the console can the actions of the functions be verified? -->

`new_user = sdk.create_user(org_uid, "abc@abc.abc', "abc@abc.abc')`
`sdk.alerts.rules.add_user("rule-id", new_user['userId'])`

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [NA ] Add an entry to CHANGELOG.md describing this change
- [ NA] Add docstrings for any new public parameters / methods / classes
