### PR TITLE
Chore/clarify legal hold get custodians doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ## Unreleased
 
+- `sdk.legalhold.get_custodians_page()` now raises `Py42Error` when missing on of the required options.
+
 ### Added
 
 - Python 3.9 support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ## Unreleased
 
-- `sdk.legalhold.get_custodians_page()` now raises `Py42Error` when missing on of the required options.
+### Changed
+
+- `sdk.legalhold.get_custodians_page()` now raises `Py42LegalHoldCriteriaMissingError` when missing one of the required options.
 
 ### Added
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -180,7 +180,7 @@ class Py42LegalHoldCriteriaMissingError(Py42BadRequestError):
     def __init__(self, exception):
         super(Py42LegalHoldCriteriaMissingError, self).__init__(
             exception,
-            u"At least one criteria must be specified; hold_membership_uid, hold_uid, user_uid, or user",
+            u"At least one criteria must be specified; hold_membership_uid, hold_uid, user_uid, or user.",
         )
 
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -174,6 +174,16 @@ class Py42LegalHoldNotFoundOrPermissionDeniedError(Py42ForbiddenError):
         )
 
 
+class Py42LegalHoldCriteriaMissingError(Py42BadRequestError):
+    """An exception raised when a bad request was made to a Legal Hold endpoint."""
+
+    def __init__(self, exception):
+        super(Py42LegalHoldCriteriaMissingError, self).__init__(
+            exception,
+            u"At least one criteria must be specified; hold_membership_uid, hold_uid, user_uid, or user",
+        )
+
+
 class Py42InvalidRuleOperationError(Py42HTTPError):
     """An exception raised when trying to add or remove users to a system rule."""
 

--- a/src/py42/services/legalhold.py
+++ b/src/py42/services/legalhold.py
@@ -237,8 +237,7 @@ class LegalHoldService(BaseService):
         except Py42BadRequestError as ex:
             if u"At least one criteria must be specified" in ex.response.text:
                 raise Py42LegalHoldCriteriaMissingError(ex)
-            else:
-                raise
+            raise
 
     def get_all_matter_custodians(
         self, legal_hold_uid=None, user_uid=None, user=None, active=True

--- a/src/py42/services/legalhold.py
+++ b/src/py42/services/legalhold.py
@@ -220,10 +220,6 @@ class LegalHoldService(BaseService):
         Returns:
             :class:`py42.response.Py42Response`:
         """
-        # if not any((legal_hold_membership_uid, legal_hold_uid, user_uid, user)):
-        #     raise Py42Error(
-        #         u"missing one of the following options: legal_hold_membership_uid, legal_hold_uid, user_uid, user"
-        #     )
         active_state = _active_state_map(active)
         page_size = page_size or settings.items_per_page
         params = {

--- a/src/py42/services/legalhold.py
+++ b/src/py42/services/legalhold.py
@@ -194,7 +194,11 @@ class LegalHoldService(BaseService):
         active=True,
         page_size=None,
     ):
-        """Gets an individual page of Legal Hold memberships.
+        """Gets an individual page of Legal Hold memberships. One of the following
+        optional args is required to determine which custodians to retrieve:
+
+        `legal_hold_membership_uid`, `legal_hold_uid`, `user_uid`, `user`
+
         `REST Documentation <https://console.us.code42.com/apidocviewer/#LegalHoldMembership-get>`__
 
         Args:
@@ -215,6 +219,10 @@ class LegalHoldService(BaseService):
         Returns:
             :class:`py42.response.Py42Response`:
         """
+        if not any((legal_hold_membership_uid, legal_hold_uid, user_uid, user)):
+            raise Py42Error(
+                u"missing one of the following options: legal_hold_membership_uid, legal_hold_uid, user_uid, user"
+            )
         active_state = _active_state_map(active)
         page_size = page_size or settings.items_per_page
         params = {

--- a/src/py42/services/legalhold.py
+++ b/src/py42/services/legalhold.py
@@ -2,8 +2,8 @@ from py42 import settings
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42Error
 from py42.exceptions import Py42ForbiddenError
-from py42.exceptions import Py42LegalHoldNotFoundOrPermissionDeniedError
 from py42.exceptions import Py42LegalHoldCriteriaMissingError
+from py42.exceptions import Py42LegalHoldNotFoundOrPermissionDeniedError
 from py42.exceptions import Py42UserAlreadyAddedError
 from py42.services import BaseService
 from py42.services.util import get_all_pages

--- a/tests/services/test_legalhold.py
+++ b/tests/services/test_legalhold.py
@@ -4,6 +4,7 @@ from requests import Response
 
 import py42
 from py42.exceptions import Py42BadRequestError
+from py42.exceptions import Py42Error
 from py42.exceptions import Py42ForbiddenError
 from py42.exceptions import Py42LegalHoldNotFoundOrPermissionDeniedError
 from py42.exceptions import Py42UserAlreadyAddedError
@@ -164,6 +165,13 @@ class TestLegalHoldService(object):
                 "pgSize": 200,
             },
         )
+
+    def test_get_custodians_page_raises_error_when_required_option_missing(
+        self, mock_connection
+    ):
+        service = LegalHoldService(mock_connection)
+        with pytest.raises(Py42Error):
+            service.get_custodians_page(20)
 
     def test_add_to_matter_calls_post_with_expected_url_and_params(
         self, mock_connection

--- a/tests/services/test_legalhold.py
+++ b/tests/services/test_legalhold.py
@@ -123,7 +123,7 @@ class TestLegalHoldService(object):
             mock_get_all_matter_custodians_response,
             mock_get_all_matter_custodians_empty_response,
         ]
-        for _ in service.get_all_matter_custodians():
+        for _ in service.get_all_matter_custodians(user="test"):
             pass
         py42.settings.items_per_page = 500
         assert mock_connection.get.call_count == 3

--- a/tests/services/test_legalhold.py
+++ b/tests/services/test_legalhold.py
@@ -4,8 +4,8 @@ from requests import Response
 
 import py42
 from py42.exceptions import Py42BadRequestError
-from py42.exceptions import Py42LegalHoldCriteriaMissingError
 from py42.exceptions import Py42ForbiddenError
+from py42.exceptions import Py42LegalHoldCriteriaMissingError
 from py42.exceptions import Py42LegalHoldNotFoundOrPermissionDeniedError
 from py42.exceptions import Py42UserAlreadyAddedError
 from py42.response import Py42Response


### PR DESCRIPTION
### Description of Change ###

The backend for `sdk.legalhold.get_custodians_page()` requires at least one of the optional params `legal_hold_membership_uid`, `legal_hold_uid`, `user_uid`, `user` or else it returns a 400 error. 

This change documents that requirement as well as raises a `Py42Error` when none of the the options are passed. 

### PR Checklist ###
Did you remember to do the below?

- [X] Add unit tests to verify this change
- [X] Add an entry to CHANGELOG.md describing this change
- [NA] Add docstrings for any new public parameters / methods / classes
