### PR TITLE
Add custom exceptions in cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - `sdk.legalhold.get_custodians_page()` now raises `Py42LegalHoldCriteriaMissingError` when missing one of the required options.
 
+- `sdk.cases.create()` now raises `Py42CaseNameExistsError` when case name already exists in the system.
+
+- `sdk.cases.create()` now raises `Py42DescriptionLimitExceededError` when description is more than 250 charachters.
+
+- `sdk.cases.update()` now raises `Py42DescriptionLimitExceededError` when description is more than 250 charachters.
+
+- `sdk.cases.file_events.add()` now raises `Py42CaseAlreadyHasEventError` when same event is added to a case more than once.
+
+- `sdk.cases.file_events.add()` now raises `Py42UpdateClosedCaseError` when event is added to a closed case.
+
+- `sdk.cases.file_events.delete()` now raises `Py42UpdateClosedCaseError` when event is deleted from a closed case.
+
 ### Added
 
 - Python 3.9 support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,15 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - `sdk.cases.create()` now raises `Py42CaseNameExistsError` when case name already exists in the system.
 
-- `sdk.cases.create()` now raises `Py42DescriptionLimitExceededError` when description is more than 250 charachters.
+- `sdk.cases.create()` now raises `Py42DescriptionLimitExceededError` when the description is more than 250 charachters.
 
-- `sdk.cases.update()` now raises `Py42DescriptionLimitExceededError` when description is more than 250 charachters.
+- `sdk.cases.update()` now raises `Py42DescriptionLimitExceededError` when the description is more than 250 charachters.
 
-- `sdk.cases.file_events.add()` now raises `Py42CaseAlreadyHasEventError` when same event is added to a case more than once.
+- `sdk.cases.file_events.add()` now raises `Py42CaseAlreadyHasEventError` when the same event is added to a case more than once.
 
-- `sdk.cases.file_events.add()` now raises `Py42UpdateClosedCaseError` when event is added to a closed case.
+- `sdk.cases.file_events.add()` now raises `Py42UpdateClosedCaseError` when the event is added to a closed case.
 
-- `sdk.cases.file_events.delete()` now raises `Py42UpdateClosedCaseError` when event is deleted from a closed case.
+- `sdk.cases.file_events.delete()` now raises `Py42UpdateClosedCaseError` when the event is deleted from a closed case.
 
 ### Added
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -263,6 +263,22 @@ class Py42UpdateClosedCaseError(Py42BadRequestError):
         super(Py42UpdateClosedCaseError, self).__init__(exception, msg)
 
 
+class Py42CaseNameExistsError(Py42BadRequestError):
+    """An error raised when trying to create a case with a name that already exists."""
+
+    def __init__(self, exception, case_name):
+        msg = "Case name '{}' already exists, please set another name".format(case_name)
+        super(Py42CaseNameExistsError, self).__init__(exception, msg)
+
+
+class Py42DescriptionLimitExceededError(Py42BadRequestError):
+    """An error raised when description of a case exceeds allowed char length limit."""
+
+    def __init__(self, exception):
+        msg = "Description limit exceeded, max 254 characters allowed."
+        super(Py42DescriptionLimitExceededError, self).__init__(exception, msg)
+
+
 def raise_py42_error(raised_error):
     """Raises the appropriate :class:`py42.exceptions.Py42HttpError` based on the given
     HTTPError's response status code.

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -279,6 +279,14 @@ class Py42DescriptionLimitExceededError(Py42BadRequestError):
         super(Py42DescriptionLimitExceededError, self).__init__(exception, msg)
 
 
+class Py42CaseAlreadyHasEventError(Py42BadRequestError):
+    """An error raised when event is already associated to the case."""
+
+    def __init__(self, exception):
+        msg = "Event is already associated to the case."
+        super(Py42CaseAlreadyHasEventError, self).__init__(exception, msg)
+
+
 def raise_py42_error(raised_error):
     """Raises the appropriate :class:`py42.exceptions.Py42HttpError` based on the given
     HTTPError's response status code.

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -272,10 +272,10 @@ class Py42CaseNameExistsError(Py42BadRequestError):
 
 
 class Py42DescriptionLimitExceededError(Py42BadRequestError):
-    """An error raised when description of a case exceeds allowed char length limit."""
+    """An error raised when description of a case exceeds the allowed char length limit."""
 
     def __init__(self, exception):
-        msg = "Description limit exceeded, max 254 characters allowed."
+        msg = "Description limit exceeded, max 250 characters allowed."
         super(Py42DescriptionLimitExceededError, self).__init__(exception, msg)
 
 

--- a/src/py42/services/cases.py
+++ b/src/py42/services/cases.py
@@ -29,9 +29,10 @@ class CasesService(BaseService):
         except Py42BadRequestError as err:
             if u"NAME_EXISTS" in err.response.text:
                 raise Py42CaseNameExistsError(err, name)
-            if u"DESCRIPTION_TOO_LONG" in err.response.text:
+            elif u"DESCRIPTION_TOO_LONG" in err.response.text:
                 raise Py42DescriptionLimitExceededError(err)
-            raise
+            else:
+                raise
 
     def get_page(
         self,
@@ -127,6 +128,7 @@ class CasesService(BaseService):
         except Py42BadRequestError as err:
             if u"NO_EDITS_ONCE_CLOSED" in err.response.text:
                 raise Py42UpdateClosedCaseError(err)
-            if u"DESCRIPTION_TOO_LONG" in err.response.text:
+            elif u"DESCRIPTION_TOO_LONG" in err.response.text:
                 raise Py42DescriptionLimitExceededError(err)
-            raise
+            else:
+                raise

--- a/src/py42/services/cases.py
+++ b/src/py42/services/cases.py
@@ -1,5 +1,7 @@
 from py42 import settings
 from py42.exceptions import Py42BadRequestError
+from py42.exceptions import Py42CaseNameExistsError
+from py42.exceptions import Py42DescriptionLimitExceededError
 from py42.exceptions import Py42UpdateClosedCaseError
 from py42.services import BaseService
 from py42.services.util import get_all_pages
@@ -22,7 +24,14 @@ class CasesService(BaseService):
             u"name": name,
             u"subject": subject,
         }
-        return self._connection.post(self._uri_prefix, json=data)
+        try:
+            return self._connection.post(self._uri_prefix, json=data)
+        except Py42BadRequestError as err:
+            if u"NAME_EXISTS" in err.response.text:
+                raise Py42CaseNameExistsError(err, name)
+            if u"DESCRIPTION_TOO_LONG" in err.response.text:
+                raise Py42DescriptionLimitExceededError(err)
+            raise
 
     def get_page(
         self,
@@ -118,4 +127,6 @@ class CasesService(BaseService):
         except Py42BadRequestError as err:
             if u"NO_EDITS_ONCE_CLOSED" in err.response.text:
                 raise Py42UpdateClosedCaseError(err)
+            if u"DESCRIPTION_TOO_LONG" in err.response.text:
+                raise Py42DescriptionLimitExceededError(err)
             raise

--- a/src/py42/services/casesfileevents.py
+++ b/src/py42/services/casesfileevents.py
@@ -1,3 +1,6 @@
+from py42.exceptions import Py42BadRequestError
+from py42.exceptions import Py42CaseAlreadyHasEventError
+from py42.exceptions import Py42UpdateClosedCaseError
 from py42.services import BaseService
 
 
@@ -18,9 +21,16 @@ class CasesFileEventsService(BaseService):
         Returns:
             :class:`py42.response.Py42Response`
         """
-        return self._connection.post(
-            u"{}{}".format(self._uri_prefix.format(case_number), event_id)
-        )
+        try:
+            return self._connection.post(
+                u"{}{}".format(self._uri_prefix.format(case_number), event_id)
+            )
+        except Py42BadRequestError as err:
+            if "CASE_IS_CLOSED" in err.response.text:
+                raise Py42UpdateClosedCaseError(err)
+            if "CASE_ALREADY_HAS_EVENT" in err.response.text:
+                raise Py42CaseAlreadyHasEventError(err)
+            raise
 
     def get(self, case_number, event_id):
         """Gets information of a specified event from the case.
@@ -57,6 +67,11 @@ class CasesFileEventsService(BaseService):
         Returns:
             :class:`py42.response.Py42Response`
         """
-        return self._connection.delete(
-            u"{}{}".format(self._uri_prefix.format(case_number), event_id)
-        )
+        try:
+            return self._connection.delete(
+                u"{}{}".format(self._uri_prefix.format(case_number), event_id)
+            )
+        except Py42BadRequestError as err:
+            if "CASE_IS_CLOSED" in err.response.text:
+                raise Py42UpdateClosedCaseError(err)
+            raise

--- a/src/py42/services/casesfileevents.py
+++ b/src/py42/services/casesfileevents.py
@@ -28,9 +28,10 @@ class CasesFileEventsService(BaseService):
         except Py42BadRequestError as err:
             if "CASE_IS_CLOSED" in err.response.text:
                 raise Py42UpdateClosedCaseError(err)
-            if "CASE_ALREADY_HAS_EVENT" in err.response.text:
+            elif "CASE_ALREADY_HAS_EVENT" in err.response.text:
                 raise Py42CaseAlreadyHasEventError(err)
-            raise
+            else:
+                raise
 
     def get(self, case_number, event_id):
         """Gets information of a specified event from the case.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -241,3 +241,10 @@ def get_file_selection(file_type, file_path, num_files=1, num_dirs=1, num_bytes=
         num_dirs,
         num_bytes,
     )
+
+
+@pytest.fixture
+def mock_error_response(mocker):
+    response = mocker.MagicMock(sepc=Response)
+    response.status_code = 400
+    return response

--- a/tests/services/test_cases.py
+++ b/tests/services/test_cases.py
@@ -293,5 +293,6 @@ class TestCasesService:
     ):
         cases_service = CasesService(mock_connection)
         mock_connection.post.side_effect = Py42BadRequestError(mock_unknown_error)
-        with pytest.raises(Py42BadRequestError):
+        with pytest.raises(Py42BadRequestError) as e:
             cases_service.create("Case")
+        assert e.value.response.status_code == 400

--- a/tests/services/test_cases.py
+++ b/tests/services/test_cases.py
@@ -29,6 +29,7 @@ NAME_EXISTS_ERROR_MSG = """{"problem":"NAME_EXISTS","description":null}"""
 DESCRIPTION_TOO_LONG_ERROR_MSG = (
     """{"problem":"DESCRIPTION_TOO_LONG","description":null}"""
 )
+UNKNOWN_ERROR_MSG = """{"problem":"SURPRISE!"}"""
 _TEST_CASE_NUMBER = 123456
 _BASE_URI = u"/api/v1/case"
 
@@ -57,27 +58,31 @@ class TestCasesService:
         return Py42Response(response)
 
     @pytest.fixture
-    def mock_update_failed_response(self, mocker, http_error):
+    def mock_update_failed_response(self, mock_error_response):
         http_error = HTTPError(UPDATE_ERROR_RESPONSE)
-        http_error.response = mocker.MagicMock(sepc=Response)
-        http_error.response.status_code = 400
+        http_error.response = mock_error_response
         http_error.response.text = UPDATE_ERROR_RESPONSE
         return http_error
 
     @pytest.fixture
-    def mock_description_too_long_response(self, mocker, http_error):
+    def mock_description_too_long_response(self, mock_error_response):
         http_error = HTTPError(DESCRIPTION_TOO_LONG_ERROR_MSG)
-        http_error.response = mocker.MagicMock(sepc=Response)
-        http_error.response.status_code = 400
+        http_error.response = mock_error_response
         http_error.response.text = DESCRIPTION_TOO_LONG_ERROR_MSG
         return http_error
 
     @pytest.fixture
-    def mock_name_exists_response(self, mocker, http_error):
+    def mock_name_exists_response(self, mock_error_response):
         http_error = HTTPError(NAME_EXISTS_ERROR_MSG)
-        http_error.response = mocker.MagicMock(sepc=Response)
-        http_error.response.status_code = 400
+        http_error.response = mock_error_response
         http_error.response.text = NAME_EXISTS_ERROR_MSG
+        return http_error
+
+    @pytest.fixture
+    def mock_unknown_error(self, mock_error_response):
+        http_error = HTTPError(UNKNOWN_ERROR_MSG)
+        http_error.response = mock_error_response
+        http_error.response.text = UNKNOWN_ERROR_MSG
         return http_error
 
     def test_create_called_with_expected_url_and_params(self, mock_connection):
@@ -264,7 +269,7 @@ class TestCasesService:
 
         assert (
             e.value.args[0]
-            == u"Description limit exceeded, max 254 characters allowed."
+            == u"Description limit exceeded, max 250 characters allowed."
         )
 
     def test_update_when_fails_with_description_too_long_error_raises_custom_exception(
@@ -280,5 +285,13 @@ class TestCasesService:
 
         assert (
             e.value.args[0]
-            == u"Description limit exceeded, max 254 characters allowed."
+            == u"Description limit exceeded, max 250 characters allowed."
         )
+
+    def test_create_when_fails_with_unknown_error_raises_custom_exception(
+        self, mock_connection, mock_unknown_error
+    ):
+        cases_service = CasesService(mock_connection)
+        mock_connection.post.side_effect = Py42BadRequestError(mock_unknown_error)
+        with pytest.raises(Py42BadRequestError):
+            cases_service.create("Case")

--- a/tests/services/test_cases.py
+++ b/tests/services/test_cases.py
@@ -6,6 +6,8 @@ from requests import Response
 
 import py42.settings
 from py42.exceptions import Py42BadRequestError
+from py42.exceptions import Py42CaseNameExistsError
+from py42.exceptions import Py42DescriptionLimitExceededError
 from py42.exceptions import Py42UpdateClosedCaseError
 from py42.response import Py42Response
 from py42.services.cases import CasesService
@@ -22,6 +24,11 @@ GET_CASE_RESPONSE = """
 "subject": "string", "subjectUsername": "string",
 "updatedAt": "2021-01-04T08:09:58.832Z"}
 """
+
+NAME_EXISTS_ERROR_MSG = """{"problem":"NAME_EXISTS","description":null}"""
+DESCRIPTION_TOO_LONG_ERROR_MSG = (
+    """{"problem":"DESCRIPTION_TOO_LONG","description":null}"""
+)
 _TEST_CASE_NUMBER = 123456
 _BASE_URI = u"/api/v1/case"
 
@@ -55,6 +62,22 @@ class TestCasesService:
         http_error.response = mocker.MagicMock(sepc=Response)
         http_error.response.status_code = 400
         http_error.response.text = UPDATE_ERROR_RESPONSE
+        return http_error
+
+    @pytest.fixture
+    def mock_description_too_long_response(self, mocker, http_error):
+        http_error = HTTPError(DESCRIPTION_TOO_LONG_ERROR_MSG)
+        http_error.response = mocker.MagicMock(sepc=Response)
+        http_error.response.status_code = 400
+        http_error.response.text = DESCRIPTION_TOO_LONG_ERROR_MSG
+        return http_error
+
+    @pytest.fixture
+    def mock_name_exists_response(self, mocker, http_error):
+        http_error = HTTPError(NAME_EXISTS_ERROR_MSG)
+        http_error.response = mocker.MagicMock(sepc=Response)
+        http_error.response.status_code = 400
+        http_error.response.text = NAME_EXISTS_ERROR_MSG
         return http_error
 
     def test_create_called_with_expected_url_and_params(self, mock_connection):
@@ -213,3 +236,49 @@ class TestCasesService:
             cases_service.update(_TEST_CASE_NUMBER, findings=u"x")
 
         assert e.value.args[0] == u"Cannot update a closed case."
+
+    def test_create_when_fails_with_name_exists_error_raises_custom_exception(
+        self, mock_connection, mock_name_exists_response
+    ):
+        cases_service = CasesService(mock_connection)
+        mock_connection.post.side_effect = Py42BadRequestError(
+            mock_name_exists_response
+        )
+        with pytest.raises(Py42CaseNameExistsError) as e:
+            cases_service.create("Duplicate")
+
+        assert (
+            e.value.args[0]
+            == u"Case name 'Duplicate' already exists, please set another name"
+        )
+
+    def test_create_when_fails_with_description_too_long_error_raises_custom_exception(
+        self, mock_connection, mock_description_too_long_response
+    ):
+        cases_service = CasesService(mock_connection)
+        mock_connection.post.side_effect = Py42BadRequestError(
+            mock_description_too_long_response
+        )
+        with pytest.raises(Py42DescriptionLimitExceededError) as e:
+            cases_service.create("test", description=u"supposedly too long")
+
+        assert (
+            e.value.args[0]
+            == u"Description limit exceeded, max 254 characters allowed."
+        )
+
+    def test_update_when_fails_with_description_too_long_error_raises_custom_exception(
+        self, mock_connection, mock_get_response, mock_description_too_long_response
+    ):
+        cases_service = CasesService(mock_connection)
+        mock_connection.get.return_value = mock_get_response
+        mock_connection.put.side_effect = Py42BadRequestError(
+            mock_description_too_long_response
+        )
+        with pytest.raises(Py42DescriptionLimitExceededError) as e:
+            cases_service.update(_TEST_CASE_NUMBER, description=u"supposedly too long")
+
+        assert (
+            e.value.args[0]
+            == u"Description limit exceeded, max 254 characters allowed."
+        )

--- a/tests/services/test_casesfileevents.py
+++ b/tests/services/test_casesfileevents.py
@@ -103,13 +103,15 @@ class TestCasesFileEventService:
     ):
         case_file_event_service = CasesFileEventsService(mock_connection)
         mock_connection.post.side_effect = Py42BadRequestError(mock_unknown_error)
-        with pytest.raises(Py42BadRequestError):
+        with pytest.raises(Py42BadRequestError) as e:
             case_file_event_service.add(_TEST_CASE_NUMBER, event_id=u"x")
+        assert e.value.response.status_code == 400
 
     def test_delete_when_unknown_error_raises_error(
         self, mock_connection, mock_unknown_error
     ):
         case_file_event_service = CasesFileEventsService(mock_connection)
         mock_connection.post.side_effect = Py42BadRequestError(mock_unknown_error)
-        with pytest.raises(Py42BadRequestError):
+        with pytest.raises(Py42BadRequestError) as e:
             case_file_event_service.add(_TEST_CASE_NUMBER, event_id=u"x")
+        assert e.value.response.status_code == 400


### PR DESCRIPTION
### Description of Change ###

Added custom exceptions for cases:

- Py42CaseNameExistsError: In create case when case name already exists in the system.
- Py42DescriptionLimitExceededError: In create case when description is too long.
- Py42DescriptionLimitExceededError: In update case when description is too long.
- Py42CaseAlreadyHasEventError: When file event is associated multiple times to a case.
- Py42UpdateClosedCaseError: While adding file event to a closed case.
- Py42UpdateClosedCaseError: While deleting file event from a closed case.

### Issues Resolved ###

- closes # INTEG-1456

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test that this change works as intended. What functions should be run? How can testers obtain valid parameters to test those functions? Where in the console can the actions of the functions be verified? -->
```
try:
    sdk.cases.create("Duplicate name")
except Py42CaseNameExistsError as err:
```### PR Checklist ###

Did you remember to do the below?

- [ ] Add unit tests to verify this change 
- [ ] Add an entry to CHANGELOG.md describing this change 
- [ ] Add docstrings for any new public parameters / methods / classes
