### PR TITLE
Integ test adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Changed
 
-- The request header `Content-Type: application/json` is no longer is sent in the situation
-    where there is no request data.
+- The request header `Content-Type: application/json` is no longer sent when there is no
+  request data.
 
 - `sdk.cases.create()` now raises `Py42CaseNameExistsError` when the case name already
   exists in the system.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,28 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ## Unreleased
 
-- `sdk.cases.create()` now raises `Py42CaseNameExistsError` when the case name already exists in the system.
+### Changed
 
-- `sdk.cases.create()` now raises `Py42DescriptionLimitExceededError` when the description is more than 250 charachters.
+- The request header `Content-Type: application/json` is no longer is sent in the situation
+    where there is no request data.
 
-- `sdk.cases.update()` now raises `Py42DescriptionLimitExceededError` when the description is more than 250 charachters.
+- `sdk.cases.create()` now raises `Py42CaseNameExistsError` when the case name already
+  exists in the system.
 
-- `sdk.cases.file_events.add()` now raises `Py42CaseAlreadyHasEventError` when the same event is added to a case more than once.
+- `sdk.cases.create()` now raises `Py42DescriptionLimitExceededError` when the description
+  is more than 250 characters.
 
-- `sdk.cases.file_events.add()` now raises `Py42UpdateClosedCaseError` when the event is added to a closed case.
+- `sdk.cases.update()` now raises `Py42DescriptionLimitExceededError` when the description
+  is more than 250 characters.
 
-- `sdk.cases.file_events.delete()` now raises `Py42UpdateClosedCaseError` when the event is deleted from a closed case.
+- `sdk.cases.file_events.add()` now raises `Py42CaseAlreadyHasEventError` when the same
+  event is added to a case more than once.
+
+- `sdk.cases.file_events.add()` now raises `Py42UpdateClosedCaseError` when the event is
+  added to a closed case.
+
+- `sdk.cases.file_events.delete()` now raises `Py42UpdateClosedCaseError` when the event
+  is deleted from a closed case.
 
 ## 1.11.0 - 2021-01-20
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,12 @@ def test_add_one_and_one_equals_two():
 
 #### Integration tests
 
-Set environment variables C42_USERNAME and C42_PW with CCA credentials. To execute integration tests:
+If not using the mock server, set the environment variables `C42_USER` and `C42_PW`
+with CCA credentials. Otherwise, the integration tests default to using
+`127.0.0.1:4200`, which is the same address that the mock server is set to run on.
+
+To execute integration tests:
+
 ```bash
 $ pytest -m integration
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,7 +158,7 @@ def test_add_one_and_one_equals_two():
 
 If not using the mock server, set the environment variables `C42_HOST`, `C42_USER`,
 and `C42_PW` with CCA credentials. Otherwise, the integration tests default to using
-`127.0.0.1:4200`, which is the same address that the mock server is set to run on.
+`http://127.0.0.1:4200`, which is the same address that the mock server is set to run on.
 
 To execute integration tests:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,8 +156,8 @@ def test_add_one_and_one_equals_two():
 
 #### Integration tests
 
-If not using the mock server, set the environment variables `C42_USER` and `C42_PW`
-with CCA credentials. Otherwise, the integration tests default to using
+If not using the mock server, set the environment variables `C42_HOST`, `C42_USER`,
+and `C42_PW` with CCA credentials. Otherwise, the integration tests default to using
 `127.0.0.1:4200`, which is the same address that the mock server is set to run on.
 
 To execute integration tests:

--- a/src/py42/sdk/queries/alerts/alert_query.py
+++ b/src/py42/sdk/queries/alerts/alert_query.py
@@ -31,13 +31,16 @@ class AlertQuery(BaseQuery):
         groups_string = u",".join(
             str(group_item) for group_item in self._filter_group_list
         )
-        json = u'{{"tenantId": null, "groupClause":"{0}", "groups":[{1}], "pgNum":{2}, "pgSize":{3}, "srtDirection":"{4}", "srtKey":"{5}"}}'.format(
-            self._group_clause,
-            groups_string,
-            self.page_number,
-            self.page_size,
-            self.sort_direction,
-            self.sort_key,
+        json = (
+            u'{{"tenantId": null, "groupClause":"{0}", "groups":[{1}], "pgNum":{2}, '
+            u'"pgSize":{3}, "srtDirection":"{4}", "srtKey":"{5}"}}'.format(
+                self._group_clause,
+                groups_string,
+                self.page_number,
+                self.page_size,
+                self.sort_direction,
+                self.sort_key,
+            )
         )
         return json
 

--- a/src/py42/services/_connection.py
+++ b/src/py42/services/_connection.py
@@ -27,7 +27,6 @@ ROOT_SESSION.mount(u"https://", SESSION_ADAPTER)
 ROOT_SESSION.mount(u"http://", SESSION_ADAPTER)
 ROOT_SESSION.headers = {
     u"Accept": u"application/json",
-    u"Content-Type": u"application/json",
     u"Accept-Encoding": u"gzip, deflate",
     u"Connection": u"keep-alive",
 }
@@ -228,9 +227,7 @@ class Connection(object):
         if json is not None:
             data = json_lib.dumps(json)
 
-        user_headers = {u"User-Agent": settings.get_user_agent_string()}
-        if headers:
-            user_headers.update(headers)
+        user_headers = _create_user_headers(headers, data)
         self._headers.update(user_headers)
         request = Request(
             method=method,
@@ -261,6 +258,16 @@ class Connection(object):
         parsed_host = urlparse(host)
         self._headers[u"Host"] = parsed_host.netloc
         self._host_address = host
+
+
+def _create_user_headers(headers, data):
+    user_headers = {u"User-Agent": settings.get_user_agent_string()}
+    if headers:
+        user_headers.update(headers)
+    if data:
+        content_header = {u"Content-Type": u"application/json"}
+        user_headers.update(content_header)
+    return user_headers
 
 
 def _handle_error(method, url, response):

--- a/src/py42/services/alertrules.py
+++ b/src/py42/services/alertrules.py
@@ -7,6 +7,7 @@ from py42.services import BaseService
 
 class AlertRulesService(BaseService):
     """A service to manage Alert Rules."""
+
     _api_prefix = u"/svc/api/v1/Rules/"
 
     def __init__(self, connection, user_context, user_profile_service):

--- a/src/py42/services/alertrules.py
+++ b/src/py42/services/alertrules.py
@@ -7,10 +7,7 @@ from py42.services import BaseService
 
 class AlertRulesService(BaseService):
     """A service to manage Alert Rules."""
-
-    _version = u"v1"
-    _resource = u"Rules/"
-    _api_prefix = u"/svc/api/{}/{}".format(_version, _resource)
+    _api_prefix = u"/svc/api/v1/Rules/"
 
     def __init__(self, connection, user_context, user_profile_service):
         super(AlertRulesService, self).__init__(connection)
@@ -79,10 +76,7 @@ class AlertRulesService(BaseService):
 
 
 class CloudShareService(BaseService):
-
-    _version = u"v1"
-    _resource = u"query-cloud-share-permissions-rule"
-    _api_prefix = u"/svc/api/{}/Rules/{}".format(_version, _resource)
+    _endpoint = u"/svc/api/v1/Rules/query-cloud-share-permissions-rule"
 
     def __init__(self, connection, tenant_id):
         super(CloudShareService, self).__init__(connection)
@@ -98,14 +92,11 @@ class CloudShareService(BaseService):
             :class:`py42.response.Py42Response`
         """
         data = {u"tenantId": self._tenant_id, u"ruleIds": [rule_id]}
-        return self._connection.post(self._api_prefix, json=data)
+        return self._connection.post(self._endpoint, json=data)
 
 
 class ExfiltrationService(BaseService):
-
-    _version = u"v1"
-    _resource = u"query-endpoint-exfiltration-rule"
-    _api_prefix = u"/svc/api/{}/Rules/{}".format(_version, _resource)
+    _endpoint = u"/svc/api/v1/Rules/query-endpoint-exfiltration-rule"
 
     def __init__(self, connection, tenant_id):
         super(ExfiltrationService, self).__init__(connection)
@@ -121,14 +112,11 @@ class ExfiltrationService(BaseService):
             :class:`py42.response.Py42Response`
         """
         data = {u"tenantId": self._tenant_id, u"ruleIds": [rule_id]}
-        return self._connection.post(self._api_prefix, json=data)
+        return self._connection.post(self._endpoint, json=data)
 
 
 class FileTypeMismatchService(BaseService):
-
-    _version = u"v1"
-    _resource = u"query-file-type-mismatch-rule"
-    _api_prefix = u"/svc/api/{}/Rules/{}".format(_version, _resource)
+    _endpoint = u"/svc/api/v1/Rules/query-file-type-mismatch-rule"
 
     def __init__(self, connection, tenant_id):
         super(FileTypeMismatchService, self).__init__(connection)
@@ -144,4 +132,4 @@ class FileTypeMismatchService(BaseService):
             :class:`py42.response.Py42Response`
         """
         data = {u"tenantId": self._tenant_id, u"ruleIds": [rule_id]}
-        return self._connection.post(self._api_prefix, json=data)
+        return self._connection.post(self._endpoint, json=data)

--- a/src/py42/services/users.py
+++ b/src/py42/services/users.py
@@ -90,7 +90,7 @@ class UserService(BaseService):
         `REST Documentation <https://console.us.code42.com/apidocviewer/#User-get>`__
 
         Args:
-            username (str): A username for a user.
+            username (str or unicode): A username for a user.
 
         Returns:
             :class:`py42.response.Py42Response`: A response containing the user.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -42,7 +42,9 @@ def observer_id(request):
 
 @pytest.fixture(scope="session")
 def connection(host):
-    return _sdk.from_local_account(host, os.environ["C42_USER"], os.environ["C42_PW"])
+    user = os.environ.get("C42_USER") or "test.user@example.com"
+    pw = os.environ.get("C42_PW") or "password"
+    return _sdk.from_local_account(host, user, pw)
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,7 +8,7 @@ import py42.sdk as _sdk
 
 # pytest plugin method
 def pytest_addoption(parser):
-    parser.addini("host_url", "Application/enviroment to connect to.")
+    parser.addini("host_url", "Application/environment to connect to.")
     parser.addini("alert_id", "Alert id that exists in the system.")
     parser.addini("device_id", "Device id that exists in the system.")
     parser.addini("observer_rule_id", "Observer rule id.")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -86,3 +86,7 @@ def new_user(connection, org, timestamp):
 def device(request, connection):
     device_id = request.config.getini("device_id")
     return connection.devices.get_by_id(device_id)
+
+
+def assert_successful_response(response):
+    assert 200 <= response.status_code < 300

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,7 +8,6 @@ from py42.util import convert_datetime_to_epoch
 
 
 def pytest_addoption(parser):
-    parser.addini("host_url", "Application/environment to connect to.")
     parser.addini("alert_id", "Alert id that exists in the system.")
     parser.addini("device_id", "Device id that exists in the system.")
     parser.addini("observer_rule_id", "Observer rule id.")
@@ -26,11 +25,6 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture(scope="session")
-def host(request):
-    return request.config.getini("host_url")
-
-
-@pytest.fixture(scope="session")
 def alert_id(request):
     return request.config.getini("alert_id")
 
@@ -41,7 +35,8 @@ def observer_id(request):
 
 
 @pytest.fixture(scope="session")
-def connection(host):
+def connection():
+    host = os.environ.get("C42_HOST") or "127.0.0.1:4200"
     user = os.environ.get("C42_USER") or "test.user@example.com"
     pw = os.environ.get("C42_PW") or "password"
     return _get_sdk(host, user, pw)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,6 +6,7 @@ import pytest
 import py42.sdk as _sdk
 
 
+# pytest plugin method
 def pytest_addoption(parser):
     parser.addini("host_url", "Application/enviroment to connect to.")
     parser.addini("alert_id", "Alert id that exists in the system.")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,9 +4,9 @@ from datetime import datetime
 import pytest
 
 import py42.sdk as _sdk
+from py42.util import convert_datetime_to_epoch
 
 
-# pytest plugin method
 def pytest_addoption(parser):
     parser.addini("host_url", "Application/environment to connect to.")
     parser.addini("alert_id", "Alert id that exists in the system.")
@@ -49,7 +49,7 @@ def connection(host):
 
 @pytest.fixture(scope="session")
 def timestamp():
-    return str(int(datetime.utcnow().timestamp()))
+    return convert_datetime_to_epoch(datetime.utcnow())
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -36,7 +36,7 @@ def observer_id(request):
 
 @pytest.fixture(scope="session")
 def connection():
-    host = os.environ.get("C42_HOST") or "127.0.0.1:4200"
+    host = os.environ.get("C42_HOST") or "http://127.0.0.1:4200"
     user = os.environ.get("C42_USER") or "test.user@example.com"
     pw = os.environ.get("C42_PW") or "password"
     return _get_sdk(host, user, pw)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -44,7 +44,17 @@ def observer_id(request):
 def connection(host):
     user = os.environ.get("C42_USER") or "test.user@example.com"
     pw = os.environ.get("C42_PW") or "password"
-    return _sdk.from_local_account(host, user, pw)
+    return _get_sdk(host, user, pw)
+
+
+def _get_sdk(host, user, pw):
+    try:
+        return _sdk.from_local_account(host, user, pw)
+    except Exception as err:
+        pytest.exit(
+            "Failed to init SDK for integration tests: {}".format(str(err)),
+            returncode=1,
+        )
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_alertrules.py
+++ b/tests/integration/test_alertrules.py
@@ -1,5 +1,4 @@
 import pytest
-
 from tests.integration.conftest import assert_successful_response
 
 

--- a/tests/integration/test_alertrules.py
+++ b/tests/integration/test_alertrules.py
@@ -1,5 +1,7 @@
 import pytest
 
+from tests.integration.conftest import assert_successful_response
+
 
 @pytest.fixture(scope="module")
 def rule_id(connection, observer_id):
@@ -11,44 +13,44 @@ def rule_id(connection, observer_id):
 class TestAlertRules:
     def test_rules_add_user(self, connection, new_user, observer_id):
         response = connection.alerts.rules.add_user(observer_id, new_user["userUid"])
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_rules_get_all(self, connection):
         response_gen = connection.alerts.rules.get_all()
         for response in response_gen:
-            assert response.status_code == 200
+            assert_successful_response(response)
             break
 
     def test_rules_get_by_observer_id(self, connection, observer_id):
         response = connection.alerts.rules.get_by_observer_id(observer_id)
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_rules_get_all_by_name(self, connection):
         response_gen = connection.alerts.rules.get_all_by_name("Test Alerts using CLI")
         for response in response_gen:
-            assert response.status_code == 200
+            assert_successful_response(response)
             break
 
     def test_rules_get_page(self, connection):
         response = connection.alerts.rules.get_page()
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_rules_remove_user(self, connection, new_user, observer_id):
         response = connection.alerts.rules.remove_user(observer_id, new_user["userId"])
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_rules_remove_all_users(self, connection, observer_id):
         response = connection.alerts.rules.remove_all_users(observer_id)
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_rules_exfiltration_get(self, connection, rule_id):
         response = connection.alerts.rules.exfiltration.get(rule_id)
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_rules_cloudshare_get(self, connection, rule_id):
         response = connection.alerts.rules.cloudshare.get(rule_id)
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_file_type_mismatch_get(self, connection, rule_id):
         response = connection.alerts.rules.filetypemismatch.get(rule_id)
-        assert response.status_code == 200
+        assert_successful_response(response)

--- a/tests/integration/test_alerts.py
+++ b/tests/integration/test_alerts.py
@@ -1,9 +1,9 @@
 import pytest
+from tests.integration.conftest import assert_successful_response
 
 from py42.sdk.queries.alerts.alert_query import AlertQuery
 from py42.sdk.queries.alerts.filters import AlertState
 from py42.sdk.queries.alerts.filters import Severity
-from tests.integration.conftest import assert_successful_response
 
 
 @pytest.mark.integration

--- a/tests/integration/test_alerts.py
+++ b/tests/integration/test_alerts.py
@@ -3,6 +3,7 @@ import pytest
 from py42.sdk.queries.alerts.alert_query import AlertQuery
 from py42.sdk.queries.alerts.filters import AlertState
 from py42.sdk.queries.alerts.filters import Severity
+from tests.integration.conftest import assert_successful_response
 
 
 @pytest.mark.integration
@@ -13,22 +14,22 @@ def test_search(connection):
     ]
     alert_query = AlertQuery(*filters)
     response = connection.alerts.search(alert_query)
-    assert response.status_code == 200
+    assert_successful_response(response)
 
 
 @pytest.mark.integration
 def test_get_details(connection, alert_id):
     response = connection.alerts.get_details(alert_id)
-    assert response.status_code == 200
+    assert_successful_response(response)
 
 
 @pytest.mark.integration
 def test_resolve(connection, alert_id):
     response = connection.alerts.resolve(alert_id)
-    assert response.status_code == 200
+    assert_successful_response(response)
 
 
 @pytest.mark.integration
 def test_reopen(connection, alert_id):
     response = connection.alerts.reopen(alert_id)
-    assert response.status_code == 200
+    assert_successful_response(response)

--- a/tests/integration/test_archive.py
+++ b/tests/integration/test_archive.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import pytest
 
 from py42.exceptions import Py42ForbiddenError
+from tests.integration.conftest import assert_successful_response
 
 
 @pytest.fixture
@@ -34,52 +35,53 @@ def device(connection, device_guid):
 class TestArchive:
     def test_get_all_by_device_guid(self, connection, device):
         for response in connection.archive.get_all_by_device_guid(device["computerId"]):
-            assert response.status_code == 200
+            assert_successful_response(response)
             break
 
     def test_get_all_device_restore_history(self, connection, device):
         for response in connection.archive.get_all_device_restore_history(
             1, device["computerId"]
         ):
-            assert response.status_code == 200
+            assert_successful_response(response)
             break
 
     def test_get_all_org_cold_storage_archives(self, connection, device):
         for response in connection.archive.get_all_org_cold_storage_archives(
             device["orgId"]
         ):
-            assert response.status_code == 200
+            assert_successful_response(response)
             break
 
     def test_get_all_org_restore_history(self, connection, device):
         for response in connection.archive.get_all_org_restore_history(
             1, device["orgId"]
         ):
-            assert response.status_code == 200
+            assert_successful_response(response)
             break
 
     def test_get_all_user_restore_history(self, connection, device):
         for response in connection.archive.get_all_user_restore_history(
             1, device["userId"]
         ):
-            assert response.status_code == 200
+            assert_successful_response(response)
             break
 
     def test_get_backup_sets(self, connection, device_guid, destination_device_guid):
         response = connection.archive.get_backup_sets(
             device_guid, destination_device_guid
         )
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_get_by_archive_guid(self, connection, archive_guid):
         response = connection.archive.get_by_archive_guid(archive_guid)
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_stream_from_backup(self, connection, device_guid, path):
         response = connection.archive.stream_from_backup(path, device_guid)
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_update_cold_storage_purge_date(self, connection, archive_guid):
         purge_date = datetime.now().strftime("%Y-%m-%d")
         with pytest.raises(Py42ForbiddenError):
-            connection.archive.update_cold_storage_purge_date(archive_guid, purge_date)
+            response = connection.archive.update_cold_storage_purge_date(archive_guid, purge_date)
+            assert_successful_response(response)

--- a/tests/integration/test_archive.py
+++ b/tests/integration/test_archive.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 
 import pytest
+from tests.integration.conftest import assert_successful_response
 
 from py42.exceptions import Py42ForbiddenError
-from tests.integration.conftest import assert_successful_response
 
 
 @pytest.fixture
@@ -83,5 +83,7 @@ class TestArchive:
     def test_update_cold_storage_purge_date(self, connection, archive_guid):
         purge_date = datetime.now().strftime("%Y-%m-%d")
         with pytest.raises(Py42ForbiddenError):
-            response = connection.archive.update_cold_storage_purge_date(archive_guid, purge_date)
+            response = connection.archive.update_cold_storage_purge_date(
+                archive_guid, purge_date
+            )
             assert_successful_response(response)

--- a/tests/integration/test_cases.py
+++ b/tests/integration/test_cases.py
@@ -1,5 +1,4 @@
 import pytest
-
 from tests.integration.conftest import assert_successful_response
 
 

--- a/tests/integration/test_cases.py
+++ b/tests/integration/test_cases.py
@@ -1,5 +1,7 @@
 import pytest
 
+from tests.integration.conftest import assert_successful_response
+
 
 @pytest.mark.integration
 class TestCases:
@@ -12,35 +14,35 @@ class TestCases:
     ):
         page_gen = connection.cases.get_all()
         for response in page_gen:
-            assert response.status_code == 200
+            assert_successful_response(response)
             break
 
     def test_get_case_by_case_number(self, connection, case):
         response = connection.cases.get(case["number"])
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_update_case(self, connection, case):
         response = connection.cases.update(
             case["number"], findings="integration test case"
         )
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_export_summary(self, connection, case):
         response = connection.cases.export_summary(case["number"])
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_add_file_event(self, connection, case, event_id):
         response = connection.cases.file_events.add(case["number"], event_id)
-        assert response.status_code == 204
+        assert_successful_response(response)
 
     def test_get_file_event(self, connection, case, event_id):
         response = connection.cases.file_events.get(case["number"], event_id)
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_delete_file_event(self, connection, case, event_id):
         response = connection.cases.file_events.delete(case["number"], event_id)
-        assert response.status_code == 204
+        assert_successful_response(response)
 
     def test_get_all_file_events(self, connection, case):
         response = connection.cases.file_events.get_all(case["number"])
-        assert response.status_code == 200
+        assert_successful_response(response)

--- a/tests/integration/test_detectionlists.py
+++ b/tests/integration/test_detectionlists.py
@@ -2,9 +2,9 @@ from datetime import datetime
 from datetime import timedelta
 
 import pytest
+from tests.integration.conftest import assert_successful_response
 
 from py42.clients.detectionlists import RiskTags
-from tests.integration.conftest import assert_successful_response
 
 alias_user = "test_user@test.com"
 user_departure_date = datetime.now() + timedelta(days=10)

--- a/tests/integration/test_detectionlists.py
+++ b/tests/integration/test_detectionlists.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import pytest
 
 from py42.clients.detectionlists import RiskTags
+from tests.integration.conftest import assert_successful_response
 
 alias_user = "test_user@test.com"
 user_departure_date = datetime.now() + timedelta(days=10)
@@ -19,110 +20,110 @@ class TestDetectionLists:
     def test_create_user(self, connection, new_user):
         username = new_user["username"]
         response = connection.detectionlists.create_user(username)
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_get_user_by_id(self, connection, new_user):
         response = connection.detectionlists.get_user_by_id(new_user["userUid"])
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_get_user(self, connection, new_user):
         response = connection.detectionlists.get_user(new_user["username"])
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_refresh_user_scim_attributes(self, connection, new_user):
         response = connection.detectionlists.refresh_user_scim_attributes(
             new_user["userUid"]
         )
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_departing_employee_get_page(self, connection):
         response = connection.detectionlists.departing_employee.get_page(1)
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_departing_employee_get_all(self, connection):
         response_gen = connection.detectionlists.departing_employee.get_all()
         for response in response_gen:
-            assert response.status_code == 200
+            assert_successful_response(response)
             break
 
     def test_high_risk_employee_get_all(self, connection):
         response_gen = connection.detectionlists.high_risk_employee.get_all()
         for response in response_gen:
-            assert response.status_code == 200
+            assert_successful_response(response)
             break
 
     def test_add_user_cloud_alias(self, connection, new_user):
         response = connection.detectionlists.add_user_cloud_alias(
             new_user["userUid"], alias_user
         )
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_remove_user_cloud_alias(self, connection, new_user):
         response = connection.detectionlists.remove_user_cloud_alias(
             new_user["userUid"], alias_user
         )
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_departing_employee_add(self, connection, new_user):
         response = connection.detectionlists.departing_employee.add(new_user["userUid"])
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_departing_employee_get(self, connection, new_user):
         response = connection.detectionlists.departing_employee.get(new_user["userUid"])
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_departing_employee_update_departure_date(self, connection, new_user):
         response = connection.detectionlists.departing_employee.update_departure_date(
             new_user["userUid"], user_departure_date
         )
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_add_user_risk_tags(self, connection, new_user):
         response = connection.detectionlists.add_user_risk_tags(
             new_user["userUid"], RiskTags.FLIGHT_RISK
         )
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_remove_user_risk_tags(self, connection, new_user):
         response = connection.detectionlists.remove_user_risk_tags(
             new_user["userUid"], RiskTags.FLIGHT_RISK
         )
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_update_user_notes(self, connection, new_user):
         response = connection.detectionlists.update_user_notes(
             new_user["userUid"], "integration test"
         )
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_departing_employee_remove(self, connection, new_user):
         response = connection.detectionlists.departing_employee.remove(
             new_user["userUid"]
         )
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_departing_employee_set_alerts_enabled(self, connection):
         response = connection.detectionlists.departing_employee.set_alerts_enabled()
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_high_risk_employee_add(self, connection, new_user):
         response = connection.detectionlists.high_risk_employee.add(new_user["userUid"])
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_high_risk_employee_get(self, connection, new_user):
         response = connection.detectionlists.high_risk_employee.get(new_user["userUid"])
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_high_risk_employee_remove(self, connection, new_user):
         response = connection.detectionlists.high_risk_employee.remove(
             new_user["userUid"]
         )
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_high_risk_employee_get_page(self, connection):
         response = connection.detectionlists.departing_employee.get_page(1)
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_high_risk_employee_set_alerts_enabled(self, connection):
         response = connection.detectionlists.high_risk_employee.set_alerts_enabled()
-        assert response.status_code == 200
+        assert_successful_response(response)

--- a/tests/integration/test_devices.py
+++ b/tests/integration/test_devices.py
@@ -1,5 +1,4 @@
 import pytest
-
 from tests.integration.conftest import assert_successful_response
 
 

--- a/tests/integration/test_devices.py
+++ b/tests/integration/test_devices.py
@@ -1,16 +1,18 @@
 import pytest
 
+from tests.integration.conftest import assert_successful_response
+
 
 @pytest.mark.integration
 class TestDevices:
     @pytest.mark.skip("Skip special case.")
     def test_get_agent_full_disk_access_state(self, connection, device):
         response = connection.devices.get_agent_full_disk_access_state(device["guid"])
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_get_by_guid(self, connection, device):
         response = connection.devices.get_by_guid(device["guid"])
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_get_settings(self, connection, device):
         response = connection.devices.get_settings(device["guid"])
@@ -18,39 +20,39 @@ class TestDevices:
 
     def test_deactivate(self, connection, device):
         response = connection.devices.deactivate(device["computerId"])
-        assert response.status_code == 204
+        assert_successful_response(response)
 
     @pytest.mark.skip("Skip special case.")
     def test_get_agent_state(self, connection, device):
         response = connection.devices.get_agent_state(device["guid"], "fullDiskAccess")
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_get_by_id(self, connection, device):
         response = connection.devices.get_by_id(device["computerId"])
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_deauthorize(self, connection, device):
         response = connection.devices.deauthorize(device["computerId"])
-        assert response.status_code == 204
+        assert_successful_response(response)
 
     def test_reactivate(self, connection, device):
         response = connection.devices.reactivate(device["computerId"])
-        assert response.status_code == 204
+        assert_successful_response(response)
 
     def test_get_all(self, connection, device):
         response_gen = connection.devices.get_all()
         for response in response_gen:
-            assert response.status_code == 200
+            assert_successful_response(response)
             break
 
     def test_get_page(self, connection, device):
         response = connection.devices.get_page(1)
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_block(self, connection, device):
         response = connection.devices.block(device["computerId"])
-        assert response.status_code == 201
+        assert_successful_response(response)
 
     def test_unblock(self, connection, device):
         response = connection.devices.unblock(device["computerId"])
-        assert response.status_code == 204
+        assert_successful_response(response)

--- a/tests/integration/test_legalhold.py
+++ b/tests/integration/test_legalhold.py
@@ -1,5 +1,4 @@
 import pytest
-
 from tests.integration.conftest import assert_successful_response
 
 

--- a/tests/integration/test_legalhold.py
+++ b/tests/integration/test_legalhold.py
@@ -1,11 +1,13 @@
 import pytest
 
+from tests.integration.conftest import assert_successful_response
+
 
 @pytest.fixture(scope="module")
 def policy(connection, timestamp):
     policy_name = "integration test policy {}".format(timestamp)
     response = connection.legalhold.create_policy(policy_name)
-    assert response.status_code == 200
+    assert_successful_response(response)
     return response["legalHoldPolicyUid"]
 
 
@@ -13,14 +15,14 @@ def policy(connection, timestamp):
 def matter(connection, policy, timestamp):
     matter_name = "integration test matter {}".format(timestamp)
     response = connection.legalhold.create_matter(matter_name, policy)
-    assert response.status_code == 201
+    assert_successful_response(response)
     return response["legalHoldUid"]
 
 
 @pytest.fixture
 def membership(connection, matter, new_user):
     response = connection.legalhold.add_to_matter(new_user["userUid"], matter)
-    assert response.status_code == 201
+    assert_successful_response(response)
     return response["legalHoldMembershipUid"]
 
 
@@ -28,46 +30,46 @@ def membership(connection, matter, new_user):
 class TestLegalhold:
     def test_get_policy_by_uid(self, connection, policy):
         response = connection.legalhold.get_policy_by_uid(policy)
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_get_policy_list(self, connection):
         response = connection.legalhold.get_policy_list()
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_get_all_matter_custodians(self, connection, policy, matter):
         response_gen = connection.legalhold.get_all_matter_custodians(policy, matter)
         for response in response_gen:
-            assert response.status_code == 200
+            assert_successful_response(response)
             break
 
     def test_get_matters_page(self, connection):
         response = connection.legalhold.get_matters_page(1)
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_remove_from_matter(self, connection, membership):
         response = connection.legalhold.remove_from_matter(membership)
-        assert response.status_code == 204
+        assert_successful_response(response)
 
     def test_get_all_matters(self, connection):
         response_gen = connection.legalhold.get_all_matters()
         for response in response_gen:
-            assert response.status_code == 200
+            assert_successful_response(response)
             break
 
     def test_get_custodians_page(self, connection, membership):
         response = connection.legalhold.get_custodians_page(
             1, legal_hold_membership_uid=membership
         )
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_deactivate_matter(self, connection, matter):
         response = connection.legalhold.deactivate_matter(matter)
-        assert response.status_code == 204
+        assert_successful_response(response)
 
     def test_get_matter_by_uid(self, connection, matter):
         response = connection.legalhold.get_matter_by_uid(matter)
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_reactivate_matter(self, connection, matter):
         response = connection.legalhold.reactivate_matter(matter)
-        assert response.status_code == 201
+        assert_successful_response(response)

--- a/tests/integration/test_orgs.py
+++ b/tests/integration/test_orgs.py
@@ -1,50 +1,52 @@
 import pytest
 
+from tests.integration.conftest import assert_successful_response
+
 
 @pytest.mark.integration
 class TestOrg:
     def test_get_agent_full_disk_access_states(self, connection, org):
         response = connection.orgs.get_agent_full_disk_access_states(org["orgId"])
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_get_by_id(self, connection, org):
         response = connection.orgs.get_by_id(org["orgId"])
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_get_page(self, connection):
         response = connection.orgs.get_page(1)
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_get_agent_state(self, connection, org):
         response = connection.orgs.get_agent_state(org["orgId"], "fullDiskAccess")
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_get_by_uid(self, connection, org):
         response = connection.orgs.get_by_uid(org["orgUid"])
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     @pytest.mark.skip("Fails when whole test suite is executed.")
     def test_deactivate(self, connection, org):
         response = connection.orgs.deactivate(org["orgId"])
-        assert response.status_code == 201
+        assert_successful_response(response)
 
     def test_reactivate(self, connection, org):
         response = connection.orgs.reactivate(org["orgId"])
-        assert response.status_code == 204
+        assert_successful_response(response)
 
     def test_get_all(self, connection):
         response_gen = connection.orgs.get_all()
         for response in response_gen:
-            assert response.status_code == 200
+            assert_successful_response(response)
 
     def test_get_current(self, connection):
         response = connection.orgs.get_current()
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_block(self, connection, org):
         response = connection.orgs.block(org["orgId"])
-        assert response.status_code == 201
+        assert_successful_response(response)
 
     def test_unblock(self, connection, org):
         response = connection.orgs.unblock(org["orgId"])
-        assert response.status_code == 204
+        assert_successful_response(response)

--- a/tests/integration/test_orgs.py
+++ b/tests/integration/test_orgs.py
@@ -1,5 +1,4 @@
 import pytest
-
 from tests.integration.conftest import assert_successful_response
 
 

--- a/tests/integration/test_securitydata.py
+++ b/tests/integration/test_securitydata.py
@@ -5,6 +5,7 @@ import pytest
 
 from py42.sdk.queries.fileevents.file_event_query import FileEventQuery
 from py42.sdk.queries.fileevents.filters import EventTimestamp
+from tests.integration.conftest import assert_successful_response
 
 
 @pytest.fixture(scope="module")
@@ -38,13 +39,13 @@ class TestSecurityData:
     def test_get_all_plan_security_events(self, connection, plan_info):
         response_gen = connection.securitydata.get_all_plan_security_events(plan_info)
         for response in response_gen:
-            assert response[0].status_code == 200
+            assert_successful_response(response)
             break
 
     def test_get_all_user_security_events(self, connection, user_uid):
         response_gen = connection.securitydata.get_all_user_security_events(user_uid)
         for response in response_gen:
-            assert response[0].status_code == 200
+            assert_successful_response(response)
             break
 
     def test_search_file_events(self, connection):
@@ -55,7 +56,7 @@ class TestSecurityData:
         )
         query = FileEventQuery.all(date_query)
         response = connection.securitydata.search_file_events(query)
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_stream_file_by_md5(self, connection, md5_hash, file_data):
         response = connection.securitydata.stream_file_by_md5(md5_hash)

--- a/tests/integration/test_securitydata.py
+++ b/tests/integration/test_securitydata.py
@@ -2,10 +2,10 @@ from datetime import datetime
 from datetime import timedelta
 
 import pytest
+from tests.integration.conftest import assert_successful_response
 
 from py42.sdk.queries.fileevents.file_event_query import FileEventQuery
 from py42.sdk.queries.fileevents.filters import EventTimestamp
-from tests.integration.conftest import assert_successful_response
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_serveradmin.py
+++ b/tests/integration/test_serveradmin.py
@@ -1,18 +1,20 @@
 import pytest
 
+from tests.integration.conftest import assert_successful_response
+
 
 @pytest.mark.integration
 class TestServerAdmin:
     @pytest.mark.skip("Requires on prem connection.")
     def test_get_alert_log(self, connection):
         response = connection.serveradmin.get_alert_log()
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_get_current_tenant(self, connection):
         response = connection.serveradmin.get_current_tenant()
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     @pytest.mark.skip("Requires on prem connection..")
     def test_get_diagnostics(self, connection):
         response = connection.serveradmin.get_diagnostics()
-        assert response.status_code == 200
+        assert_successful_response(response)

--- a/tests/integration/test_serveradmin.py
+++ b/tests/integration/test_serveradmin.py
@@ -1,5 +1,4 @@
 import pytest
-
 from tests.integration.conftest import assert_successful_response
 
 

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -1,5 +1,7 @@
 import pytest
 
+from tests.integration.conftest import assert_successful_response
+
 role = "Desktop User"
 
 
@@ -7,68 +9,68 @@ role = "Desktop User"
 class TestUser:
     def test_add_role(self, connection, new_user):
         response = connection.users.add_role(new_user["userId"], role)
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_get_by_uid(self, connection, new_user):
         response = connection.users.get_by_uid(new_user["userUid"])
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_get_roles(self, connection, new_user):
         response = connection.users.get_roles(new_user["userId"])
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_unblock(self, connection, new_user):
         response = connection.users.unblock(new_user["userId"])
-        assert response.status_code == 204
+        assert_successful_response(response)
 
     def test_block(self, connection, new_user):
         response = connection.users.block(new_user["userId"])
-        assert response.status_code == 201
+        assert_successful_response(response)
 
     def test_get_all(self, connection):
         response_gen = connection.users.get_all()
         for response in response_gen:
-            assert response.status_code == 200
+            assert_successful_response(response)
 
     def test_get_by_username(self, connection, new_user):
         response = connection.users.get_by_username(new_user["username"])
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_get_scim_data_by_uid(self, connection, new_user):
         response = connection.users.get_scim_data_by_uid(new_user["userUid"])
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_change_org_assignment(self, connection, new_user, org):
         response = connection.users.change_org_assignment(
             new_user["userId"], org["parentOrgId"]
         )
-        assert response.status_code == 204
+        assert_successful_response(response)
 
     def test_get_available_roles(self, connection):
         response = connection.users.get_available_roles()
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_get_current(self, connection):
         response = connection.users.get_current()
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     @pytest.mark.skip("Fails when whole test suite is executed.")
     def test_deactivate(self, connection, new_user):
         response = connection.users.deactivate(new_user["userId"])
-        assert response.status_code == 201
+        assert_successful_response(response)
 
     def test_reactivate(self, connection, new_user):
         response = connection.users.get_roles(new_user["userId"])
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_get_by_id(self, connection, new_user):
         response = connection.users.get_by_id(new_user["userId"])
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_get_page(self, connection):
         response = connection.users.get_page(1)
-        assert response.status_code == 200
+        assert_successful_response(response)
 
     def test_remove_role(self, connection, new_user):
         response = connection.users.remove_role(new_user["userId"], role)
-        assert response.status_code == 204
+        assert_successful_response(response)

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -1,5 +1,4 @@
 import pytest
-
 from tests.integration.conftest import assert_successful_response
 
 role = "Desktop User"

--- a/tests/services/alertrules/test_cloudshare.py
+++ b/tests/services/alertrules/test_cloudshare.py
@@ -6,7 +6,7 @@ class TestCloudShareClient(object):
         self, mock_connection
     ):
         alert_rule_client = CloudShareService(mock_connection, u"tenant-id")
-        alert_rule_client.get(u"rule-id")
+        alert_rule_client.get("rule-id")
         url = mock_connection.post.call_args[0][0]
         assert url == "/svc/api/v1/Rules/query-cloud-share-permissions-rule"
         posted_data = mock_connection.post.call_args[1]["json"]

--- a/tests/services/alertrules/test_file_type_mismatch.py
+++ b/tests/services/alertrules/test_file_type_mismatch.py
@@ -6,7 +6,7 @@ class TestFileTypeMisMatchClient(object):
         self, mock_connection
     ):
         alert_rule_client = FileTypeMismatchService(mock_connection, u"tenant-id")
-        alert_rule_client.get(u"rule-id")
+        alert_rule_client.get("rule-id")
         url = mock_connection.post.call_args[0][0]
         assert url == "/svc/api/v1/Rules/query-file-type-mismatch-rule"
         posted_data = mock_connection.post.call_args[1]["json"]

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -307,3 +307,19 @@ class TestConnection(object):
         connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
         with pytest.raises(Py42Error):
             connection.get(URL)
+
+    def test_connection_request_when_no_data_does_not_include_content_type_header(
+        self, mock_host_resolver, mock_auth, success_requests_session
+    ):
+        connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
+        connection.put(URL)
+        request = success_requests_session.prepare_request.call_args[0][0]
+        assert request.headers.get("Content-Type") is None
+
+    def test_connection_request_when_has_data_includes_content_type_header(
+        self, mock_host_resolver, mock_auth, success_requests_session
+    ):
+        connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
+        connection.put(URL, data='{"foo":"bar"}')
+        request = success_requests_session.prepare_request.call_args[0][0]
+        assert request.headers["Content-Type"] == "application/json"

--- a/tests/services/test_users.py
+++ b/tests/services/test_users.py
@@ -12,7 +12,6 @@ from py42.services.users import UserService
 
 
 USER_URI = "/api/User"
-
 DEFAULT_GET_ALL_PARAMS = {
     "active": None,
     "email": None,
@@ -22,13 +21,9 @@ DEFAULT_GET_ALL_PARAMS = {
     "pgSize": 500,
     "q": None,
 }
-
 MOCK_GET_USER_RESPONSE = """{"totalCount": 3000, "users": ["foo"]}"""
-
 MOCK_EMPTY_GET_USER_RESPONSE = """{"totalCount": 3000, "users": []}"""
-
 MOCK_text = '{"item_list_key": [{"foo": "foo_val"}, {"bar": "bar_val"}]}'
-
 MOCK_ERROR_text = '{"body": "USER_DUPLICATE"}'
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,6 @@ commands = pre-commit run --all-files --show-diff-on-failure
 [pytest]
 markers =
     integration: mark test as a integration test
-host_url = http://127.0.0.1:4200
 alert_id = 1cae9f92-5fd7-4504-b363-9bc45015adaa
 device_id = 251691
 observer_rule_id = d52cbfe0-f9de-468e-afbe-3c91037322da

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands = pre-commit run --all-files --show-diff-on-failure
 [pytest]
 markers =
     integration: mark test as a integration test
-host_url = https://console.us.code42.com
+host_url = http://127.0.0.1:4200
 alert_id = 1cae9f92-5fd7-4504-b363-9bc45015adaa
 device_id = 251691
 observer_rule_id = d52cbfe0-f9de-468e-afbe-3c91037322da


### PR DESCRIPTION
### Description of Change ###

Fixes small things and improves the flow of using the mock server while using running py42 integration tests.

* Use default arguments that are the expected host/port of the mockserver when environment variables are not set.
* Corrects the name of said environment variable in the CONTRIBUTING guide as well as update the CONTRIBUTING guide 
to include part about default variables.
* Checks for successful status code range instead of specific status code in integration tests
* Fails integ tests early when SDK doesn't get created (thanks @timabrmsn )
*** Removes `Content-Type application/json` when no request data.**
* Make URLs easier to parse; remove unneeded class variables
* Some formatting and spelling fixes
* Makes test py2 compat

### Issues Resolved ###
n/a

### Testing Procedure ###
Now, when testing the mock server PRs, you don't have to worry about setting the environment variables.

### PR Checklist ###
Did you remember to do the below?

- [n/a] Add unit tests to verify this change
- [n/a] Add an entry to CHANGELOG.md describing this change
- [n/a] Add docstrings for any new public parameters / methods / classes
