### PR TITLE
make header not persist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 ### Changed
 
 - The request header `Content-Type: application/json` is no longer sent when there is no
-  request data.
+  request data.tox
 
 - `sdk.cases.create()` now raises `Py42CaseNameExistsError` when the case name already
   exists in the system.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 ### Changed
 
 - The request header `Content-Type: application/json` is no longer sent when there is no
-  request data.tox
+  request data.
 
 - `sdk.cases.create()` now raises `Py42CaseNameExistsError` when the case name already
   exists in the system.

--- a/src/py42/services/_connection.py
+++ b/src/py42/services/_connection.py
@@ -226,6 +226,7 @@ class Connection(object):
         if json is not None:
             data = json_lib.dumps(json)
 
+        headers = headers or {}
         headers.update(self._headers)
         if data:
             headers.update({u"Content-Type": u"application/json"})

--- a/src/py42/services/_connection.py
+++ b/src/py42/services/_connection.py
@@ -183,7 +183,6 @@ class Connection(object):
                 auth=auth,
                 hooks=hooks,
             )
-
             response = self._session.send(
                 request,
                 stream=stream,
@@ -227,13 +226,14 @@ class Connection(object):
         if json is not None:
             data = json_lib.dumps(json)
 
-        user_headers = _create_user_headers(headers, data)
-        self._set_content_header(data)
-        self._headers.update(user_headers)
+        headers = _create_user_headers(headers, data)
+        headers.update(self._headers)
+        if data:
+            headers.update({u"Content-Type": u"application/json"})
         request = Request(
             method=method,
             url=url,
-            headers=self._headers,
+            headers=headers,
             files=files,
             data=data,
             params=params,
@@ -244,14 +244,6 @@ class Connection(object):
 
         _print_request(method, url, params=params, data=data)
         return self._session.prepare_request(request)
-
-    def _set_content_header(self, data):
-        content_key = u"Content-Type"
-        content_header = {content_key: u"application/json"}
-        if data:
-            self._headers.update(content_header)
-        elif content_key in self._headers:
-            del self._headers[content_key]
 
     def _get_host_address(self):
         if not self._host_address:

--- a/src/py42/services/_connection.py
+++ b/src/py42/services/_connection.py
@@ -228,6 +228,7 @@ class Connection(object):
             data = json_lib.dumps(json)
 
         user_headers = _create_user_headers(headers, data)
+        self._set_content_header(data)
         self._headers.update(user_headers)
         request = Request(
             method=method,
@@ -243,6 +244,14 @@ class Connection(object):
 
         _print_request(method, url, params=params, data=data)
         return self._session.prepare_request(request)
+
+    def _set_content_header(self, data):
+        content_key = u"Content-Type"
+        content_header = {content_key: u"application/json"}
+        if data:
+            self._headers.update(content_header)
+        elif content_key in self._headers:
+            del self._headers[content_key]
 
     def _get_host_address(self):
         if not self._host_address:
@@ -264,9 +273,6 @@ def _create_user_headers(headers, data):
     user_headers = {u"User-Agent": settings.get_user_agent_string()}
     if headers:
         user_headers.update(headers)
-    if data:
-        content_header = {u"Content-Type": u"application/json"}
-        user_headers.update(content_header)
     return user_headers
 
 

--- a/src/py42/services/_connection.py
+++ b/src/py42/services/_connection.py
@@ -226,10 +226,10 @@ class Connection(object):
         if json is not None:
             data = json_lib.dumps(json)
 
-        headers = _create_user_headers(headers, data)
         headers.update(self._headers)
         if data:
             headers.update({u"Content-Type": u"application/json"})
+        headers = _create_user_headers(headers)
         request = Request(
             method=method,
             url=url,
@@ -261,7 +261,7 @@ class Connection(object):
         self._host_address = host
 
 
-def _create_user_headers(headers, data):
+def _create_user_headers(headers):
     user_headers = {u"User-Agent": settings.get_user_agent_string()}
     if headers:
         user_headers.update(headers)

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -53,7 +53,6 @@ class TestUser:
         response = connection.users.get_current()
         assert_successful_response(response)
 
-    @pytest.mark.skip("Fails when whole test suite is executed.")
     def test_deactivate(self, connection, new_user):
         response = connection.users.deactivate(new_user["userId"])
         assert_successful_response(response)

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -332,3 +332,21 @@ class TestConnection(object):
         connection.get(URL)
         request = success_requests_session.prepare_request.call_args[0][0]
         assert request.headers.get("Content-Type") is None
+
+    def test_connection_request_uses_given_headers(
+        self, mock_host_resolver, mock_auth, success_requests_session
+    ):
+        connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
+        connection.put(URL, data='{"foo":"bar"}', headers={"Header1": "Foo", "Header2": "Bar"})
+        request = success_requests_session.prepare_request.call_args[0][0]
+        assert request.headers["Header1"] == "Foo"
+        assert request.headers["Header2"] == "Bar"
+
+    def test_connection_request_when_given_header_as_param_does_not_persist_header(
+        self, mock_host_resolver, mock_auth, success_requests_session
+    ):
+        connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
+        connection.put(URL, data='{"foo":"bar"}', headers={"Foo": "Bar"})
+        connection.get(URL)
+        request = success_requests_session.prepare_request.call_args[0][0]
+        assert request.headers.get("Foo") is None

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -328,7 +328,7 @@ class TestConnection(object):
         self, mock_host_resolver, mock_auth, success_requests_session
     ):
         connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
-        connection.put(URL, data='{"foo":"bar"}')  # Uses data and Content-Type: application/json
+        connection.put(URL, data='{"foo":"bar"}')  # Content-Type: application/json
         connection.get(URL)
         request = success_requests_session.prepare_request.call_args[0][0]
         assert request.headers.get("Content-Type") is None

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -350,3 +350,11 @@ class TestConnection(object):
         connection.get(URL)
         request = success_requests_session.prepare_request.call_args[0][0]
         assert request.headers.get("Foo") is None
+
+    def test_connection_request_includes_user_agent_header(
+        self, mock_host_resolver, mock_auth, success_requests_session
+    ):
+        connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
+        connection.put(URL)
+        request = success_requests_session.prepare_request.call_args[0][0]
+        assert request.headers["User-Agent"] is not None

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -323,3 +323,12 @@ class TestConnection(object):
         connection.put(URL, data='{"foo":"bar"}')
         request = success_requests_session.prepare_request.call_args[0][0]
         assert request.headers["Content-Type"] == "application/json"
+
+    def test_connection_request_when_has_data_does_not_use_header_on_following_request_that_does_not_have_data(
+        self, mock_host_resolver, mock_auth, success_requests_session
+    ):
+        connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
+        connection.put(URL, data='{"foo":"bar"}')  # Uses data and Content-Type: application/json
+        connection.get(URL)
+        request = success_requests_session.prepare_request.call_args[0][0]
+        assert request.headers.get("Content-Type") is None

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -337,7 +337,9 @@ class TestConnection(object):
         self, mock_host_resolver, mock_auth, success_requests_session
     ):
         connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
-        connection.put(URL, data='{"foo":"bar"}', headers={"Header1": "Foo", "Header2": "Bar"})
+        connection.put(
+            URL, data='{"foo":"bar"}', headers={"Header1": "Foo", "Header2": "Bar"}
+        )
         request = success_requests_session.prepare_request.call_args[0][0]
         assert request.headers["Header1"] == "Foo"
         assert request.headers["Header2"] == "Bar"


### PR DESCRIPTION
### Description of Change ###

Fixed bug from last PR where the header would persist if getting added once.
Now, the header will get removed, as you can see with the unit test.
Also, finally my Prism tests are working, so that is a really good sign.

### Issues Resolved ###


### Testing Procedure ###
Unit test
make sure py42 still works (it does but I will continue to verify)

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
