### PR TITLE
Fix content type param header issue

### DIFF
--- a/src/py42/services/_connection.py
+++ b/src/py42/services/_connection.py
@@ -226,16 +226,15 @@ class Connection(object):
         if json is not None:
             data = json_lib.dumps(json)
 
-        request_headers = dict(self._headers)
-        if headers:
-            request_headers.update(headers)
-        if data:
-            request_headers.update({u"Content-Type": u"application/json"})
-        request_headers = _create_user_headers(request_headers)
+        headers = headers or {}
+        headers.update(self._headers)
+        if data and u"Content-Type" not in headers:
+            headers.update({u"Content-Type": u"application/json"})
+        headers = _create_user_headers(headers)
         request = Request(
             method=method,
             url=url,
-            headers=request_headers,
+            headers=headers,
             files=files,
             data=data,
             params=params,

--- a/src/py42/services/_connection.py
+++ b/src/py42/services/_connection.py
@@ -226,15 +226,16 @@ class Connection(object):
         if json is not None:
             data = json_lib.dumps(json)
 
-        headers = headers or {}
-        headers.update(self._headers)
+        request_headers = dict(self._headers)
+        if headers:
+            request_headers.update(headers)
         if data:
-            headers.update({u"Content-Type": u"application/json"})
-        headers = _create_user_headers(headers)
+            request_headers.update({u"Content-Type": u"application/json"})
+        request_headers = _create_user_headers(request_headers)
         request = Request(
             method=method,
             url=url,
-            headers=headers,
+            headers=request_headers,
             files=files,
             data=data,
             params=params,

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -366,7 +366,7 @@ class TestConnection(object):
     ):
         connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
         connection.put(
-            URL, headers={"Content-Type": "*/*"}
+            URL, data='{"foo":"bar"}', headers={"Content-Type": "*/*"}
         )
         request = success_requests_session.prepare_request.call_args[0][0]
         assert request.headers["Content-Type"] == "*/*"

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -360,3 +360,13 @@ class TestConnection(object):
         connection.put(URL)
         request = success_requests_session.prepare_request.call_args[0][0]
         assert request.headers["User-Agent"] is not None
+
+    def test_connection_request_is_able_to_accept_content_type_header(
+        self, mock_host_resolver, mock_auth, success_requests_session
+    ):
+        connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
+        connection.put(
+            URL, headers={"Content-Type": "*/*"}
+        )
+        request = success_requests_session.prepare_request.call_args[0][0]
+        assert request.headers["Content-Type"] == "*/*"

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -365,8 +365,6 @@ class TestConnection(object):
         self, mock_host_resolver, mock_auth, success_requests_session
     ):
         connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
-        connection.put(
-            URL, data='{"foo":"bar"}', headers={"Content-Type": "*/*"}
-        )
+        connection.put(URL, data='{"foo":"bar"}', headers={"Content-Type": "*/*"})
         request = success_requests_session.prepare_request.call_args[0][0]
         assert request.headers["Content-Type"] == "*/*"


### PR DESCRIPTION
### Description of Change ###

Fixes issue that removed Content-Type header when it was given as a parameter

### Issues Resolved ###
N/a

### Testing Procedure ###
Before, the key value store (which adds */* content type header) was not succeeding in adding it.
Verify that it now adds it (using -d in CLI?)

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [n/a] Add an entry to CHANGELOG.md describing this change
- [n/a] Add docstrings for any new public parameters / methods / classes
