### PR TITLE
conditionally set Accept header when not in headers arg

### DIFF
--- a/src/py42/services/_connection.py
+++ b/src/py42/services/_connection.py
@@ -26,7 +26,6 @@ ROOT_SESSION = Session()
 ROOT_SESSION.mount(u"https://", SESSION_ADAPTER)
 ROOT_SESSION.mount(u"http://", SESSION_ADAPTER)
 ROOT_SESSION.headers = {
-    u"Accept": u"application/json",
     u"Accept-Encoding": u"gzip, deflate",
     u"Connection": u"keep-alive",
 }
@@ -230,6 +229,8 @@ class Connection(object):
         headers.update(self._headers)
         if data and u"Content-Type" not in headers:
             headers.update({u"Content-Type": u"application/json"})
+        if u"Accept" not in headers:
+            headers.update({u"Accept": u"application/json"})
         headers = _create_user_headers(headers)
         request = Request(
             method=method,

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -368,3 +368,19 @@ class TestConnection(object):
         connection.put(URL, data='{"foo":"bar"}', headers={"Content-Type": "*/*"})
         request = success_requests_session.prepare_request.call_args[0][0]
         assert request.headers["Content-Type"] == "*/*"
+
+    def test_connection_request_is_able_to_accept_accept_header(
+        self, mock_host_resolver, mock_auth, success_requests_session
+    ):
+        connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
+        connection.put(URL, data='{"foo":"bar"}', headers={"Accept": "*/*"})
+        request = success_requests_session.prepare_request.call_args[0][0]
+        assert request.headers["Accept"] == "*/*"
+
+    def test_connection_request_when_not_give_accept_header_sets_accept_to_application_json(
+        self, mock_host_resolver, mock_auth, success_requests_session
+    ):
+        connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
+        connection.put(URL, data='{"foo":"bar"}')
+        request = success_requests_session.prepare_request.call_args[0][0]
+        assert request.headers["Accept"] == "application/json"


### PR DESCRIPTION
### Description of Change ###
Conditionally sets Accept header for when user client passes in, we don't overwrite

### Issues Resolved ###
Helps Prism work in the Mock Server

### Testing Procedure ###
Run integration tests for alerts using mock server


### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [n/a] Add an entry to CHANGELOG.md describing this change
- [n/a] Add docstrings for any new public parameters / methods / classes
