### PR TITLE
Remove trailing slash from get all cases fileevents URL

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,7 +22,7 @@ jobs:
           path-to-cla-document: 'https://code42.github.io/code42-cla/Code42_Individual_Contributor_License_Agreement'
           # branch should not be protected
           branch: 'master'
-          allowlist: alang13,unparalleled-js,kiran-chaudhary,ceciliastevens,DiscoRiver,annie-payseur,amoravec,patelsagar192
+          allowlist: alang13,unparalleled-js,kiran-chaudhary,ceciliastevens,DiscoRiver,annie-payseur,amoravec,patelsagar192,peterbriggs42
 
           #below are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)

--- a/src/py42/services/casesfileevents.py
+++ b/src/py42/services/casesfileevents.py
@@ -6,7 +6,7 @@ from py42.services import BaseService
 
 class CasesFileEventsService(BaseService):
 
-    _uri_prefix = u"/api/v1/case/{0}/fileevent/"
+    _uri_prefix = u"/api/v1/case/{0}/fileevent"
 
     def __init__(self, connection):
         super(CasesFileEventsService, self).__init__(connection)
@@ -23,7 +23,7 @@ class CasesFileEventsService(BaseService):
         """
         try:
             return self._connection.post(
-                u"{}{}".format(self._uri_prefix.format(case_number), event_id)
+                u"{}/{}".format(self._uri_prefix.format(case_number), event_id)
             )
         except Py42BadRequestError as err:
             if "CASE_IS_CLOSED" in err.response.text:
@@ -44,7 +44,7 @@ class CasesFileEventsService(BaseService):
             :class:`py42.response.Py42Response`
         """
         return self._connection.get(
-            u"{}{}".format(self._uri_prefix.format(case_number), event_id)
+            u"{}/{}".format(self._uri_prefix.format(case_number), event_id)
         )
 
     def get_all(self, case_number):
@@ -70,7 +70,7 @@ class CasesFileEventsService(BaseService):
         """
         try:
             return self._connection.delete(
-                u"{}{}".format(self._uri_prefix.format(case_number), event_id)
+                u"{}/{}".format(self._uri_prefix.format(case_number), event_id)
             )
         except Py42BadRequestError as err:
             if "CASE_IS_CLOSED" in err.response.text:

--- a/tests/services/test_casesfileevents.py
+++ b/tests/services/test_casesfileevents.py
@@ -60,7 +60,7 @@ class TestCasesFileEventService:
         case_file_event_service.get_all(_TEST_CASE_NUMBER)
         assert mock_connection.get.call_args[0][
             0
-        ] == u"/api/v1/case/{}/fileevent/".format(_TEST_CASE_NUMBER)
+        ] == u"/api/v1/case/{}/fileevent".format(_TEST_CASE_NUMBER)
 
     def test_add_on_a_closed_case_raises_error(
         self, mock_connection, mock_update_failed_response


### PR DESCRIPTION
### Description of Change ###

Remove a trailing slash from the get all case file events endpoint URL. This is related to a change to the mock server, as Prism will throw an error if the trailing slash is present in the request but not specified in the yaml spec.  

Removing the trailing slash makes the get all case file events URL consistent with other URLs in py42.
  
### Issues Resolved ###
N/A

- closes #

### Testing Procedure ###
Run ./tests/integration/test_cases.py against the mock server and against a live environment and verify that the tests pass.

In order to successfully run these tests against the mock server, the `cases` pull request on `mock-microservices-endpoints` must be completed.

### PR Checklist ###
Did you remember to do the below?

- [x ] Add unit tests to verify this change
- [ N/A] Add an entry to CHANGELOG.md describing this change
- [ N/A] Add docstrings for any new public parameters / methods / classes
