### PR TITLE
modify error response, set api response content when unknown errors occur

### DIFF
--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -54,7 +54,12 @@ class Py42HTTPError(Py42ResponseError):
     """A base custom class to manage all HTTP errors raised by an API endpoint."""
 
     def __init__(self, exception, message=None):
-        message = message or u"Failure in HTTP call {}".format(str(exception))
+        error_message = ""
+        if hasattr(exception.response, "text"):
+            error_message = "\n Error message: {}".format(exception.response.text)
+        message = message or u"Failure in HTTP call {}.{}".format(
+            str(exception), error_message
+        )
         super(Py42HTTPError, self).__init__(exception.response, message)
 
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -55,11 +55,13 @@ class Py42HTTPError(Py42ResponseError):
     """A base custom class to manage all HTTP errors raised by an API endpoint."""
 
     def __init__(self, exception, message=None):
-        response_content = "\n Response content: {}".format(exception.response.text)
-        message = message or u"Failure in HTTP call {}.{}".format(
-            str(exception), response_content
-        )
-        debug.logger.error(message)
+        if not message:
+            response_content = "\n Response content: {}".format(exception.response.text)
+            message = u"Failure in HTTP call {}.{}".format(
+                str(exception), response_content
+            )
+            debug.logger.error(message)
+
         super(Py42HTTPError, self).__init__(exception.response, message)
 
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -1,6 +1,7 @@
 import re
 
 from py42._compat import str
+from py42.settings import debug
 
 
 class Py42Error(Exception):
@@ -58,6 +59,7 @@ class Py42HTTPError(Py42ResponseError):
         message = message or u"Failure in HTTP call {}.{}".format(
             str(exception), response_content
         )
+        debug.logger.error(message)
         super(Py42HTTPError, self).__init__(exception.response, message)
 
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -54,11 +54,9 @@ class Py42HTTPError(Py42ResponseError):
     """A base custom class to manage all HTTP errors raised by an API endpoint."""
 
     def __init__(self, exception, message=None):
-        error_message = ""
-        if hasattr(exception.response, "text"):
-            error_message = "\n Error message: {}".format(exception.response.text)
+        response_content = "\n Response content: {}".format(exception.response.text)
         message = message or u"Failure in HTTP call {}.{}".format(
-            str(exception), error_message
+            str(exception), response_content
         )
         super(Py42HTTPError, self).__init__(exception.response, message)
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -56,8 +56,8 @@ class Py42HTTPError(Py42ResponseError):
 
     def __init__(self, exception, message=None):
         if not message:
-            response_content = "\n Response content: {}".format(exception.response.text)
-            message = u"Failure in HTTP call {}.{}".format(
+            response_content = "Response content: {}".format(exception.response.text)
+            message = u"Failure in HTTP call {}. {}".format(
                 str(exception), response_content
             )
             debug.logger.error(message)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,11 +105,13 @@ def error_response(mocker, http_error):
 
 @pytest.fixture
 def unauthorized_response(mocker, http_error):
+    error = http_error
     response = mocker.MagicMock(spec=Response)
     response.text = TEST_RESPONSE_CONTENT
     response.status_code = 401
     response.encoding = None
-    response.raise_for_status.side_effect = [Py42UnauthorizedError(http_error)]
+    error.response = response
+    response.raise_for_status.side_effect = [Py42UnauthorizedError(error)]
     return response
 
 

--- a/tests/services/storage/test_service_factory.py
+++ b/tests/services/storage/test_service_factory.py
@@ -1,6 +1,5 @@
 import pytest
 from requests import Response
-from requests.exceptions import HTTPError
 from tests.conftest import TEST_DEVICE_GUID
 
 from py42.exceptions import Py42HTTPError
@@ -112,9 +111,12 @@ class TestStorageSessionManager(object):
         assert session1 is session2
 
     def test_get_storage_session_raises_session_init_error_when_tmp_auth_raises_http_error(
-        self, mock_tmp_auth
+        self, mock_tmp_auth, http_error, mocker
     ):
-        mock_tmp_auth.get_storage_url.side_effect = Py42HTTPError(HTTPError())
+        error = http_error
+        error.response = mocker.MagicMock(spec=Response)
+        error.response.text = ""
+        mock_tmp_auth.get_storage_url.side_effect = Py42HTTPError(error)
         storage_session_manager = ConnectionManager()
         with pytest.raises(Py42StorageSessionInitializationError):
             storage_session_manager.get_storage_connection(mock_tmp_auth)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -83,11 +83,10 @@ class TestPy42Errors(object):
             Py42ResponseError, "__init__", return_value=None
         ) as mock_method:
             with pytest.raises(Py42HTTPError):
-                print(mock_error_response.response.status_code)
                 raise_py42_error(mock_error_response)
         mock_method.assert_called_once_with(
             mock_error_response.response,
-            "Failure in HTTP call {}.\n Error message: {}".format(
+            "Failure in HTTP call {}.\n Response content: {}".format(
                 mock_error_response, error_message
             ),
         )

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -83,7 +83,7 @@ class TestPy42Errors(object):
         mock_method.assert_called_with(
             Py42HTTPError(mock_error_response),
             mock_error_response.response,
-            "Failure in HTTP call {}.\n Response content: {}".format(
+            "Failure in HTTP call {}. Response content: {}".format(
                 str(mock_error_response), error_message
             ),
         )

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import pytest
 from tests.conftest import REQUEST_EXCEPTION_MESSAGE
 
@@ -74,19 +72,18 @@ class TestPy42Errors(object):
             assert isinstance(e.response, type(error_response.response))
 
     def test_raise_py42_error_when_has_unexpected_error_returns_api_error_response(
-        self, mock_error_response
+        self, mock_error_response, mocker
     ):
         mock_error_response.response.status_code = 410
         error_message = '{"error": { "message": "error"}}'
         mock_error_response.response.text = error_message
-        with patch.object(
-            Py42ResponseError, "__init__", return_value=None
-        ) as mock_method:
-            with pytest.raises(Py42HTTPError):
-                raise_py42_error(mock_error_response)
-        mock_method.assert_called_once_with(
+        mock_method = mocker.patch.object(Py42ResponseError, "__init__", autospec=True)
+        with pytest.raises(Py42HTTPError):
+            raise_py42_error(mock_error_response)
+        mock_method.assert_called_with(
+            Py42HTTPError(mock_error_response),
             mock_error_response.response,
             "Failure in HTTP call {}.\n Response content: {}".format(
-                mock_error_response, error_message
+                str(mock_error_response), error_message
             ),
         )


### PR DESCRIPTION
### Description of Change ###

Set api response error text when unknown errors occur.

### Issues Resolved ###
INTEG-1149

- closes #

### Testing Procedure ###
```
try:
    sdk.devices.reactivate("test")
except Exception as e:
    print(e)
```

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [ n/a] Add an entry to CHANGELOG.md describing this change
- [ n/a] Add docstrings for any new public parameters / methods / classes
