### PR TITLE
use userUid instead of userId

### DIFF
--- a/tests/integration/test_alertrules.py
+++ b/tests/integration/test_alertrules.py
@@ -35,7 +35,7 @@ class TestAlertRules:
         assert_successful_response(response)
 
     def test_rules_remove_user(self, connection, new_user, observer_id):
-        response = connection.alerts.rules.remove_user(observer_id, new_user["userId"])
+        response = connection.alerts.rules.remove_user(observer_id, new_user["userUid"])
         assert_successful_response(response)
 
     def test_rules_remove_all_users(self, connection, observer_id):


### PR DESCRIPTION
### Description of Change ###

Fixes a test in the alert rules which conflated the userId from detectionlists with the userId from users by using the userUid from users instead. This fixed validation errors in the integration tests when using the mock server as well as removes the false-positive test in a real environment.

### Issues Resolved ###
n/a

- closes #

### Testing Procedure ###
n/a

### PR Checklist ###
Did you remember to do the below?

- [n/a] Add unit tests to verify this change
- [n/a] Add an entry to CHANGELOG.md describing this change
- [n/a] Add docstrings for any new public parameters / methods / classes
