### PR TITLE
Fix integration tests in security data

### DIFF
--- a/src/py42/clients/securitydata.py
+++ b/src/py42/clients/securitydata.py
@@ -108,8 +108,8 @@ class SecurityDataClient(object):
                 str format "yyyy-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
 
         Returns:
-            generator: An object that iterates over :class:`py42.response.Py42Response` objects
-            that each contain a page of events.
+            generator: An object that iterates over tuples whose first element is a :class:`py42.response.Py42Response` object
+            containing a page of events, and whose second element is a cursor.
         """
         return self._get_security_detection_events(
             plan_storage_info,
@@ -158,8 +158,8 @@ class SecurityDataClient(object):
                 str format "yyyy-MM-DD HH:MM:SS" or a datetime instance. Defaults to None.
 
         Returns:
-            generator: An object that iterates over :class:`py42.response.Py42Response` objects
-            that each contain a page of events.
+            generator: An object that iterates over tuples whose first element is a :class:`py42.response.Py42Response` object
+            containing a page of events, and whose second element is a cursor.
         """
         security_plan_storage_infos = self.get_security_plan_storage_info_list(user_uid)
         return self._get_security_detection_events(

--- a/src/py42/clients/securitydata.py
+++ b/src/py42/clients/securitydata.py
@@ -109,7 +109,7 @@ class SecurityDataClient(object):
 
         Returns:
             generator: An object that iterates over tuples whose first element is a :class:`py42.response.Py42Response` object
-            containing a page of events, and whose second element is a cursor.
+            containing a page of events, and whose second element is a string cursor.
         """
         return self._get_security_detection_events(
             plan_storage_info,
@@ -159,7 +159,7 @@ class SecurityDataClient(object):
 
         Returns:
             generator: An object that iterates over tuples whose first element is a :class:`py42.response.Py42Response` object
-            containing a page of events, and whose second element is a cursor.
+            containing a page of events, and whose second element is a string cursor.
         """
         security_plan_storage_infos = self.get_security_plan_storage_info_list(user_uid)
         return self._get_security_detection_events(

--- a/tests/integration/test_securitydata.py
+++ b/tests/integration/test_securitydata.py
@@ -39,13 +39,13 @@ class TestSecurityData:
     def test_get_all_plan_security_events(self, connection, plan_info):
         response_gen = connection.securitydata.get_all_plan_security_events(plan_info)
         for response in response_gen:
-            assert_successful_response(response)
+            assert_successful_response(response[0])
             break
 
     def test_get_all_user_security_events(self, connection, user_uid):
         response_gen = connection.securitydata.get_all_user_security_events(user_uid)
         for response in response_gen:
-            assert_successful_response(response)
+            assert_successful_response(response[0])
             break
 
     def test_search_file_events(self, connection):


### PR DESCRIPTION
### Description of Change ###

Fix two integration tests that were not properly consuming the output of `get_all_plan_security_events`. The output of that function is now a tuple with the first element being the Py42Response object and the second term being a cursor.

### Issues Resolved ###
N/A

### Testing Procedure ###
Run the tests in `./tests/integration/test_securitydata.py` against Partner.

### PR Checklist ###
Did you remember to do the below?

- [N/A ] Add unit tests to verify this change
- [N/A ] Add an entry to CHANGELOG.md describing this change
- [N/A ] Add docstrings for any new public parameters / methods / classes
