### PR TITLE
use datetime diff for max default set test

### DIFF
--- a/tests/clients/test_cases.py
+++ b/tests/clients/test_cases.py
@@ -151,7 +151,7 @@ class TestCasesClient:
         service_args = mock_cases_service.get_all.call_args[1]
         assert service_args["updated_at"] == expected_range
 
-    def test_get_all_sets_default_max_when_begin_specified(
+    def test_get_all_sets_default_max_when_min_specified(
         self, mock_cases_service, mock_cases_file_event_service
     ):
         cases_client = CasesClient(mock_cases_service, mock_cases_file_event_service)


### PR DESCRIPTION
### Description of Change ###

* Fixes a test that intermittently was failing because of ts precision and testing against the string values. This adjust the test to use the difference of the datetime objects instead of string comparison. Since begin time test uses the utc(0) value, that test should not intermittently fail and was changed.
* To be separate the tests, they were split apart from a single test
### Issues Resolved ###
n/a

### Testing Procedure ###
Run unit tests.


### PR Checklist ###
Did you remember to do the below?

- [x ] Add unit tests to verify this change
- [n/a] Add an entry to CHANGELOG.md describing this change
- [n/a] Add docstrings for any new public parameters / methods / classes
