### PR TITLE
support custom user token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## unreleased
+
+### Added
+
+- `sdk.from_jwt_provider()` method to create `SDKClient` that supports custom auth mechanism.
+
 ## 1.11.1 - 2021-02-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Initialize the client.
 ```python
 >>> sdk = py42.sdk.from_local_account("https://console.us.code42.com", "john.doe", "password")
 ```
+or alternatively
+```
+>>> sdk = py42.sdk.from_jwt_provider(jwt_provider_function)
+```
 
 Get and print your user information.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Initialize the client.
 ```
 or alternatively
 ```
->>> sdk = py42.sdk.from_jwt_provider(jwt_provider_function)
+>>> sdk = py42.sdk.from_jwt_provider("https://console.us.code42.com", jwt_provider_function)
 ```
 
 Get and print your user information.

--- a/docs/methods.md
+++ b/docs/methods.md
@@ -1,7 +1,7 @@
 # Method Documentation
 
 The main SDK object by which all other methods are accessed is created by
-calling `py42.sdk.from_local_account`. For example:
+calling `py42.sdk.from_local_account` or `py42.sdk.from_jwt_provider`. For example:
 
 ```python
 import py42.sdk

--- a/docs/userguides/basics.md
+++ b/docs/userguides/basics.md
@@ -40,10 +40,10 @@ sdk = py42.sdk.from_local_account("https://console.us.code42.com", "my_username"
 Alternatively, define a function that returns the auth token based on user's authentication approach
 
 ```
+import json
+import requests
+from requests.auth import HTTPBasicAuth
 def jwt_provider():
-    import json
-    import requests
-    from requests.auth import HTTPBasicAuth
     res = requests.get(
             'https://console.us.code42.com/c42api/v3/auth/jwt?useBody=true',
             auth=HTTPBasicAuth('username', 'password')

--- a/docs/userguides/basics.md
+++ b/docs/userguides/basics.md
@@ -37,6 +37,15 @@ def promptForPassword():
 sdk = py42.sdk.from_local_account("https://console.us.code42.com", "my_username", "my_password", totp=promptForPassword)
 ```
 
+Alternatively, define a function that returns the auth token based on user's authentication approach
+
+```
+def jwt_provider():
+    ...
+
+sdk = py42.sdk.from_jwt_provider(jwt_provider)
+```
+
 
 ## Paging
 

--- a/docs/userguides/basics.md
+++ b/docs/userguides/basics.md
@@ -41,9 +41,17 @@ Alternatively, define a function that returns the auth token based on user's aut
 
 ```
 def jwt_provider():
-    ...
+    import json
+    import requests
+    from requests.auth import HTTPBasicAuth
+    res = requests.get(
+            'https://console.us.code42.com/c42api/v3/auth/jwt?useBody=true',
+            auth=HTTPBasicAuth('username', 'password')
+          )
+    res_json = json.loads(res.text)
+    return res_json['data']['v3_user_token']
 
-sdk = py42.sdk.from_jwt_provider(jwt_provider)
+sdk_client = py42.sdk.from_jwt_provider("https://console.us.code42.com", jwt_provider)
 ```
 
 

--- a/src/py42/sdk/__init__.py
+++ b/src/py42/sdk/__init__.py
@@ -92,7 +92,7 @@ class SDKClient(object):
         """Creates a :class:`~py42.sdk.SDKClient` object for accessing the Code42 REST APIs using
         the supplied credentials. This method supports only accounts created within the Code42 console or
         using the APIs (including py42). Username/passwords that are based on Active
-        Directory, Okta, or other Identity providers cannot be used with this method.
+        Directory, Okta, or other Identity providers should use the `from_jwt_provider` method.
 
         Args:
             host_address (str): The domain name of the Code42 instance being authenticated to, e.g.

--- a/src/py42/sdk/__init__.py
+++ b/src/py42/sdk/__init__.py
@@ -40,8 +40,8 @@ from py42.usercontext import UserContext
 
 def from_local_account(host_address, username, password, totp=None):
     """Creates a :class:`~py42.sdk.SDKClient` object for accessing the Code42 REST APIs using the
-    supplied credentials. Currently, only accounts created within the Code42 console or using the
-    APIs (including py42) are supported. Username/passwords that are based on Active Directory,
+    supplied credentials. This method supports only accounts created within the Code42 console or using the
+    APIs (including py42). Username/passwords that are based on Active Directory,
     Okta, or other Identity providers cannot be used with this method.
 
     Args:
@@ -90,8 +90,8 @@ class SDKClient(object):
     @classmethod
     def from_local_account(cls, host_address, username, password, totp=None):
         """Creates a :class:`~py42.sdk.SDKClient` object for accessing the Code42 REST APIs using
-        the supplied credentials. Currently, only accounts created within the Code42 console or
-        using the APIs (including py42) are supported. Username/passwords that are based on Active
+        the supplied credentials. This method supports only accounts created within the Code42 console or
+        using the APIs (including py42). Username/passwords that are based on Active
         Directory, Okta, or other Identity providers cannot be used with this method.
 
         Args:

--- a/src/py42/services/_auth.py
+++ b/src/py42/services/_auth.py
@@ -43,9 +43,9 @@ class V3Auth(C42RenewableAuth):
         return u"v3_user_token {}".format(response["v3_user_token"])
 
 
-class JWTAuth(C42RenewableAuth):
+class CustomJWTAuth(C42RenewableAuth):
     def __init__(self, jwt_provider):
-        super(JWTAuth, self).__init__()
+        super(CustomJWTAuth, self).__init__()
         self._jwt_provider = jwt_provider
 
     def _get_credentials(self):

--- a/src/py42/services/_auth.py
+++ b/src/py42/services/_auth.py
@@ -41,3 +41,12 @@ class V3Auth(C42RenewableAuth):
         headers = {"totp-auth": str(current_token)} if current_token else None
         response = self._auth_connection.get(uri, params=params, headers=headers)
         return u"v3_user_token {}".format(response["v3_user_token"])
+
+
+class JWTAuth(C42RenewableAuth):
+    def __init__(self, jwt_provider):
+        super(JWTAuth, self).__init__()
+        self._jwt_provider = jwt_provider
+
+    def _get_credentials(self):
+        return u"v3_user_token {}".format(self._jwt_provider())

--- a/src/py42/services/_connection.py
+++ b/src/py42/services/_connection.py
@@ -93,7 +93,6 @@ class ConnectedServerHostResolver(HostResolver):
         return response[u"serverUrl"]
 
 
-
 class Connection(object):
     def __init__(self, host_resolver, auth=None, session=None):
         self._host_resolver = host_resolver

--- a/src/py42/services/_connection.py
+++ b/src/py42/services/_connection.py
@@ -93,6 +93,7 @@ class ConnectedServerHostResolver(HostResolver):
         return response[u"serverUrl"]
 
 
+
 class Connection(object):
     def __init__(self, host_resolver, auth=None, session=None):
         self._host_resolver = host_resolver

--- a/tests/services/test_auth.py
+++ b/tests/services/test_auth.py
@@ -78,7 +78,7 @@ class TestV3Auth(object):
 
 
 class TestCustomJWTAuth(object):
-    def test_call_returns_jwt_string(self, mock_custom_auth_function):
+    def test_get_credentials_returns_jwt_string(self, mock_custom_auth_function):
         auth = CustomJWTAuth(mock_custom_auth_function)
         jwt_string = auth.get_credentials()
         assert jwt_string == "v3_user_token token-string"

--- a/tests/services/test_auth.py
+++ b/tests/services/test_auth.py
@@ -1,6 +1,7 @@
 import pytest
 from requests import Request
 
+from py42.services._auth import CustomJWTAuth
 from py42.services._auth import V3Auth
 
 
@@ -16,6 +17,14 @@ def mock_v3_conn(mock_connection, py42_response):
     py42_response.text = '{"v3_user_token": "TEST_TOKEN_VALUE"}'
     mock_connection.get.return_value = py42_response
     return mock_connection
+
+
+@pytest.fixture
+def mock_custom_auth_function():
+    def custom_function():
+        return "token-string"
+
+    return custom_function
 
 
 class TestV3Auth(object):
@@ -66,3 +75,10 @@ class TestV3Auth(object):
         auth.clear_credentials()
         auth(mock_request)
         assert mock_v3_conn.get.call_count == 2
+
+
+class TestCustomJWTAuth(object):
+    def test_call_returns_jwt_string(self, mock_custom_auth_function):
+        auth = CustomJWTAuth(mock_custom_auth_function)
+        jwt_string = auth.get_credentials()
+        assert jwt_string == "v3_user_token token-string"


### PR DESCRIPTION
### Description of Change ###

Add option to create sdk client instance with custom user token.

### Issues Resolved ###

- closes #INTEG-1206

### Testing Procedure ###
`sdk = sdk.from_jwt_provider()`

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
