### PR TITLE
Run integration tests against code42-mock-servers during build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          path: py42
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
@@ -34,6 +36,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: code42/code42-mock-servers
-          path: ../code42-mock-servers
+          path: code42-mock-servers
       - name: Start up the mock servers
-        run: pwd; cd ../code42-mock-servers; make
+        run: pwd; ls -lah; cd code42-mock-servers; make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         uses: codecov/codecov-action@v1.0.7
         with:
           file: py42/coverage.xml
-      - name: Checkout mock server 
+      - name: Checkout mock server
         uses: actions/checkout@v2
         with:
           ref: feature/make-containers-use-host

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Start up the mock servers
         run: cd code42-mock-servers; docker-compose up -d --build
       - name: Curl against one of the containers 
-        run: docker ps -a; docker inspect mock_core; sleep 1; curl http://127.0.0.1:4200/api/User/asdfz; docker logs mock_core
+        run: docker ps -a; docker inspect mock_core; sleep 1; curl http://127.0.0.1:4200/api/User/asdfz && docker logs mock_core

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Start up the mock servers
         run: cd code42-mock-servers; docker-compose up -d --build
       - name: Curl against one of the containers 
-        run: docker ps -a; docker inspect mock_core; curl http://127.0.0.1:4200/api/User/asdfz
+        run: docker ps -a; docker inspect mock_core; sleep 1; curl http://127.0.0.1:4200/api/User/asdfz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Start up the mock servers
         run: cd code42-mock-servers; docker-compose up -d --build
       - name: Curl against one of the containers 
-        run: docker ps -a; docker inspect mock_core #;curl http://127.0.0.1:4200/api/User/asdfz
+        run: docker ps -a; docker inspect mock_core; curl http://127.0.0.1:4200/api/User/asdfz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Start up the mock servers
         run: cd code42-mock-servers; docker-compose up -d --build
       - name: Curl against one of the containers 
-        run: docker ps -a; docker inspect mock_core; sleep 1; curl http://127.0.0.1:4200/api/User/asdfz && docker logs mock_core
+        run: docker ps -a; docker inspect mock_core; sleep 1; curl http://127.0.0.1:4200/api/User/asdfz || docker logs mock_core

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Start up the mock servers
         run: cd code42-mock-servers; docker-compose up -d --build
       - name: Curl against one of the containers 
-        run: docker ps -a; docker inspect mock_core; curl http://127.0.0.1:4200/api/User/asdfz
+        run: docker ps -a; docker inspect mock_core; curl http://0.0.0.0:4200/api/User/asdfz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,8 @@ jobs:
       #     file: py42/coverage.xml
       - name: Checkout mock server 
         uses: actions/checkout@v2
-        ref: feature/make-containers-use-host
         with:
+          ref: feature/make-containers-use-host
           repository: code42/code42-mock-servers
           path: code42-mock-servers
       - name: Start up the mock servers

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,4 +38,6 @@ jobs:
           repository: code42/code42-mock-servers
           path: code42-mock-servers
       - name: Start up the mock servers
-        run: pwd; ls -lah; cd code42-mock-servers; make
+        run: cd code42-mock-servers; docker-compose up -d 
+      - name: Curl against one of the containers
+        run: curl http://127.0.0.1/4200/api/User/asdfz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,8 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python }}
-      # - name: Install tox
-      #   run: pip install tox==3.17.1
+      - name: Install tox
+        run: pip install tox==3.17.1
       # - name: Run Unit tests
       #   run: cd py42; tox -e py  # Run tox using the version of Python in `PATH`
       # - name: Submit coverage report
@@ -43,4 +43,4 @@ jobs:
       # - name: Curl against one of the containers 
       #   run: docker ps -a; docker inspect --format "{{json .State.Health }}" mock_core | jq; curl http://127.0.0.1:4200/api/User/asdfz
       - name: Run the integration tests!!
-        run: tox -e integration
+        run: cd py42; tox -e integration

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,6 @@ jobs:
           repository: code42/code42-mock-servers
           path: code42-mock-servers
       - name: Start up the mock servers
-        run: cd code42-mock-servers; docker-compose up -d 
-      - name: Curl against one of the containers
-        run: curl http://127.0.0.1:4200/api/User/asdfz
+        run: cd code42-mock-servers; docker-compose up -d; curl http://127.0.0.1:4200/api/User/asdfz
+      - name: Curl against one of the containers 
+        run: docker ps -a; curl http://127.0.0.1:4200/api/User/asdfz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,4 +40,4 @@ jobs:
       - name: Start up the mock servers
         run: cd code42-mock-servers; docker-compose up -d 
       - name: Curl against one of the containers
-        run: curl http://127.0.0.1/4200/api/User/asdfz
+        run: curl http://127.0.0.1:4200/api/User/asdfz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Install tox
         run: pip install tox==3.17.1
       - name: Run Unit tests
-        run: tox -e py  # Run tox using the version of Python in `PATH`
+        run: cd py42; tox -e py  # Run tox using the version of Python in `PATH`
       - name: Submit coverage report
         uses: codecov/codecov-action@v1.0.7
         with:
-          file: ./coverage.xml
+          file: py42/coverage.xml
       - name: Checkout mock server 
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Start up the mock servers
         run: cd code42-mock-servers; docker-compose up -d --build
       - name: Curl against one of the containers 
-        run: docker ps -a; docker inspect mock_core; curl http://0.0.0.0:4200/api/User/asdfz
+        run: docker ps -a; docker inspect mock_core; curl http://127.0.0.1:4200/api/User/asdfz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Start up the mock servers
         run: cd code42-mock-servers; docker-compose up -d --build
       - name: Curl against one of the containers 
-        run: docker ps -a; docker inspect mock_core; sleep 10; curl http://127.0.0.1:4200/api/User/asdfz || docker logs mock_core
+        run: docker ps -a; docker inspect --format "{{json .State.Health }}" mock_core | jq; curl http://127.0.0.1:4200/api/User/asdfz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,16 +24,17 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python }}
-      - name: Install tox
-        run: pip install tox==3.17.1
-      - name: Run Unit tests
-        run: cd py42; tox -e py  # Run tox using the version of Python in `PATH`
-      - name: Submit coverage report
-        uses: codecov/codecov-action@v1.0.7
-        with:
-          file: py42/coverage.xml
+      # - name: Install tox
+      #   run: pip install tox==3.17.1
+      # - name: Run Unit tests
+      #   run: cd py42; tox -e py  # Run tox using the version of Python in `PATH`
+      # - name: Submit coverage report
+      #   uses: codecov/codecov-action@v1.0.7
+      #   with:
+      #     file: py42/coverage.xml
       - name: Checkout mock server 
         uses: actions/checkout@v2
+        ref: feature/make-containers-use-host
         with:
           repository: code42/code42-mock-servers
           path: code42-mock-servers

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,4 +43,4 @@ jobs:
       # - name: Curl against one of the containers 
       #   run: docker ps -a; docker inspect --format "{{json .State.Health }}" mock_core | jq; curl http://127.0.0.1:4200/api/User/asdfz
       - name: Run the integration tests!!
-        run: pytest -m integration
+        run: tox -e integration

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Start up the mock servers
         run: cd code42-mock-servers; docker-compose up -d --build
       - name: Curl against one of the containers 
-        run: docker ps -a; docker inspect mock_core; sleep 1; curl http://127.0.0.1:4200/api/User/asdfz
+        run: docker ps -a; docker inspect mock_core; sleep 1; curl http://127.0.0.1:4200/api/User/asdfz; docker logs mock_core

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: code42/code42-mock-servers
-          path: code42-mock-servers
+          path: ../code42-mock-servers
       - name: Start up the mock servers
-        run: pwd; ls -lah
+        run: pwd; cd ../code42-mock-servers; make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,6 @@ jobs:
           repository: code42/code42-mock-servers
           path: code42-mock-servers
       - name: Start up the mock servers
-        run: cd code42-mock-servers; docker-compose up -d
+        run: cd code42-mock-servers; docker-compose up -d --build
       - name: Curl against one of the containers 
-        run: docker ps -a; curl http://127.0.0.1:4200/api/User/asdfz
+        run: docker ps -a; docker inspect mock_core #;curl http://127.0.0.1:4200/api/User/asdfz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Start up the mock servers
         run: cd code42-mock-servers; docker-compose up -d --build
       - name: Curl against one of the containers 
-        run: docker ps -a; docker inspect mock_core; sleep 1; curl http://127.0.0.1:4200/api/User/asdfz || docker logs mock_core
+        run: docker ps -a; docker inspect mock_core; sleep 10; curl http://127.0.0.1:4200/api/User/asdfz || docker logs mock_core

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,6 @@ jobs:
           repository: code42/code42-mock-servers
           path: code42-mock-servers
       - name: Start up the mock servers
-        run: cd code42-mock-servers; docker-compose up -d; curl http://127.0.0.1:4200/api/User/asdfz
+        run: cd code42-mock-servers; docker-compose up -d
       - name: Curl against one of the containers 
         run: docker ps -a; curl http://127.0.0.1:4200/api/User/asdfz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,12 +26,12 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install tox
         run: pip install tox==3.17.1
-      # - name: Run Unit tests
-      #   run: cd py42; tox -e py  # Run tox using the version of Python in `PATH`
-      # - name: Submit coverage report
-      #   uses: codecov/codecov-action@v1.0.7
-      #   with:
-      #     file: py42/coverage.xml
+      - name: Run Unit tests
+        run: cd py42; tox -e py  # Run tox using the version of Python in `PATH`
+      - name: Submit coverage report
+        uses: codecov/codecov-action@v1.0.7
+        with:
+          file: py42/coverage.xml
       - name: Checkout mock server 
         uses: actions/checkout@v2
         with:
@@ -40,7 +40,5 @@ jobs:
           path: code42-mock-servers
       - name: Start up the mock servers
         run: cd code42-mock-servers; docker-compose up -d --build
-      # - name: Curl against one of the containers 
-      #   run: docker ps -a; docker inspect --format "{{json .State.Health }}" mock_core | jq; curl http://127.0.0.1:4200/api/User/asdfz
-      - name: Run the integration tests!!
+      - name: Run the integration tests
         run: cd py42; tox -e integration

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,3 +30,10 @@ jobs:
         uses: codecov/codecov-action@v1.0.7
         with:
           file: ./coverage.xml
+      - name: Checkout mock server 
+        uses: actions/checkout@v2
+        with:
+          repository: code42/code42-mock-servers
+          path: code42-mock-servers
+      - name: Start up the mock servers
+        run: pwd; ls -lah

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,5 +40,7 @@ jobs:
           path: code42-mock-servers
       - name: Start up the mock servers
         run: cd code42-mock-servers; docker-compose up -d --build
-      - name: Curl against one of the containers 
-        run: docker ps -a; docker inspect --format "{{json .State.Health }}" mock_core | jq; curl http://127.0.0.1:4200/api/User/asdfz
+      # - name: Curl against one of the containers 
+      #   run: docker ps -a; docker inspect --format "{{json .State.Health }}" mock_core | jq; curl http://127.0.0.1:4200/api/User/asdfz
+      - name: Run the integration tests!!
+        run: pytest -m integration

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Checkout mock server
         uses: actions/checkout@v2
         with:
-          ref: feature/make-containers-use-host
           repository: code42/code42-mock-servers
           path: code42-mock-servers
       - name: Start up the mock servers

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist =
     py{39,38,37,36,35,27}
     docs
     style
-    integration
 
 skip_missing_interpreters = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands = pre-commit run --all-files --show-diff-on-failure
 
 [testenv:integration]
 commands =
-    pytest --cov=py42 --cov-report xml --cov-report term -v -rsxX -l --tb=short --strict -m integration
+    pytest -v -rsxX -l --tb=short --strict -m integration
 
 [pytest]
 markers =

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     py{39,38,37,36,35,27}
     docs
     style
+    integration
 
 skip_missing_interpreters = true
 
@@ -37,6 +38,10 @@ commands =
 deps = pre-commit
 skip_install = true
 commands = pre-commit run --all-files --show-diff-on-failure
+
+[testenv:integration]
+commands =
+    pytest --cov=py42 --cov-report xml --cov-report term -v -rsxX -l --tb=short --strict -m integration
 
 [pytest]
 markers =


### PR DESCRIPTION
### Description of Change ###
Before, we weren't able to run integration tests in the Github Action build action because we could not mock the downstream API endpoints.

Now, we have access to the `code42-mock-servers` project which allows us to run the integration tests in the build action.

#### NOTE: this PR has a dependency on https://github.com/code42/code42-mock-servers/pull/5

### Testing Procedure ###
Cut a new branch and push a commit to remote. Go to Github Actions and find the `build` action that was triggered by your branch. Open up one of the Python version build environments and select the Action step "Run the integration tests". Verify that the py42 integration tests were run and that they all passed.

### PR Checklist ###
Did you remember to do the below?

- [ N/A] Add unit tests to verify this change
- [ N/A] Add an entry to CHANGELOG.md describing this change
- [ N/A] Add docstrings for any new public parameters / methods / classes
