### PR TITLE
Change  fileCategory attribute values to camelcase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ## unreleased
 
+### Changed
+
+- Attribute value for `sdk.queries.fileevents.filters.file_filter.FileCategory.*` changed to "CamelCase" format.
+
 ### Added
 
 - `sdk.alerts.update_note()` to add or update note regarding an alert.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,6 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ## unreleased
 
-### Changed
-
-- Attribute value for `sdk.queries.fileevents.filters.file_filter.FileCategory.*` changed to "CamelCase" format.
-
 ### Added
 
 - `sdk.alerts.update_note()` to add or update note regarding an alert.

--- a/src/py42/sdk/queries/fileevents/filters/file_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/file_filter.py
@@ -24,18 +24,18 @@ class FileCategory(FileEventFilterStringField):
 
     _term = u"fileCategory"
 
-    AUDIO = u"AUDIO"
-    DOCUMENT = u"DOCUMENT"
-    EXECUTABLE = u"EXECUTABLE"
-    IMAGE = u"IMAGE"
-    PDF = u"PDF"
-    PRESENTATION = u"PRESENTATION"
-    SCRIPT = u"SCRIPT"
-    SOURCE_CODE = u"SOURCE_CODE"
-    SPREADSHEET = u"SPREADSHEET"
-    VIDEO = u"VIDEO"
-    VIRTUAL_DISK_IMAGE = u"VIRTUAL_DISK_IMAGE"
-    ZIP = u"ARCHIVE"
+    AUDIO = u"Audio"
+    DOCUMENT = u"Document"
+    EXECUTABLE = u"Executable"
+    IMAGE = u"Image"
+    PDF = u"Pdf"
+    PRESENTATION = u"Presentation"
+    SCRIPT = u"Script"
+    SOURCE_CODE = u"SourceCode"
+    SPREADSHEET = u"Spreadsheet"
+    VIDEO = u"Video"
+    VIRTUAL_DISK_IMAGE = u"VirtualDiskImage"
+    ZIP = u"Archive"
 
     @staticmethod
     def choices():

--- a/tests/sdk/queries/fileevents/filters/test_file_filter.py
+++ b/tests/sdk/queries/fileevents/filters/test_file_filter.py
@@ -18,13 +18,13 @@ from py42.sdk.queries.fileevents.filters.file_filter import SHA256
 
 def test_file_category_eq_str_gives_correct_json_representation():
     _filter = FileCategory.eq(FileCategory.AUDIO)
-    expected = IS.format("fileCategory", "AUDIO")
+    expected = IS.format("fileCategory", "Audio")
     assert str(_filter) == expected
 
 
 def test_file_category_not_eq_str_gives_correct_json_representation():
     _filter = FileCategory.not_eq(FileCategory.DOCUMENT)
-    expected = IS_NOT.format("fileCategory", "DOCUMENT")
+    expected = IS_NOT.format("fileCategory", "Document")
     assert str(_filter) == expected
 
 
@@ -271,17 +271,17 @@ def test_sha256_not_in_str_gives_correct_json_representation():
 def test_file_category_choices_returns_valid_attributes():
     choices = FileCategory.choices()
     valid_set = {
-        "AUDIO",
-        "DOCUMENT",
-        "EXECUTABLE",
-        "IMAGE",
-        "PDF",
-        "PRESENTATION",
-        "SCRIPT",
-        "SOURCE_CODE",
-        "SPREADSHEET",
-        "VIDEO",
-        "VIRTUAL_DISK_IMAGE",
-        "ARCHIVE",
+        "Audio",
+        "Document",
+        "Executable",
+        "Image",
+        "Pdf",
+        "Presentation",
+        "Script",
+        "SourceCode",
+        "Spreadsheet",
+        "Video",
+        "VirtualDiskImage",
+        "Archive",
     }
     assert set(choices) == valid_set


### PR DESCRIPTION
### Description of Change ###

Change attribute values to `CamelCase` format as changed in the API.

### Issues Resolved ###

- closes #INTEG-1521

### Testing Procedure ###
```
from py42.sdk.queries.fileevents.filters import *
fc_query = FileCategory.is_in([FileCategory.AUDIO])
query = FileEventQuery.all(fc_query)
>>> sdk.securitydata.search_all_file_events(query)
```

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [ NA] Add docstrings for any new public parameters / methods / classes
