### PR TITLE
use correct arg names in err

### DIFF
--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -187,7 +187,8 @@ class Py42LegalHoldCriteriaMissingError(Py42BadRequestError):
     def __init__(self, exception):
         super(Py42LegalHoldCriteriaMissingError, self).__init__(
             exception,
-            u"At least one criteria must be specified; hold_membership_uid, hold_uid, user_uid, or user.",
+            u"At least one criteria must be specified; legal_hold_membership_uid, "
+            u"legal_hold_uid, user_uid, or user.",
         )
 
 

--- a/tests/services/test_legalhold.py
+++ b/tests/services/test_legalhold.py
@@ -177,8 +177,13 @@ class TestLegalHoldService(object):
 
         mock_connection.get.side_effect = side_effect
         service = LegalHoldService(mock_connection)
-        with pytest.raises(Py42LegalHoldCriteriaMissingError):
+        with pytest.raises(Py42LegalHoldCriteriaMissingError) as err:
             service.get_custodians_page(1)
+
+        assert (
+            str(err.value) == "At least one criteria must be specified; "
+            "legal_hold_membership_uid, legal_hold_uid, user_uid, or user."
+        )
 
     def test_add_to_matter_calls_post_with_expected_url_and_params(
         self, mock_connection


### PR DESCRIPTION
### Description of Change ###

The argument names in the custom exception were incorrect. This fixes them.

### Issues Resolved ###
N/a

- closes #

### Testing Procedure ###
👁️ 

### PR Checklist ###
Did you remember to do the below?

- [X] Add unit tests to verify this change
- [n/a] Add an entry to CHANGELOG.md describing this change
- [ n/a] Add docstrings for any new public parameters / methods / classes
