### PR TITLE
Chore/remove detectionlist create_if_not_exists

### DIFF
--- a/docs/userguides/departingemployee.md
+++ b/docs/userguides/departingemployee.md
@@ -27,7 +27,6 @@ except Py42UserAlreadyAddedError:
 .. important::
     If the user is already in the Departing Employees list, you will get an `py42.exceptions.Py42UserAlreadyAddedError`.
 
-    If a detection list user profile doesn't exist yet for this user, one will automatically be created before adding the user to the Departing Employees list.
 ```
 
 To remove a user from the Departing Employees list:

--- a/docs/userguides/highriskemployee.md
+++ b/docs/userguides/highriskemployee.md
@@ -23,11 +23,8 @@ response = sdk.detectionlists.high_risk_employee.add(user_id)
 
 ```eval_rst
 .. important::
-    If the user is already in the High Risk Employee list, you will get a response indicating that it is a
-    bad request.
+    If the user is already in the High Risk Employee list, you will get a `py42.exceptions.Py42UserAlreadyAddedError`.
 
-    If a detection list user profile doesn't exist yet for this user, one will automatically be created before adding
-    the user to the High Risk Employee list.
 ```
 
 To remove a user from the High Risk Employee list:

--- a/src/py42/services/alertrules.py
+++ b/src/py42/services/alertrules.py
@@ -1,7 +1,5 @@
-from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42InvalidRuleError
 from py42.exceptions import Py42NotFoundError
-from py42.exceptions import Py42UserNotOnListError
 from py42.services import BaseService
 
 

--- a/src/py42/services/alertrules.py
+++ b/src/py42/services/alertrules.py
@@ -43,11 +43,7 @@ class AlertRulesService(BaseService):
 
     def add_user(self, rule_id, user_id):
         tenant_id = self._user_context.get_current_tenant_id()
-        try:
-            self._user_profile_service.create_if_not_exists(user_id)
-            user_details = self._user_profile_service.get_by_id(user_id)
-        except (Py42BadRequestError, Py42NotFoundError) as err:
-            raise Py42UserNotOnListError(err, user_id, "user profile")
+        user_details = self._user_profile_service.get_by_id(user_id)
         user_aliases = user_details.data.get(u"cloudUsernames") or []
         data = {
             u"tenantId": tenant_id,

--- a/src/py42/services/detectionlists/departing_employee.py
+++ b/src/py42/services/detectionlists/departing_employee.py
@@ -39,7 +39,7 @@ class DepartingEmployeeService(BaseService):
         """Adds a user to the Departing Employees list.
         `REST Documentation <https://developer.code42.com/api/#operation/DepartingEmployeeControllerV2_AddEmployee>`__
 
-        Raises a :class:`Py42BadRequestError` when a user already exists in the Departing Employee \
+        Raises a :class:`Py42UserAlreadyAddedError` when a user already exists in the Departing Employee \
             detection list.
 
         Args:

--- a/src/py42/services/detectionlists/departing_employee.py
+++ b/src/py42/services/detectionlists/departing_employee.py
@@ -36,8 +36,7 @@ class DepartingEmployeeService(BaseService):
         self._user_profile_service = user_profile_service
 
     def add(self, user_id, departure_date=None):
-        """Adds a user to the Departing Employees list. Creates a detection list user profile if one \
-            didn't already exist.
+        """Adds a user to the Departing Employees list.
         `REST Documentation <https://developer.code42.com/api/#operation/DepartingEmployeeControllerV2_AddEmployee>`__
 
         Raises a :class:`Py42BadRequestError` when a user already exists in the Departing Employee \
@@ -54,21 +53,18 @@ class DepartingEmployeeService(BaseService):
         """
         if isinstance(departure_date, datetime):
             departure_date = departure_date.strftime(_DATE_FORMAT)
-        if self._user_profile_service.create_if_not_exists(user_id):
-            tenant_id = self._user_context.get_current_tenant_id()
-            data = {
-                u"tenantId": tenant_id,
-                u"userId": user_id,
-                u"departureDate": departure_date,
-            }
-            uri = self._uri_prefix.format(u"add")
-            try:
-                return self._connection.post(uri, json=data)
-            except Py42BadRequestError as err:
-                handle_user_already_added_error(
-                    err, user_id, u"departing-employee list"
-                )
-                raise
+        tenant_id = self._user_context.get_current_tenant_id()
+        data = {
+            u"tenantId": tenant_id,
+            u"userId": user_id,
+            u"departureDate": departure_date,
+        }
+        uri = self._uri_prefix.format(u"add")
+        try:
+            return self._connection.post(uri, json=data)
+        except Py42BadRequestError as err:
+            handle_user_already_added_error(err, user_id, u"departing-employee list")
+            raise
 
     def remove(self, user_id):
         """Removes a user from the Departing Employees list.

--- a/src/py42/services/detectionlists/high_risk_employee.py
+++ b/src/py42/services/detectionlists/high_risk_employee.py
@@ -36,8 +36,7 @@ class HighRiskEmployeeService(BaseService):
         return self._connection.post(uri, json=data)
 
     def add(self, user_id):
-        """Adds a user to the High Risk Employee detection list. Creates a detection list user
-        profile if one didn't already exist.
+        """Adds a user to the High Risk Employee detection list.
 
         Raises a :class:`Py42BadRequestError` when a user already exists in the High Risk Employee
         detection list.
@@ -50,15 +49,12 @@ class HighRiskEmployeeService(BaseService):
         Returns:
             :class:`py42.response.Py42Response`
         """
-        if self._user_profile_service.create_if_not_exists(user_id):
-            tenant_id = self._user_context.get_current_tenant_id()
-            try:
-                return self._add_high_risk_employee(tenant_id, user_id)
-            except Py42BadRequestError as err:
-                handle_user_already_added_error(
-                    err, user_id, u"high-risk-employee list"
-                )
-                raise
+        tenant_id = self._user_context.get_current_tenant_id()
+        try:
+            return self._add_high_risk_employee(tenant_id, user_id)
+        except Py42BadRequestError as err:
+            handle_user_already_added_error(err, user_id, u"high-risk-employee list")
+            raise
 
     def set_alerts_enabled(self, enabled=True):
         """Enables alerts.

--- a/src/py42/services/detectionlists/high_risk_employee.py
+++ b/src/py42/services/detectionlists/high_risk_employee.py
@@ -38,7 +38,7 @@ class HighRiskEmployeeService(BaseService):
     def add(self, user_id):
         """Adds a user to the High Risk Employee detection list.
 
-        Raises a :class:`Py42BadRequestError` when a user already exists in the High Risk Employee
+        Raises a :class:`Py42UserAlreadyAddedError` when a user already exists in the High Risk Employee
         detection list.
         `REST Documentation <https://developer.code42.com/api/#operation/HighRiskEmployeeControllerV2_AddEmployee>`__
 

--- a/src/py42/services/detectionlists/user_profile.py
+++ b/src/py42/services/detectionlists/user_profile.py
@@ -20,26 +20,6 @@ class DetectionListUserService(BaseService):
     def _make_uri(self, action):
         return u"{}{}".format(self._resource, action)
 
-    def create_if_not_exists(self, user_id):
-        """Find out whether the detection list profile exists for a given uid. If not,
-           if user_id is a valid uid of code42 user then it will create detection list profile
-           of the user.
-
-            Returns True when profile is created else raises error.
-
-            Args:
-                user_id (str or int): Uid of user.
-
-            Returns:
-                bool
-        """
-        try:
-            self.get_by_id(user_id)
-        except (Py42NotFoundError, Py42BadRequestError):
-            user = self._user_service.get_by_uid(user_id)
-            self.create(user[u"username"])
-        return True
-
     def create(self, username):
         """Create a detection list profile for a user.
 

--- a/src/py42/services/detectionlists/user_profile.py
+++ b/src/py42/services/detectionlists/user_profile.py
@@ -1,6 +1,5 @@
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42CloudAliasLimitExceededError
-from py42.exceptions import Py42NotFoundError
 from py42.services import BaseService
 
 

--- a/tests/services/detectionlists/test_departing_employee.py
+++ b/tests/services/detectionlists/test_departing_employee.py
@@ -121,7 +121,7 @@ class TestDepartingEmployeeClient(object):
             and posted_data["departureDate"] == "2022-12-20"
         )
         assert mock_connection.post.call_args[0][0] == "v2/departingemployee/add"
-        assert mock_connection.post.call_count == 2
+        assert mock_connection.post.call_count == 1
 
     def test_add_when_user_already_on_list_raises_user_already_added_error(
         self, mocker, mock_connection, user_context, mock_detection_list_user_client

--- a/tests/services/detectionlists/test_high_risk_employee.py
+++ b/tests/services/detectionlists/test_high_risk_employee.py
@@ -62,7 +62,7 @@ class TestHighRiskEmployeeClient(object):
         high_risk_employee_client.add("942897397520289999")
 
         posted_data = mock_connection_post_success.post.call_args[1]["json"]
-        assert mock_connection_post_success.post.call_count == 2
+        assert mock_connection_post_success.post.call_count == 1
         assert (
             mock_connection_post_success.post.call_args[0][0]
             == "v2/highriskemployee/add"

--- a/tests/services/detectionlists/test_user_profile.py
+++ b/tests/services/detectionlists/test_user_profile.py
@@ -198,52 +198,6 @@ class TestDetectionListUserClient(object):
             and posted_data["cloudUsernames"] == ["Test"]
         )
 
-    def test_create_if_not_exists_posts_expected_data_when_user_exists(
-        self, mock_connection, user_context, mock_user_client
-    ):
-        detection_list_user_client = DetectionListUserService(
-            mock_connection, user_context, mock_user_client
-        )
-        assert (
-            detection_list_user_client.create_if_not_exists("942897397520289999")
-            is True
-        )
-
-        posted_data = mock_connection.post.call_args[1]["json"]
-        assert mock_connection.post.call_args[0][0] == "v2/user/getbyid"
-        assert (
-            posted_data["tenantId"] == user_context.get_current_tenant_id()
-            and posted_data["userId"] == "942897397520289999"
-        )
-        assert mock_connection.post.call_count == 1
-
-    def test_create_if_not_exists_posts_expected_data_when_user_does_not_exist(
-        self, mock_get_by_id_fails, user_context, mock_user_client
-    ):
-        # In this test case we can't verify create successful, hence we verified failure in create
-        # because same mock_connection instance
-        # 'mock_get_by_id_fails' will be called for get & create and its going to return failure.
-        # We verified create is being called and two times post method is called, also we
-        # verified user_client.get_by_uid is successfully called.
-        detection_list_user_client = DetectionListUserService(
-            mock_get_by_id_fails, user_context, mock_user_client
-        )
-        with pytest.raises(Py42BadRequestError):
-            detection_list_user_client.create_if_not_exists("942897397520289999")
-
-        posted_data = mock_get_by_id_fails.post.call_args[1]["json"]
-        assert mock_get_by_id_fails.post.call_args[0][0] == "v2/user/create"
-        assert (
-            posted_data["tenantId"] == user_context.get_current_tenant_id()
-            and posted_data["userName"] == "username"
-        )
-        assert mock_get_by_id_fails.post.call_count == 2
-        assert mock_user_client._connection.get.call_count == 1
-        assert (
-            mock_user_client._connection.get.call_args[0][0]
-            == "/api/User/942897397520289999"
-        )
-
     def test_refresh_posts_expected_data(
         self, mock_connection, user_context, mock_user_client
     ):

--- a/tests/services/test_alert_rules.py
+++ b/tests/services/test_alert_rules.py
@@ -3,10 +3,8 @@ import json
 import pytest
 from requests import Response
 
-from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42InvalidRuleError
 from py42.exceptions import Py42NotFoundError
-from py42.exceptions import Py42UserNotOnListError
 from py42.services.alertrules import AlertRulesService
 from py42.services.detectionlists.user_profile import DetectionListUserService
 
@@ -34,22 +32,6 @@ def mock_detection_list_user_service(mocker, py42_response):
 
 
 @pytest.fixture
-def mock_detection_list_get_by_id_failure_when_invalid_id(
-    mocker, mock_connection, py42_response
-):
-    response = mocker.MagicMock(spec=Response)
-    response.status_code = 400
-    exception = mocker.MagicMock(spec=Py42BadRequestError)
-    exception.response = response
-    detection_list_user_service = mocker.MagicMock(spec=DetectionListUserService)
-    detection_list_user_service.create_if_not_exists.return_value = False
-    detection_list_user_service.get_by_id.side_effect = Py42BadRequestError(
-        exception, ""
-    )
-    return detection_list_user_service
-
-
-@pytest.fixture
 def mock_detection_list_post_failure_when_invalid_rule_id(
     mocker, mock_connection, py42_response
 ):
@@ -59,25 +41,7 @@ def mock_detection_list_post_failure_when_invalid_rule_id(
     exception.response = response
     mock_connection.post.side_effect = Py42NotFoundError(exception, "")
     detection_list_user_service = mocker.MagicMock(spec=DetectionListUserService)
-    detection_list_user_service.create_if_not_exists.return_value = True
     detection_list_user_service.get_by_id.return_value = py42_response
-    return detection_list_user_service
-
-
-@pytest.fixture
-def mock_detection_list_user_service_create_user(
-    mocker, py42_response, http_error, mock_connection
-):
-    py42_response.text = MOCK_DETECTION_LIST_GET_RESPONSE
-    py42_response.data = json.loads(MOCK_DETECTION_LIST_GET_RESPONSE)
-    response = mocker.MagicMock(spec=Response)
-    response.status_code = 400
-    exception = mocker.MagicMock(spec=Py42BadRequestError)
-    exception.response = response
-    detection_list_user_service = mocker.MagicMock(spec=DetectionListUserService)
-    detection_list_user_service.get_by_id.return_value = py42_response
-    detection_list_user_service.create_if_not_exists.return_value = False
-    mock_connection.post.return_value = py42_response
     return detection_list_user_service
 
 
@@ -136,24 +100,6 @@ class TestAlertRulesService(object):
             and posted_data["ruleId"] == u"rule-id"
         )
 
-    def test_add_user_raises_valid_exception_when_user_id_is_invalid(
-        self,
-        mock_connection,
-        user_context,
-        mock_detection_list_get_by_id_failure_when_invalid_id,
-    ):
-        alert_rule_service = AlertRulesService(
-            mock_connection,
-            user_context,
-            mock_detection_list_get_by_id_failure_when_invalid_id,
-        )
-        with pytest.raises(Py42UserNotOnListError) as e:
-            alert_rule_service.add_user("rule-id", "invalid-user-id")
-        assert (
-            "'invalid-user-id' is not currently on the user profile list."
-            in e.value.args[0]
-        )
-
     def test_add_user_raises_valid_exception_when_rule_id_is_invalid(
         self,
         mock_connection,
@@ -168,25 +114,3 @@ class TestAlertRulesService(object):
         with pytest.raises(Py42InvalidRuleError) as e:
             alert_rule_service.add_user("invalid-rule-id", "user-id")
         assert "Invalid Observer Rule ID 'invalid-rule-id'." in e.value.args[0]
-
-    def test_add_user_posts_expected_data_when_user_does_not_exist_in_detectionlist(
-        self,
-        mock_connection,
-        user_context,
-        mock_detection_list_user_service_create_user,
-    ):
-        alert_rule_service = AlertRulesService(
-            mock_connection, user_context, mock_detection_list_user_service_create_user
-        )
-        alert_rule_service.add_user(u"rule-id", u"user-id")
-
-        assert mock_connection.post.call_count == 1
-        posted_data = mock_connection.post.call_args[1]["json"]
-        assert mock_connection.post.call_args[0][0] == "/svc/api/v1/Rules/add-users"
-        assert (
-            posted_data["tenantId"] == user_context.get_current_tenant_id()
-            and posted_data["ruleId"] == u"rule-id"
-            and posted_data["userList"][0]["userIdFromAuthority"] == u"user-id"
-            and posted_data["userList"][0]["userAliasList"]
-            == [u"user.aliases@code42.com"]
-        )


### PR DESCRIPTION
### Description of Change ###

Removes the logic for creating detection list profiles if they don't exist, since they now automatically get created on core user creation in the backend services.

### Issues Resolved ###
None

### Testing Procedure ###
Regression test methods for adding to Departing Employee, High Risk Employee, and Alert Rules lists. 

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change (removed related unit tests)
- [ ] Add an entry to CHANGELOG.md describing this change
- [x] Updated docstrings for any public parameters / methods / classes
