### PR TITLE
Add LegalHoldEventsReport call to legalhold service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Added
+
+- `sdk.legalhold.get_all_events` to search for legal hold events with optional parmeters of legal_hold_uid, min_event_date, and max_event_date
+
 ## 1.12.0 - 2021-02-25
 
 ### Added

--- a/src/py42/services/legalhold.py
+++ b/src/py42/services/legalhold.py
@@ -7,6 +7,7 @@ from py42.exceptions import Py42LegalHoldNotFoundOrPermissionDeniedError
 from py42.exceptions import Py42UserAlreadyAddedError
 from py42.services import BaseService
 from py42.services.util import get_all_pages
+from py42.util import parse_timestamp_to_milliseconds_precision
 
 
 def _active_state_map(active):
@@ -301,6 +302,10 @@ class LegalHoldService(BaseService):
             :class:`py42.response.Py42Response`:
         """
         page_size = page_size or settings.items_per_page
+        if min_event_date:
+            min_event_date = parse_timestamp_to_milliseconds_precision(min_event_date)
+        if max_event_date:
+            max_event_date = parse_timestamp_to_milliseconds_precision(max_event_date)
         params = {
             u"legalHoldUid": legal_hold_uid,
             u"minEventDate": min_event_date,
@@ -322,11 +327,11 @@ class LegalHoldService(BaseService):
         Args:
             legal_hold_uid (str, optional): Find LegalHoldEvent for the Legal Hold Matter
                 with this unique identifier. Defaults to None.
-            min_event_date (ISO date/time string, optional): Find LegalHoldEvents whose
-                eventDate is equal to or after this time. E.g. 2021-02-19T10:00:00.000-05:00
+            min_event_date (date/time string, optional): Find LegalHoldEvents whose
+                eventDate is equal to or after this time. E.g. yyyy-MM-dd HH:MM:SS
                  Defaults to None
-            max_event_date (ISO date/time string, optional): Find LegalHoldEvents whose
-                eventDate is equal to or before this time. E.g. 2021-02-19T10:00:00.000-05:00
+            max_event_date (date/time string, optional): Find LegalHoldEvents whose
+                eventDate is equal to or before this time. E.g. yyyy-MM-dd HH:MM:SS
                 Defaults to None
 
 
@@ -339,10 +344,8 @@ class LegalHoldService(BaseService):
             u"legalHoldEvents",
             legal_hold_uid=legal_hold_uid,
             min_event_date=min_event_date,
-            max_event_date=max_event_date
+            max_event_date=max_event_date,
         )
-
-
 
     def add_to_matter(self, user_uid, legal_hold_uid):
         """Add a user (Custodian) to a Legal Hold Matter.

--- a/src/py42/services/legalhold.py
+++ b/src/py42/services/legalhold.py
@@ -286,16 +286,16 @@ class LegalHoldService(BaseService):
     ):
         """Gets an individual page of Legal Hold events.
 
-        `REST Documentation <https://www.crashplan.com/apidocviewer/#LegalHoldEvent-get>`__
+        `REST Documentation <https://console.us.code42.com/apidocviewer/#LegalHoldEventReport-get>`__
 
         Args:
             page_num (int): The page number to request.
             legal_hold_uid (str, optional): Find LegalHoldEvents for the Legal Hold Matter
                 with this unique identifier. Defaults to None.
             min_event_date (ISO date/time string, optional): Find LegalHoldEvents whose
-                eventDate is equal to or after this time. Defaults to None
+                eventDate is equal to or after this time. Defaults to None.
             max_event_date (ISO date/time string, optional): Find LegalHoldEvents whose
-                eventDate is equal to or before this time. Defaults to None
+                eventDate is equal to or before this time. Defaults to None.
             page_size (int, optional): The size of the page. Defaults to `py42.settings.items_per_page`.
 
         Returns:
@@ -321,17 +321,17 @@ class LegalHoldService(BaseService):
         self, legal_hold_uid=None, min_event_date=None, max_event_date=None
     ):
         """Gets an individual page of Legal Hold events.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#LegalHoldEvent-get>`__
+        `REST Documentation <https://console.us.code42.com/apidocviewer/#LegalHoldEventReport-get>`__
 
         Args:
-            legal_hold_uid (str, optional): Find LegalHoldEvent for the Legal Hold Matter
+            legal_hold_uid (str, optional): Find LegalHoldEvents for the Legal Hold Matter
                 with this unique identifier. Defaults to None.
             min_event_date (date/time string, optional): Find LegalHoldEvents whose
                 eventDate is equal to or after this time. E.g. yyyy-MM-dd HH:MM:SS
-                Defaults to None
+                Defaults to None.
             max_event_date (date/time string, optional): Find LegalHoldEvents whose
                 eventDate is equal to or before this time. E.g. yyyy-MM-dd HH:MM:SS
-                Defaults to None
+                Defaults to None.
 
         Returns:
             generator: An object that iterates over :class:`py42.response.Py42Response` objects

--- a/src/py42/services/legalhold.py
+++ b/src/py42/services/legalhold.py
@@ -321,7 +321,6 @@ class LegalHoldService(BaseService):
         self, legal_hold_uid=None, min_event_date=None, max_event_date=None
     ):
         """Gets an individual page of Legal Hold events.
-
         `REST Documentation <https://console.us.code42.com/apidocviewer/#LegalHoldEvent-get>`__
 
         Args:
@@ -329,11 +328,10 @@ class LegalHoldService(BaseService):
                 with this unique identifier. Defaults to None.
             min_event_date (date/time string, optional): Find LegalHoldEvents whose
                 eventDate is equal to or after this time. E.g. yyyy-MM-dd HH:MM:SS
-                 Defaults to None
+                Defaults to None
             max_event_date (date/time string, optional): Find LegalHoldEvents whose
                 eventDate is equal to or before this time. E.g. yyyy-MM-dd HH:MM:SS
                 Defaults to None
-
 
         Returns:
             generator: An object that iterates over :class:`py42.response.Py42Response` objects

--- a/src/py42/services/legalhold.py
+++ b/src/py42/services/legalhold.py
@@ -275,6 +275,75 @@ class LegalHoldService(BaseService):
             active=active,
         )
 
+    def get_events_page(
+        self,
+        page_num,
+        legal_hold_uid=None,
+        min_event_date=None,
+        max_event_date=None,
+        page_size=None,
+    ):
+        """Gets an individual page of Legal Hold events.
+
+        `REST Documentation <https://www.crashplan.com/apidocviewer/#LegalHoldEvent-get>`__
+
+        Args:
+            page_num (int): The page number to request.
+            legal_hold_uid (str, optional): Find LegalHoldEvents for the Legal Hold Matter
+                with this unique identifier. Defaults to None.
+            min_event_date (ISO date/time string, optional): Find LegalHoldEvents whose
+                eventDate is equal to or after this time. Defaults to None
+            max_event_date (ISO date/time string, optional): Find LegalHoldEvents whose
+                eventDate is equal to or before this time. Defaults to None
+            page_size (int, optional): The size of the page. Defaults to `py42.settings.items_per_page`.
+
+        Returns:
+            :class:`py42.response.Py42Response`:
+        """
+        page_size = page_size or settings.items_per_page
+        params = {
+            u"legalHoldUid": legal_hold_uid,
+            u"minEventDate": min_event_date,
+            u"maxEventDate": max_event_date,
+            u"pgNum": page_num,
+            u"pgSize": page_size,
+        }
+        uri = u"/api/LegalHoldEventReport"
+
+        return self._connection.get(uri, params=params)
+
+    def get_all_events(
+        self, legal_hold_uid=None, min_event_date=None, max_event_date=None
+    ):
+        """Gets an individual page of Legal Hold events.
+
+        `REST Documentation <https://console.us.code42.com/apidocviewer/#LegalHoldEvent-get>`__
+
+        Args:
+            legal_hold_uid (str, optional): Find LegalHoldEvent for the Legal Hold Matter
+                with this unique identifier. Defaults to None.
+            min_event_date (ISO date/time string, optional): Find LegalHoldEvents whose
+                eventDate is equal to or after this time. E.g. 2021-02-19T10:00:00.000-05:00
+                 Defaults to None
+            max_event_date (ISO date/time string, optional): Find LegalHoldEvents whose
+                eventDate is equal to or before this time. E.g. 2021-02-19T10:00:00.000-05:00
+                Defaults to None
+
+
+        Returns:
+            generator: An object that iterates over :class:`py42.response.Py42Response` objects
+            that each contain a page of LegalHoldEvent objects.
+        """
+        return get_all_pages(
+            self.get_events_page,
+            u"legalHoldEvents",
+            legal_hold_uid=legal_hold_uid,
+            min_event_date=min_event_date,
+            max_event_date=max_event_date
+        )
+
+
+
     def add_to_matter(self, user_uid, legal_hold_uid):
         """Add a user (Custodian) to a Legal Hold Matter.
         `REST Documentation <https://console.us.code42.com/apidocviewer/#LegalHoldMembership-post>`__

--- a/tests/services/test_legalhold.py
+++ b/tests/services/test_legalhold.py
@@ -208,15 +208,13 @@ class TestLegalHoldService(object):
         self, mock_connection
     ):
         service = LegalHoldService(mock_connection)
-        service.get_events_page(
-            20, "legalhold", "2021-03-01 00:00:00", "2021-03-01 00:00:00", 200
-        )
+        service.get_events_page(20, "legalhold", None, None, 200)
         mock_connection.get.assert_called_once_with(
             "/api/LegalHoldEventReport",
             params={
                 "legalHoldUid": "legalhold",
-                "minEventDate": "2021-03-01T00:00:00.000Z",
-                "maxEventDate": "2021-03-01T00:00:00.000Z",
+                "minEventDate": None,
+                "maxEventDate": None,
                 "pgNum": 20,
                 "pgSize": 200,
             },

--- a/tests/services/test_legalhold.py
+++ b/tests/services/test_legalhold.py
@@ -34,6 +34,9 @@ MOCK_GET_ALL_MATTER_CUSTODIANS_RESPONSE = """{"legalHoldMemberships": ["foo"]}""
 
 MOCK_EMPTY_GET_ALL_MATTER_CUSTODIANS_RESPONSE = """{"legalHoldMemberships": []}"""
 
+MOCK_GET_ALL_EVENTS_RESPONSE = """{"legalHoldEvents":["foo"]}"""
+
+MOCK_EMPTY_GET_ALL_EVENTS_RESPONSE = """{"legalHoldEvents": []}"""
 
 class TestLegalHoldService(object):
     @pytest.fixture
@@ -66,6 +69,23 @@ class TestLegalHoldService(object):
         response.status_code = 200
         response.encoding = "utf-8"
         response.text = MOCK_EMPTY_GET_ALL_MATTER_CUSTODIANS_RESPONSE
+        return Py42Response(response)
+
+
+    @pytest.fixture
+    def mock_get_all_events_response(self, mocker):
+        response = mocker.MagicMock(spec=Response)
+        response.status_code = 200
+        response.encoding = "utf-8"
+        response.text = MOCK_GET_ALL_EVENTS_RESPONSE
+        return Py42Response(response)
+
+    @pytest.fixture
+    def mock_get_all_events_empty_response(self, mocker):
+        response = mocker.MagicMock(spec=Response)
+        response.status_code = 200
+        response.encoding = "utf-8"
+        response.text = MOCK_EMPTY_GET_ALL_EVENTS_RESPONSE
         return Py42Response(response)
 
     def test_get_matter_by_uid_calls_get_with_uri_and_params(
@@ -129,6 +149,24 @@ class TestLegalHoldService(object):
         py42.settings.items_per_page = 500
         assert mock_connection.get.call_count == 3
 
+    def test_get_all_events_calls_get_expected_number_of_times(
+        self,
+        mock_connection,
+        mock_get_all_events_response,
+        mock_get_all_events_empty_response,
+    ):
+        py42.settings.items_per_page = 1
+        service = LegalHoldService(mock_connection)
+        mock_connection.get.side_effect = [
+            mock_get_all_events_response,
+            mock_get_all_events_response,
+            mock_get_all_events_empty_response,
+        ]
+        for _ in service.get_all_events():
+            pass
+        py42.settings.items_per_page = 500
+        assert mock_connection.get.call_count == 3
+
     def test_get_matters_page_calls_get_with_expected_url_and_params(
         self, mock_connection
     ):
@@ -161,6 +199,24 @@ class TestLegalHoldService(object):
                 "userUid": "user ID",
                 "user": "username",
                 "activeState": "ACTIVE",
+                "pgNum": 20,
+                "pgSize": 200,
+            },
+        )
+
+    def test_get_events_page_calls_get_with_expected_url_and_params(
+        self, mock_connection
+    ):
+        service = LegalHoldService(mock_connection)
+        service.get_events_page(
+            20, "legalhold", "min event date", "max event date", 200
+        )
+        mock_connection.get.assert_called_once_with(
+            "/api/LegalHoldEventReport",
+            params={
+                "legalHoldUid": "legalhold",
+                "minEventDate": "min event date",
+                "maxEventDate": "max event date",
                 "pgNum": 20,
                 "pgSize": 200,
             },

--- a/tests/services/test_legalhold.py
+++ b/tests/services/test_legalhold.py
@@ -38,6 +38,7 @@ MOCK_GET_ALL_EVENTS_RESPONSE = """{"legalHoldEvents":["foo"]}"""
 
 MOCK_EMPTY_GET_ALL_EVENTS_RESPONSE = """{"legalHoldEvents": []}"""
 
+
 class TestLegalHoldService(object):
     @pytest.fixture
     def mock_get_all_matters_response(self, mocker):
@@ -70,7 +71,6 @@ class TestLegalHoldService(object):
         response.encoding = "utf-8"
         response.text = MOCK_EMPTY_GET_ALL_MATTER_CUSTODIANS_RESPONSE
         return Py42Response(response)
-
 
     @pytest.fixture
     def mock_get_all_events_response(self, mocker):
@@ -209,14 +209,14 @@ class TestLegalHoldService(object):
     ):
         service = LegalHoldService(mock_connection)
         service.get_events_page(
-            20, "legalhold", "min event date", "max event date", 200
+            20, "legalhold", "2021-03-01 00:00:00", "2021-03-01 00:00:00", 200
         )
         mock_connection.get.assert_called_once_with(
             "/api/LegalHoldEventReport",
             params={
                 "legalHoldUid": "legalhold",
-                "minEventDate": "min event date",
-                "maxEventDate": "max event date",
+                "minEventDate": "2021-03-01T00:00:00.000Z",
+                "maxEventDate": "2021-03-01T00:00:00.000Z",
                 "pgNum": 20,
                 "pgSize": 200,
             },


### PR DESCRIPTION
### Description of Change ###

Adds functions to call LegalHoldEventsReport resource and associated tests. Meets a gap identified by Code42CLI Issue # 176.

### Issues Resolved ###
Fixes #301 

### Testing Procedure ###

```
sdk.legalhold.get_all_events(legal_hold_uid=000000000000000000,min_event_date="yyyy-MM-dd HH:MM:SS",max_event_date="yyyy-MM-dd HH:MM:SS")
```

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
