### PR TITLE
added update user method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - `sdk.legalhold.get_all_events()` to search for legal hold events.
 
+- `sdk.users.update_user()` to update an existing user in Code42.
+
 ## 1.12.0 - 2021-02-25
 
 ### Added

--- a/src/py42/services/users.py
+++ b/src/py42/services/users.py
@@ -346,7 +346,7 @@ class UserService(BaseService):
         `REST Documentation <https://console.us.code42.com/apidocviewer/#User-put>`__
 
         Args:
-            user_uid (int): An ID for the user.
+            user_uid (int): The unique identifier for the user.
             username (str, optional): The username to which the user's username will be changed. Defaults to None.
             email (str, optional): The email to which the user's email will be changed. Defaults to None.
             password (str, optional): The password to which the user's password will be changed. Defaults to None.

--- a/src/py42/services/users.py
+++ b/src/py42/services/users.py
@@ -353,6 +353,7 @@ class UserService(BaseService):
             first_name (str, optional): The first name to which the user's first name will be changed. Defaults to None.
             last_name (str, optional): The last name to which the user's last name will be changed. Defaults to None.
             note (str, optional): Descriptive information about the user. Defaults to None.
+            quota (int, optional): The quota in bytes that limits the user's archive size.
 
         Returns:
             :class:`py42.response.Py42Response`

--- a/src/py42/services/users.py
+++ b/src/py42/services/users.py
@@ -339,7 +339,7 @@ class UserService(BaseService):
         password=None,
         first_name=None,
         last_name=None,
-        note=None,
+        notes=None,
         quota=None,
     ):
         """Updates an existing user.
@@ -352,7 +352,7 @@ class UserService(BaseService):
             password (str, optional): The password to which the user's password will be changed. Defaults to None.
             first_name (str, optional): The first name to which the user's first name will be changed. Defaults to None.
             last_name (str, optional): The last name to which the user's last name will be changed. Defaults to None.
-            note (str, optional): Descriptive information about the user. Defaults to None.
+            notes (str, optional): Descriptive information about the user. Defaults to None.
             quota (int, optional): The quota in bytes that limits the user's archive size. Defaults to None.
 
         Returns:
@@ -366,7 +366,7 @@ class UserService(BaseService):
             u"password": password,
             u"firstName": first_name,
             u"lastName": last_name,
-            u"notes": note,
+            u"notes": notes,
             u"quota": quota,
         }
         return self._connection.put(uri, json=data)

--- a/src/py42/services/users.py
+++ b/src/py42/services/users.py
@@ -333,7 +333,7 @@ class UserService(BaseService):
 
     def update_user(
         self,
-        user_id,
+        user_uid,
         username=None,
         email=None,
         password=None,
@@ -346,20 +346,20 @@ class UserService(BaseService):
         `REST Documentation <https://console.us.code42.com/apidocviewer/#User-put>`__
 
         Args:
-            user_id (int): An ID for the user.
+            user_uid (int): An ID for the user.
             username (str, optional): The username to which the user's username will be changed. Defaults to None.
             email (str, optional): The email to which the user's email will be changed. Defaults to None.
             password (str, optional): The password to which the user's password will be changed. Defaults to None.
             first_name (str, optional): The first name to which the user's first name will be changed. Defaults to None.
             last_name (str, optional): The last name to which the user's last name will be changed. Defaults to None.
             note (str, optional): Descriptive information about the user. Defaults to None.
-            quota (int, optional): The quota in bytes that limits the user's archive size.
+            quota (int, optional): The quota in bytes that limits the user's archive size. Defaults to None.
 
         Returns:
             :class:`py42.response.Py42Response`
         """
 
-        uri = u"/api/User/{}".format(user_id)
+        uri = u"/api/User/{}?idType=uid".format(user_uid)
         data = {
             u"username": username,
             u"email": email,
@@ -367,6 +367,6 @@ class UserService(BaseService):
             u"firstName": first_name,
             u"lastName": last_name,
             u"notes": note,
+            u"quota": quota,
         }
-
         return self._connection.put(uri, json=data)

--- a/src/py42/services/users.py
+++ b/src/py42/services/users.py
@@ -346,7 +346,7 @@ class UserService(BaseService):
         `REST Documentation <https://console.us.code42.com/apidocviewer/#User-put>`__
 
         Args:
-            user_uid (int): The unique identifier for the user.
+            user_uid (int): A Code42 user UID.
             username (str, optional): The username to which the user's username will be changed. Defaults to None.
             email (str, optional): The email to which the user's email will be changed. Defaults to None.
             password (str, optional): The password to which the user's password will be changed. Defaults to None.

--- a/src/py42/services/users.py
+++ b/src/py42/services/users.py
@@ -330,3 +330,42 @@ class UserService(BaseService):
         role_name = quote(role_name)
         uri = u"/api/UserRole?userId={}&roleName={}".format(user_id, role_name)
         return self._connection.delete(uri)
+
+    def update_user(
+        self,
+        user_id,
+        username=None,
+        email=None,
+        password=None,
+        first_name=None,
+        last_name=None,
+        note=None,
+        quota=None,
+    ):
+        """Updates an existing user.
+        `REST Documentation <https://console.us.code42.com/apidocviewer/#User-put>`__
+
+        Args:
+            user_id (int): An ID for the user.
+            username (str, optional): The username to which the user's username will be changed. Defaults to None.
+            email (str, optional): The email to which the user's email will be changed. Defaults to None.
+            password (str, optional): The password to which the user's password will be changed. Defaults to None.
+            first_name (str, optional): The first name to which the user's first name will be changed. Defaults to None.
+            last_name (str, optional): The last name to which the user's last name will be changed. Defaults to None.
+            note (str, optional): Descriptive information about the user. Defaults to None.
+
+        Returns:
+            :class:`py42.response.Py42Response`
+        """
+
+        uri = u"/api/User/{}".format(user_id)
+        data = {
+            u"username": username,
+            u"email": email,
+            u"password": password,
+            u"firstName": first_name,
+            u"lastName": last_name,
+            u"notes": note,
+        }
+
+        return self._connection.put(uri, json=data)

--- a/tests/services/test_users.py
+++ b/tests/services/test_users.py
@@ -53,6 +53,14 @@ class TestUserService(object):
         return Py42Response(response)
 
     @pytest.fixture
+    def put_api_mock_response(self, mocker):
+        response = mocker.MagicMock(spec=Response)
+        response.status_code = 200
+        response.encoding = "utf-8"
+        response.text = MOCK_text
+        return Py42Response(response)
+
+    @pytest.fixture
     def post_api_mock_error_response(self, mocker):
         response = mocker.MagicMock(spec=Response)
         response.status_code = 500
@@ -215,3 +223,54 @@ class TestUserService(object):
 
         expected = u"Cannot deactivate the user with ID 1234 as the user is involved in a legal hold matter."
         assert str(err.value) == expected
+
+    def test_update_user_calls_put_with_expected_url_and_params(
+        self, mock_connection, put_api_mock_response
+    ):
+        user_service = UserService(mock_connection)
+        mock_connection.post.return_value = put_api_mock_response
+        user_id = "TEST_USER_ID"
+        expected_uri = "{}/{}".format(USER_URI, user_id)
+        username = "TEST_ORG@TEST.COM"
+        email = "TEST_EMAIL@TEST.com"
+        password = "password"
+        first_name = "FIRSTNAME"
+        last_name = "LASTNAME"
+        note = "Test Note"
+        user_service.update_user(
+            user_id,
+            username=username,
+            email=email,
+            password=password,
+            first_name=first_name,
+            last_name=last_name,
+            note=note,
+        )
+        expected_params = {
+            u"username": username,
+            u"email": email,
+            u"password": password,
+            u"firstName": first_name,
+            u"lastName": last_name,
+            u"notes": note,
+        }
+        mock_connection.put.assert_called_once_with(expected_uri, json=expected_params)
+
+    def test_update_user_does_not_include_empty_params(
+        self, mock_connection, put_api_mock_response
+    ):
+        user_service = UserService(mock_connection)
+        mock_connection.post.return_value = put_api_mock_response
+        user_id = "TEST_USER_ID"
+        expected_uri = "{}/{}".format(USER_URI, user_id)
+        username = "TEST_ORG@TEST.COM"
+        user_service.update_user(user_id, username=username)
+        expected_params = {
+            u"username": username,
+            u"email": None,
+            u"password": None,
+            u"firstName": None,
+            u"lastName": None,
+            u"notes": None,
+        }
+        mock_connection.put.assert_called_once_with(expected_uri, json=expected_params)

--- a/tests/services/test_users.py
+++ b/tests/services/test_users.py
@@ -230,13 +230,14 @@ class TestUserService(object):
         user_service = UserService(mock_connection)
         mock_connection.post.return_value = put_api_mock_response
         user_id = "TEST_USER_ID"
-        expected_uri = "{}/{}".format(USER_URI, user_id)
+        expected_uri = "{}/{}?idType=uid".format(USER_URI, user_id)
         username = "TEST_ORG@TEST.COM"
         email = "TEST_EMAIL@TEST.com"
         password = "password"
         first_name = "FIRSTNAME"
         last_name = "LASTNAME"
         note = "Test Note"
+        quota = 12345
         user_service.update_user(
             user_id,
             username=username,
@@ -245,6 +246,7 @@ class TestUserService(object):
             first_name=first_name,
             last_name=last_name,
             note=note,
+            quota=quota,
         )
         expected_params = {
             u"username": username,
@@ -253,6 +255,7 @@ class TestUserService(object):
             u"firstName": first_name,
             u"lastName": last_name,
             u"notes": note,
+            u"quota": quota,
         }
         mock_connection.put.assert_called_once_with(expected_uri, json=expected_params)
 
@@ -262,7 +265,7 @@ class TestUserService(object):
         user_service = UserService(mock_connection)
         mock_connection.post.return_value = put_api_mock_response
         user_id = "TEST_USER_ID"
-        expected_uri = "{}/{}".format(USER_URI, user_id)
+        expected_uri = "{}/{}?idType=uid".format(USER_URI, user_id)
         username = "TEST_ORG@TEST.COM"
         user_service.update_user(user_id, username=username)
         expected_params = {
@@ -272,5 +275,6 @@ class TestUserService(object):
             u"firstName": None,
             u"lastName": None,
             u"notes": None,
+            u"quota": None,
         }
         mock_connection.put.assert_called_once_with(expected_uri, json=expected_params)

--- a/tests/services/test_users.py
+++ b/tests/services/test_users.py
@@ -245,7 +245,7 @@ class TestUserService(object):
             password=password,
             first_name=first_name,
             last_name=last_name,
-            note=note,
+            notes=note,
             quota=quota,
         )
         expected_params = {


### PR DESCRIPTION
### Description of Change ###

Currently, py42 can create a user, but cannot update a user that already exists. This change adds a method to allow updates to existing users.

### Issues Resolved ###
n/a, this is a prerequesite for work on parts of https://github.com/code42/code42cli/issues/259

### Testing Procedure ###
1. Create a user in Code42.
2. Create an SDK object using py42.
3. Run `sdk.users.update_user(user_id, username="new_username@test.com", email="new_username@test.com", first_name="new", last_name="name")`
4. Verify using the Code42 console that changes have applied as expected.

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
