### PR TITLE
Bugfix: use proxies from settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Fixed
+
+- Bug where proxy settings were not being applied correctly.
+
 ## 1.12.0 - 2021-02-25
 
 ### Added

--- a/src/py42/services/_connection.py
+++ b/src/py42/services/_connection.py
@@ -188,7 +188,7 @@ class Connection(object):
                 timeout=timeout,
                 verify=settings.verify_ssl_certs,
                 cert=cert,
-                proxies=proxies,
+                proxies=proxies or settings.proxies,
             )
 
             if not stream and response is not None:


### PR DESCRIPTION
### Description of Change ###

Proxy configuration defined on `py42.settings.proxies` were not actually being passed in to requests made in the session. This resolves that.

### Issues Resolved ###
#305 

### Testing Procedure ###
1. Start a local proxy server: 

```
docker run -it -p 8899:8899 --rm abhinavsingh/proxy.py:latest
```

2. Configure local proxy in py42 settings and make some requests: 

```
from py42 import sdk, settings

settings.proxies = {"https": "http://localhost:8899"}
sdk = sdk.from_local_account(...)

sdk.users.get_current()
```
3. Requests should show up in proxy.py container log output, confirming requests are going through the proxy. 
4. Shut down proxy container and attempt more py42 requests
5. Request attempts should raise `requests.exceptions.ProxyError` as py42 can't connect to the configured proxy. 
6. Remove proxy config by setting `settings.proxies = None`
7. Make more py42 requests
8. Requests should again succeed after proxy config disabled. 


### PR Checklist ###
Did you remember to do the below?

- [X] Add unit tests to verify this change
- [X] Add an entry to CHANGELOG.md describing this change
- [ ] Add docstrings for any new public parameters / methods / classes
