### PR TITLE
Fix arg name

### DIFF
--- a/src/py42/services/users.py
+++ b/src/py42/services/users.py
@@ -340,13 +340,13 @@ class UserService(BaseService):
         first_name=None,
         last_name=None,
         notes=None,
-        quota=None,
+        archive_size_quota_bytes=None,
     ):
         """Updates an existing user.
         `REST Documentation <https://console.us.code42.com/apidocviewer/#User-put>`__
 
         Args:
-            user_uid (int): A Code42 user UID.
+            user_uid (str or int): A Code42 user UID.
             username (str, optional): The username to which the user's username will be changed. Defaults to None.
             email (str, optional): The email to which the user's email will be changed. Defaults to None.
             password (str, optional): The password to which the user's password will be changed. Defaults to None.
@@ -367,6 +367,6 @@ class UserService(BaseService):
             u"firstName": first_name,
             u"lastName": last_name,
             u"notes": notes,
-            u"quota": quota,
+            u"quotaInBytes": archive_size_quota_bytes,
         }
         return self._connection.put(uri, json=data)

--- a/tests/services/test_users.py
+++ b/tests/services/test_users.py
@@ -246,7 +246,7 @@ class TestUserService(object):
             first_name=first_name,
             last_name=last_name,
             notes=note,
-            quota=quota,
+            archive_size_quota_bytes=quota,
         )
         expected_params = {
             u"username": username,
@@ -255,7 +255,7 @@ class TestUserService(object):
             u"firstName": first_name,
             u"lastName": last_name,
             u"notes": note,
-            u"quota": quota,
+            u"quotaInBytes": quota,
         }
         mock_connection.put.assert_called_once_with(expected_uri, json=expected_params)
 
@@ -275,6 +275,6 @@ class TestUserService(object):
             u"firstName": None,
             u"lastName": None,
             u"notes": None,
-            u"quota": None,
+            u"quotaInBytes": None,
         }
         mock_connection.put.assert_called_once_with(expected_uri, json=expected_params)


### PR DESCRIPTION
### Description of Change ###

Seems like the arg name for `quota` is incorrect. This fixes it as well as makes the public facing one more apparent at what it is 

### Issues Resolved ###

- closes #

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test that this change works as intended. What functions should be run? How can testers obtain valid parameters to test those functions? Where in the console can the actions of the functions be verified? -->

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [n/a] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
