### PR TITLE
Renamed filter term tabUrl to tabUrls and windowTitle to tabTitles

### DIFF
--- a/src/py42/sdk/queries/fileevents/filters/exposure_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/exposure_filter.py
@@ -129,7 +129,7 @@ class TabURL(FileEventFilterStringField):
     contents were read by the browser (applies to ``read by browser or other app`` events only).
     """
 
-    _term = u"tabUrl"
+    _term = u"tabUrls"
 
 
 class WindowTitle(FileEventFilterStringField):
@@ -138,4 +138,4 @@ class WindowTitle(FileEventFilterStringField):
     events only).
     """
 
-    _term = u"windowTitle"
+    _term = u"tabTitles"

--- a/src/py42/sdk/queries/fileevents/filters/exposure_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/exposure_filter.py
@@ -125,7 +125,7 @@ class SyncDestination(FileEventFilterStringField):
 
 
 class TabURL(FileEventFilterStringField):
-    """Class that filters events based on the URL of the active browser tab at the time the file
+    """Class that filters events based on all the URLs of the browser tabs at the time the file
     contents were read by the browser (applies to ``read by browser or other app`` events only).
     """
 
@@ -133,7 +133,7 @@ class TabURL(FileEventFilterStringField):
 
 
 class WindowTitle(FileEventFilterStringField):
-    """Class that filters events based on the name of the browser tab or application window that was
+    """Class that filters events based on the name of all the browser tabs or application windows that were
     open when a browser or other app event occurred (applies to ``read by browser or other app``
     events only).
     """

--- a/tests/sdk/queries/fileevents/filters/test_exposure_filter.py
+++ b/tests/sdk/queries/fileevents/filters/test_exposure_filter.py
@@ -413,77 +413,77 @@ def test_sync_destination_name_not_in_str_gives_correct_json_representation():
 
 def test_tab_url_exists_str_gives_correct_json_representation():
     _filter = TabURL.exists()
-    expected = EXISTS.format("tabUrl")
+    expected = EXISTS.format("tabUrls")
     assert str(_filter) == expected
 
 
 def test_tab_url_not_exists_str_gives_correct_json_representation():
     _filter = TabURL.not_exists()
-    expected = NOT_EXISTS.format("tabUrl")
+    expected = NOT_EXISTS.format("tabUrls")
     assert str(_filter) == expected
 
 
 def test_tab_url_eq_str_gives_correct_json_representation():
     _filter = TabURL.eq("test_tab_url")
-    expected = IS.format("tabUrl", "test_tab_url")
+    expected = IS.format("tabUrls", "test_tab_url")
     assert str(_filter) == expected
 
 
 def test_tab_url_not_eq_str_gives_correct_json_representation():
     _filter = TabURL.not_eq("test_tab_url")
-    expected = IS_NOT.format("tabUrl", "test_tab_url")
+    expected = IS_NOT.format("tabUrls", "test_tab_url")
     assert str(_filter) == expected
 
 
 def test_tab_url_is_in_str_gives_correct_json_representation():
     items = ["tab1", "tab2", "tab3"]
     _filter = TabURL.is_in(items)
-    expected = IS_IN.format("tabUrl", *items)
+    expected = IS_IN.format("tabUrls", *items)
     assert str(_filter) == expected
 
 
 def test_tab_url_not_in_str_gives_correct_json_representation():
     items = ["tab1", "tab2", "tab3"]
     _filter = TabURL.not_in(items)
-    expected = NOT_IN.format("tabUrl", *items)
+    expected = NOT_IN.format("tabUrls", *items)
     assert str(_filter) == expected
 
 
 def test_window_title_exists_str_gives_correct_json_representation():
     _filter = WindowTitle.exists()
-    expected = EXISTS.format("windowTitle")
+    expected = EXISTS.format("tabTitles")
     assert str(_filter) == expected
 
 
 def test_window_title_not_exists_str_gives_correct_json_representation():
     _filter = WindowTitle.not_exists()
-    expected = NOT_EXISTS.format("windowTitle")
+    expected = NOT_EXISTS.format("tabTitles")
     assert str(_filter) == expected
 
 
 def test_window_title_eq_str_gives_correct_json_representation():
     _filter = WindowTitle.eq("test_window")
-    expected = IS.format("windowTitle", "test_window")
+    expected = IS.format("tabTitles", "test_window")
     assert str(_filter) == expected
 
 
 def test_window_title_not_eq_str_gives_correct_json_representation():
     _filter = WindowTitle.not_eq("test_window")
-    expected = IS_NOT.format("windowTitle", "test_window")
+    expected = IS_NOT.format("tabTitles", "test_window")
     assert str(_filter) == expected
 
 
 def test_window_title_is_in_str_gives_correct_json_representation():
     items = ["window1", "window2", "window3"]
     _filter = WindowTitle.is_in(items)
-    expected = IS_IN.format("windowTitle", *items)
+    expected = IS_IN.format("tabTitles", *items)
     assert str(_filter) == expected
 
 
 def test_window_title_not_in_str_gives_correct_json_representation():
     items = ["window1", "window2", "window3"]
     _filter = WindowTitle.not_in(items)
-    expected = NOT_IN.format("windowTitle", *items)
+    expected = NOT_IN.format("tabTitles", *items)
     assert str(_filter) == expected
 
 


### PR DESCRIPTION
### Description of Change ###

Changed `term` value in exposure filters, as the changes are done in the underlying API.

### Issues Resolved ###
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- closes #INTEG-1494

### Testing Procedure ###
```
query = WindowTitle.exists()
sdk.securitydata.search_all_file_events(query)
```  
 or 
```
 query = TabUrl.exists()
>>> sdk.securitydata.search_all_file_events(query)
```
and similarly for all other possibilities.

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [ NA] Add an entry to CHANGELOG.md describing this change
- [ NA] Add docstrings for any new public parameters / methods / classes
