### PR TITLE
Custom err for username != email and fix unraised 500s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - Bug where proxy settings were not being applied correctly.
 
+- Bug where 500 errors would not raise during `sdk.users.create_user()`.
+
 ## 1.12.0 - 2021-02-25
 
 ### Added

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -219,6 +219,15 @@ class Py42UserAlreadyExistsError(Py42InternalServerError):
         super(Py42UserAlreadyExistsError, self).__init__(exception, message)
 
 
+class Py42UsernameMustBeEmailError(Py42InternalServerError):
+    """An exception raised when trying to set a non-email as a user's username
+    in a cloud environment."""
+
+    def __init__(self, exception):
+        message = "Username must be an email address."
+        super(Py42UsernameMustBeEmailError, self).__init__(exception, message)
+
+
 class Py42CloudAliasLimitExceededError(Py42BadRequestError):
     """An Exception raised when trying to add a cloud alias to a user when that user
     already has the max amount of supported cloud aliases."""


### PR DESCRIPTION
### Description of Change ###

* Adds customer error handling for `update_user()` when trying to update the username to a non-email.
* Fixes bug in `create_user()` method where the 500 errors would not raise
* Fixed test that would not testing anything
* Adds missing tests

### Issues Resolved ###
n/a

### Testing Procedure ###

* Try updating a user's username to something that is not an email in a cloud env and notice the custom error


### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
