### PR TITLE
DocFix/Remove-ISO-requirement-from-date-str-args-and-adjust-type

### DIFF
--- a/src/py42/clients/cases.py
+++ b/src/py42/clients/cases.py
@@ -56,18 +56,6 @@ class CasesClient(object):
             findings=findings,
         )
 
-    @staticmethod
-    def _make_range(begin_time, end_time):
-        if not begin_time and not end_time:
-            return None
-        if not begin_time:
-            begin_time = datetime.utcfromtimestamp(0)
-        if not end_time:
-            end_time = datetime.utcnow()
-        end = parse_timestamp_to_milliseconds_precision(end_time)
-        start = parse_timestamp_to_milliseconds_precision(begin_time)
-        return "{}/{}".format(start, end)
-
     def get_page(
         self,
         page_num,
@@ -111,8 +99,8 @@ class CasesClient(object):
             :class:`py42.response.Py42Response`
         """
 
-        created_at = CasesClient._make_range(min_create_time, max_create_time)
-        updated_at = CasesClient._make_range(min_update_time, max_update_time)
+        created_at = _make_range(min_create_time, max_create_time)
+        updated_at = _make_range(min_update_time, max_update_time)
 
         return self._cases_service.get_page(
             page_num,
@@ -170,8 +158,8 @@ class CasesClient(object):
             that each contain a page of cases.
         """
 
-        created_at = CasesClient._make_range(min_create_time, max_create_time)
-        updated_at = CasesClient._make_range(min_update_time, max_update_time)
+        created_at = _make_range(min_create_time, max_create_time)
+        updated_at = _make_range(min_update_time, max_update_time)
 
         return self._cases_service.get_all(
             name=name,
@@ -247,3 +235,15 @@ class CasesClient(object):
             findings=findings,
             status=status,
         )
+
+
+def _make_range(begin_time, end_time):
+    if not begin_time and not end_time:
+        return None
+    if not begin_time:
+        begin_time = datetime.utcfromtimestamp(0)
+    if not end_time:
+        end_time = datetime.utcnow()
+    end = parse_timestamp_to_milliseconds_precision(end_time)
+    start = parse_timestamp_to_milliseconds_precision(begin_time)
+    return "{}/{}".format(start, end)

--- a/src/py42/services/legalhold.py
+++ b/src/py42/services/legalhold.py
@@ -293,10 +293,10 @@ class LegalHoldService(BaseService):
                 Matter with this unique identifier. Defaults to None.
             min_event_date (str or int or float or datetime, optional): Find
                 LegalHoldEvents whose eventDate is equal to or after this time.
-                Defaults to None.
+                E.g. yyyy-MM-dd HH:MM:SS. Defaults to None.
             max_event_date (str or int or float or datetime, optional): Find
                 LegalHoldEvents whose eventDate is equal to or before this time.
-                Defaults to None.
+                E.g. yyyy-MM-dd HH:MM:SS. Defaults to None.
             page_num (int): The page number to request. Defaults to 1.
             page_size (int, optional): The size of the page.
                 Defaults to `py42.settings.items_per_page`.

--- a/src/py42/services/legalhold.py
+++ b/src/py42/services/legalhold.py
@@ -289,14 +289,17 @@ class LegalHoldService(BaseService):
         `REST Documentation <https://console.us.code42.com/apidocviewer/#LegalHoldEventReport-get>`__
 
         Args:
-            legal_hold_uid (str, optional): Find LegalHoldEvents for the Legal Hold Matter
-                with this unique identifier. Defaults to None.
-            min_event_date (ISO date/time string, optional): Find LegalHoldEvents whose
-                eventDate is equal to or after this time. Defaults to None.
-            max_event_date (ISO date/time string, optional): Find LegalHoldEvents whose
-                eventDate is equal to or before this time. Defaults to None.
+            legal_hold_uid (str, optional): Find LegalHoldEvents for the Legal Hold
+                Matter with this unique identifier. Defaults to None.
+            min_event_date (str or int or float or datetime, optional): Find
+                LegalHoldEvents whose eventDate is equal to or after this time.
+                Defaults to None.
+            max_event_date (str or int or float or datetime, optional): Find
+                LegalHoldEvents whose eventDate is equal to or before this time.
+                Defaults to None.
             page_num (int): The page number to request. Defaults to 1.
-            page_size (int, optional): The size of the page. Defaults to `py42.settings.items_per_page`.
+            page_size (int, optional): The size of the page.
+                Defaults to `py42.settings.items_per_page`.
 
         Returns:
             :class:`py42.response.Py42Response`:
@@ -326,12 +329,12 @@ class LegalHoldService(BaseService):
         Args:
             legal_hold_uid (str, optional): Find LegalHoldEvents for the Legal Hold Matter
                 with this unique identifier. Defaults to None.
-            min_event_date (date/time string, optional): Find LegalHoldEvents whose
-                eventDate is equal to or after this time. E.g. yyyy-MM-dd HH:MM:SS
-                Defaults to None.
-            max_event_date (date/time string, optional): Find LegalHoldEvents whose
-                eventDate is equal to or before this time. E.g. yyyy-MM-dd HH:MM:SS
-                Defaults to None.
+            min_event_date (str or int or float or datetime, optional): Find
+                LegalHoldEvents whose eventDate is equal to or after this time.
+                E.g. yyyy-MM-dd HH:MM:SS. Defaults to None.
+            max_event_date (str or int or float or datetime, optional): Find
+                LegalHoldEvents whose eventDate is equal to or before this time.
+                E.g. yyyy-MM-dd HH:MM:SS. Defaults to None.
 
         Returns:
             generator: An object that iterates over :class:`py42.response.Py42Response` objects
@@ -374,8 +377,8 @@ class LegalHoldService(BaseService):
         `REST Documentation <https://console.us.code42.com/apidocviewer/#LegalHoldMembershipDeactivation-post>`__
 
         Args:
-            legal_hold_membership_uid (str): The identifier of the LegalHoldMembership representing
-                the Custodian to Matter relationship.
+            legal_hold_membership_uid (str): The identifier of the LegalHoldMembership
+                representing the Custodian to Matter relationship.
 
         Returns:
             :class:`py42.response.Py42Response`

--- a/src/py42/util.py
+++ b/src/py42/util.py
@@ -115,7 +115,7 @@ def parse_timestamp_to_milliseconds_precision(timestamp):
 
 
 def parse_timestamp_to_microseconds_precision(timestamp):
-    if isinstance(timestamp, int) or isinstance(timestamp, float):
+    if isinstance(timestamp, (int, float)):
         return datetime.utcfromtimestamp(timestamp).strftime(_MICROSECOND_FORMAT)
     elif isinstance(timestamp, datetime):
         return timestamp.strftime(_MICROSECOND_FORMAT)

--- a/src/py42/util.py
+++ b/src/py42/util.py
@@ -104,7 +104,7 @@ def to_list(value):
 
 
 def parse_timestamp_to_milliseconds_precision(timestamp):
-    if isinstance(timestamp, int) or isinstance(timestamp, float):
+    if isinstance(timestamp, (int, float)):
         return convert_timestamp_to_str(timestamp)
     elif isinstance(timestamp, datetime):
         return convert_datetime_to_timestamp_str(timestamp)


### PR DESCRIPTION
### Description of Change ###

The doc for `min_event_date` and `max_event_date` for `get_all_events()` method mistakenly said ISO format was required.  Also, it left out the possibility that `datetime` objects or ints/floats could be used.  This adjusts those docs.

### Issues Resolved ###
Resolves an issue from QA.

### Testing Procedure ###
Look at docs.

### PR Checklist ###
Did you remember to do the below?

- [n/a] Add unit tests to verify this change
- [n/a] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
