### PR TITLE
switch to debug logs only

### DIFF
--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -60,7 +60,7 @@ class Py42HTTPError(Py42ResponseError):
             message = u"Failure in HTTP call {}. {}".format(
                 str(exception), response_content
             )
-            debug.logger.error(message)
+            debug.logger.debug(message)
 
         super(Py42HTTPError, self).__init__(exception.response, message)
 


### PR DESCRIPTION
### Description of Change ###

Changing the `.error` method to `.debug` for logging http errors because it looks really bad when doing bulk operations and depending on CLI output for progress, like we do in the CLI.

Here is what the output looks like (no `-d` was given for the CLI - this always happens no matter what)

```
Updating alerts:  [########################------------]   66%  00:00:01  2 succeeded, 0 failed out of 3Failure in HTTP call 404 Client Error: Not Found for url: https://alert-service-east.us.code42.com/svc/api/v1/update-state. Response content: {
  "pop-bulletin": {
    "Details": []
  }
}
Updating alerts:  [####################################]  100%  2 succeeded, 1 failed out of 3 
```

### Issues Resolved ###
No official issue

### Testing Procedure ###
Use this in the CLI as its py42 dependency. Do something erroronous.  Rely on logs instead of stdout.

### PR Checklist ###
Did you remember to do the below?

- [n/a] Add unit tests to verify this change
- [?] Add an entry to CHANGELOG.md describing this change
- [n/a] Add docstrings for any new public parameters / methods / classes
