### PR TITLE
Chore/users-get-all-org-does-not-exist-custom-error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 - Issue when calling `sdk.alerts.update_state()` without specifying a `note` parameter
     would set the existing alert's note's message to the empty string.
 
+### Added
+
+- Custom exception `Py42OrgNotFoundError`.
+
+### Changed
+
+- `sdk.users.get_all()` now raises `Py42OrgNotFoundError` when the given `org_uid`
+    was not found.
+
+- `sdk.users.get_page()` now raises `Py42OrgNotFoundError` when the given `org_uid`
+    was not found.
+
 ## 1.14.0 - 2021-04-20
 
 ### Added

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -148,6 +148,15 @@ class Py42TooManyRequestsError(Py42HTTPError):
     """A wrapper to represent an HTTP 429 error."""
 
 
+class Py42OrgNotFoundError(Py42BadRequestError):
+    """An error raised when the message of a 400 HTTP error indicates that
+    a Code42 organization was not found."""
+
+    def __init__(self, exception, org_uid):
+        msg = u"The organization with UID '{}' was not found.".format(org_uid)
+        super(Py42OrgNotFoundError, self).__init__(exception, msg)
+
+
 class Py42ActiveLegalHoldError(Py42BadRequestError):
     """An exception raised when attempting to deactivate a user or device that is in an
     active legal hold."""

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -149,8 +149,8 @@ class Py42TooManyRequestsError(Py42HTTPError):
 
 
 class Py42OrgNotFoundError(Py42BadRequestError):
-    """An error raised when the message of a 400 HTTP error indicates that
-    a Code42 organization was not found."""
+    """An exception raised when a 400 HTTP error message indicates that an
+    organization was not found."""
 
     def __init__(self, exception, org_uid):
         msg = u"The organization with UID '{}' was not found.".format(org_uid)

--- a/src/py42/services/users.py
+++ b/src/py42/services/users.py
@@ -2,6 +2,7 @@ from py42 import settings
 from py42._compat import quote
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42InternalServerError
+from py42.exceptions import Py42OrgNotFoundError
 from py42.exceptions import Py42UserAlreadyExistsError
 from py42.exceptions import Py42UsernameMustBeEmailError
 from py42.services import BaseService
@@ -151,8 +152,12 @@ class UserService(BaseService):
             q=q,
             **kwargs
         )
-
-        return self._connection.get(uri, params=params)
+        try:
+            return self._connection.get(uri, params=params)
+        except Py42BadRequestError as err:
+            if u"Organization was not found" in str(err.response.text):
+                raise Py42OrgNotFoundError(err, org_uid)
+            raise
 
     def get_all(
         self, active=None, email=None, org_uid=None, role_id=None, q=None, **kwargs


### PR DESCRIPTION
### Description of Change ###

* Adds custom error for when an org is not found when specifying `org_uid` when calling `sdk.users.get_all()` or `sdk.users.get_page()`.

### Issues Resolved ###
Will help resolve INTEG-1650

### Testing Procedure ###
Specify an org that does not exist using `org_uid` param for method `sdk.users.get_all()`.
Notice the custom error instead of just a Bad Request.

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
