### PR TITLE
make create just call get instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 - Issue where `sdk.detectionlists.create_user()` would always fail because of API changes.
     The method has been deprecated and now returns the response from `sdk.detectionlists.get()`.
 
+### Added
+
+- New custom exception `Py42UnableToCreateProfileError` that is raised when unable to call the
+    method `sdk.detectionlists.create_user()` method due to the user not existing in Code42 or
+    is already in the process of being created on the back-end.
+
 ## 1.14.2 - 2021-05-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Fixed
+
+- Issue where `sdk.detectionlists.create_user()` would always fail because of API changes.
+    The method has been deprecated now returns the response from `sdk.detectionlists.get()`.
+
 ## 1.14.2 - 2021-05-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Added
 
-- New custom exception `Py42UnableToCreateProfileError` that is raised when unable to call the
-    method `sdk.detectionlists.create_user()` method due to the user not existing in Code42 or
+- New custom exception `Py42UnableToCreateProfileError` that is raised when calling the
+    method `sdk.detectionlists.create_user()` due to the user not existing in Code42 or
     is already in the process of being created on the back-end.
 
 ## 1.14.2 - 2021-05-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 ### Fixed
 
 - Issue where `sdk.detectionlists.create_user()` would always fail because of API changes.
-    The method has been deprecated now returns the response from `sdk.detectionlists.get()`.
+    The method has been deprecated and now returns the response from `sdk.detectionlists.get()`.
 
 ## 1.14.2 - 2021-05-07
 

--- a/src/py42/clients/detectionlists.py
+++ b/src/py42/clients/detectionlists.py
@@ -1,3 +1,5 @@
+from py42.exceptions import Py42BadRequestError
+from py42.exceptions import Py42UnableToCreateProfileError
 from py42.util import get_attribute_keys_from_class
 
 
@@ -50,7 +52,12 @@ class DetectionListsClient(object):
         Returns:
             :class:`py42.response.Py42Response`
         """
-        return self._user_profile_service.get(username)
+        try:
+            return self._user_profile_service.get(username)
+        except Py42BadRequestError as err:
+            if "Could not find user" in str(err):
+                raise Py42UnableToCreateProfileError(err, username)
+            raise
 
     def get_user(self, username):
         """Get user details by username.

--- a/src/py42/clients/detectionlists.py
+++ b/src/py42/clients/detectionlists.py
@@ -40,8 +40,9 @@ class DetectionListsClient(object):
         return self._high_risk_employee_service
 
     def create_user(self, username):
-        """Create a detection list profile for a user.
-        `Rest Documentation <https://developer.code42.com/api/#operation/UserControllerV2_Create>`__
+        """Deprecated. Used to create a detection list profile for a user, but now that
+        happens automatically. Thus, this method instead returns the response from
+        an API call that gets the user's profile.
 
         Args:
             username (str): The Code42 username of the user.
@@ -49,7 +50,7 @@ class DetectionListsClient(object):
         Returns:
             :class:`py42.response.Py42Response`
         """
-        return self._user_profile_service.create(username)
+        return self._user_profile_service.get(username)
 
     def get_user(self, username):
         """Get user details by username.

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -281,9 +281,10 @@ class Py42UnableToCreateProfileError(Py42BadRequestError):
 
     def __init__(self, exception, username):
         message = (
-            u"Detection-list profiles are now created automatically on the server."
+            u"Detection-list profiles are now created automatically on the server. "
             u"Unable to find a detection-list profile for '{}'. "
-            u"It is possibly still being created.".format(username)
+            u"It is possibly still being created if you just recently created the "
+            u"Code42 user.".format(username)
         )
         super(Py42UnableToCreateProfileError, self).__init__(exception, message)
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -277,7 +277,7 @@ class Py42UnableToCreateProfileError(Py42BadRequestError):
     """An error raised when trying to call the method for creating a detection-list
     user when the user does not exist or is currently awaiting the profile to get
     created on the back-end. Note: you are no longer able to create detection-list
-    profiles using the API and the py42 only returns already existing profiles."""
+    profiles using the API and py42 only returns already existing profiles."""
 
     def __init__(self, exception, username):
         message = (

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -273,6 +273,21 @@ class Py42UserNotOnListError(Py42NotFoundError):
         super(Py42NotFoundError, self).__init__(exception, message)
 
 
+class Py42UnableToCreateProfileError(Py42BadRequestError):
+    """An error raised when trying to call the method for creating a detection-list
+    user when the user does not exist or is currently awaiting the profile to get
+    created on the back-end. Note: you are no longer able to create detection-list
+    profiles using the API and the py42 only returns already existing profiles."""
+
+    def __init__(self, exception, username):
+        message = (
+            u"Detection-list profiles are now created automatically on the server."
+            u"Unable to find a detection-list profile for '{}'. "
+            u"It is possibly still being created.".format(username)
+        )
+        super(Py42UnableToCreateProfileError, self).__init__(exception, message)
+
+
 class Py42InvalidRuleError(Py42NotFoundError):
     """An exception raised when the observer rule ID does not exist."""
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -277,7 +277,7 @@ class Py42UnableToCreateProfileError(Py42BadRequestError):
     """An error raised when trying to call the method for creating a detection-list
     user when the user does not exist or is currently awaiting the profile to get
     created on the back-end. Note: you are no longer able to create detection-list
-    profiles using the API and py42 only returns already existing profiles."""
+    profiles using the API; py42 only returns already existing profiles."""
 
     def __init__(self, exception, username):
         message = (

--- a/src/py42/services/detectionlists/user_profile.py
+++ b/src/py42/services/detectionlists/user_profile.py
@@ -19,25 +19,6 @@ class DetectionListUserService(BaseService):
     def _make_uri(self, action):
         return u"{}{}".format(self._resource, action)
 
-    def create(self, username):
-        """Create a detection list profile for a user.
-
-        Args:
-            username (str): Username of the user.
-
-        Returns:
-            :class:`py42.response.Py42Response`
-        """
-        data = {
-            u"tenantId": self._user_context.get_current_tenant_id(),
-            u"userName": username,
-            u"notes": "",
-            u"riskFactors": [],
-            u"cloudUsernames": [],
-        }
-        uri = self._make_uri(u"/create")
-        return self._connection.post(uri, json=data)
-
     def get_by_id(self, user_id):
         """Get user details by user UID.
 

--- a/tests/clients/test_alertrules.py
+++ b/tests/clients/test_alertrules.py
@@ -1,8 +1,8 @@
 import json
 
 import pytest
-from requests import HTTPError
 from requests import Response
+from tests.conftest import create_mock_error
 
 from py42.clients.alertrules import AlertRulesClient
 from py42.exceptions import Py42InternalServerError
@@ -48,9 +48,7 @@ def mock_alerts_service(mocker):
 
 @pytest.fixture
 def internal_server_error(mocker):
-    base_err = mocker.MagicMock(spec=HTTPError)
-    base_err.response = mocker.MagicMock(spec=Response)
-    return Py42InternalServerError(base_err)
+    return create_mock_error(Py42InternalServerError, mocker, "")
 
 
 class TestAlertRulesClient(object):

--- a/tests/clients/test_detectionlists.py
+++ b/tests/clients/test_detectionlists.py
@@ -114,9 +114,10 @@ class TestDetectionListClient(object):
 
         assert (
             str(err.value)
-            == "Detection-list profiles are now created automatically on the server. Unable "
-            "to find a detection-list profile for 'testusername'. It is possibly still "
-            "being created if you just recently created the Code42 user."
+            == "Detection-list profiles are now created automatically on the server. "
+            "Unable to find a detection-list profile for 'testusername'. It is "
+            "possibly still being created if you just recently created the Code42 "
+            "user."
         )
 
     def test_create_user_when_service_returns_bad_request_raises(

--- a/tests/clients/test_detectionlists.py
+++ b/tests/clients/test_detectionlists.py
@@ -79,7 +79,7 @@ class TestDetectionListClient(object):
             mock_high_risk_employee_service,
         )
         client.create_user("testusername")
-        mock_detection_list_user_service.create.assert_called_once_with("testusername")
+        mock_detection_list_user_service.get.assert_called_once_with("testusername")
 
     def test_get_user_calls_user_client_with_expected_values(
         self,

--- a/tests/clients/test_detectionlists.py
+++ b/tests/clients/test_detectionlists.py
@@ -113,10 +113,10 @@ class TestDetectionListClient(object):
             client.create_user("testusername")
 
         assert (
-            str(err.value) == "Detection-list profiles are now created automatically "
-            "on the server.Unable to find a detection-list profile "
-            "for 'testusername'. It is possibly still being "
-            "created."
+            str(err.value)
+            == "Detection-list profiles are now created automatically on the server. Unable "
+            "to find a detection-list profile for 'testusername'. It is possibly still "
+            "being created if you just recently created the Code42 user."
         )
 
     def test_create_user_when_service_returns_bad_request_raises(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,6 +213,12 @@ def create_mock_response(mocker, text):
     return Py42Response(response)
 
 
+def create_mock_error(err_class, mocker, text):
+    mock_http_error = mocker.MagicMock(spec=HTTPError)
+    mock_http_error.response = create_mock_response(mocker, text)
+    return err_class(mock_http_error)
+
+
 @pytest.fixture
 def mock_post_not_found_session(mocker, mock_connection):
     response = mocker.MagicMock(spec=Response)

--- a/tests/services/detectionlists/test_departing_employee.py
+++ b/tests/services/detectionlists/test_departing_employee.py
@@ -2,8 +2,7 @@
 from datetime import datetime
 
 import pytest
-from requests import HTTPError
-from requests import Response
+from tests.conftest import create_mock_error
 from tests.conftest import TENANT_ID_FROM_RESPONSE
 
 from py42.exceptions import Py42BadRequestError
@@ -128,10 +127,9 @@ class TestDepartingEmployeeClient(object):
     ):
         def side_effect(url, json):
             if "add" in url:
-                base_err = mocker.MagicMock(spec=HTTPError)
-                base_err.response = mocker.MagicMock(spec=Response)
-                base_err.response.text = "User already on list"
-                raise Py42BadRequestError(base_err)
+                raise create_mock_error(
+                    Py42BadRequestError, mocker, "User already on list"
+                )
 
         mock_connection.post.side_effect = side_effect
         client = DepartingEmployeeService(

--- a/tests/services/detectionlists/test_high_risk_employee.py
+++ b/tests/services/detectionlists/test_high_risk_employee.py
@@ -1,6 +1,5 @@
 import pytest
-from requests import HTTPError
-from requests import Response
+from tests.conftest import create_mock_error
 
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42NotFoundError
@@ -77,10 +76,9 @@ class TestHighRiskEmployeeClient(object):
     ):
         def side_effect(url, json):
             if "add" in url:
-                base_err = mocker.MagicMock(spec=HTTPError)
-                base_err.response = mocker.MagicMock(spec=Response)
-                base_err.response.text = "User already on list"
-                raise Py42BadRequestError(base_err)
+                raise create_mock_error(
+                    Py42BadRequestError, mocker, "User already on list"
+                )
 
         mock_connection.post.side_effect = side_effect
         client = HighRiskEmployeeService(

--- a/tests/services/detectionlists/test_user_profile.py
+++ b/tests/services/detectionlists/test_user_profile.py
@@ -60,25 +60,6 @@ class TestDetectionListUserClient(object):
         mock_connection.post.side_effect = Py42BadRequestError(exception)
         return user_client
 
-    def test_create_posts_expected_data(
-        self, mock_connection, user_context, mock_user_client
-    ):
-        detection_list_user_client = DetectionListUserService(
-            mock_connection, user_context, mock_user_client
-        )
-        detection_list_user_client.create("942897397520289999")
-
-        posted_data = mock_connection.post.call_args[1]["json"]
-        assert mock_connection.post.call_count == 1
-        assert mock_connection.post.call_args[0][0] == "v2/user/create"
-        assert (
-            posted_data["tenantId"] == user_context.get_current_tenant_id()
-            and posted_data["userName"] == "942897397520289999"
-            and posted_data["riskFactors"] == []
-            and posted_data["cloudUsernames"] == []
-            and posted_data["notes"] == ""
-        )
-
     def test_get_posts_expected_data(
         self, mock_connection, user_context, mock_user_client
     ):

--- a/tests/services/detectionlists/test_user_profile.py
+++ b/tests/services/detectionlists/test_user_profile.py
@@ -1,12 +1,10 @@
 import pytest
-from requests import Response
-from requests.exceptions import HTTPError
+from tests.conftest import create_mock_error
 
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42CloudAliasLimitExceededError
 from py42.services.detectionlists.user_profile import DetectionListUserService
 from py42.services.users import UserService
-
 
 CLOUD_ALIAS_LIMIT_EXCEEDED_ERROR_MESSAGE = """{
 "pop-bulletin": {
@@ -28,11 +26,9 @@ class TestDetectionListUserClient(object):
 
     @pytest.fixture
     def mock_get_by_id_fails(self, mocker, mock_connection):
-        response = mocker.MagicMock(spec=Response)
-        response.status_code = 400
-        exception = mocker.MagicMock(spec=HTTPError)
-        exception.response = response
-        mock_connection.post.side_effect = Py42BadRequestError(exception)
+        mock_connection.post.side_effect = create_mock_error(
+            Py42BadRequestError, mocker, ""
+        )
         return mock_connection
 
     @pytest.fixture
@@ -40,11 +36,9 @@ class TestDetectionListUserClient(object):
         self, mocker, mock_connection, user_context, py42_response
     ):
         user_client = UserService(mock_connection)
-        response = mocker.MagicMock(spec=Response)
-        response.status_code = 400
-        exception = mocker.MagicMock(spec=HTTPError)
-        exception.response = response
-        mock_connection.post.side_effect = Py42BadRequestError(exception)
+        mock_connection.post.side_effect = create_mock_error(
+            Py42BadRequestError, mocker, ""
+        )
         return user_client
 
     @pytest.fixture
@@ -52,12 +46,9 @@ class TestDetectionListUserClient(object):
         self, mocker, mock_connection, user_context, py42_response
     ):
         user_client = UserService(mock_connection)
-        response = mocker.MagicMock(spec=Response)
-        response.status_code = 400
-        response.text = CLOUD_ALIAS_LIMIT_EXCEEDED_ERROR_MESSAGE
-        exception = mocker.MagicMock(spec=HTTPError)
-        exception.response = response
-        mock_connection.post.side_effect = Py42BadRequestError(exception)
+        mock_connection.post.side_effect = create_mock_error(
+            Py42BadRequestError, mocker, CLOUD_ALIAS_LIMIT_EXCEEDED_ERROR_MESSAGE
+        )
         return user_client
 
     def test_get_posts_expected_data(

--- a/tests/services/storage/test_restore.py
+++ b/tests/services/storage/test_restore.py
@@ -1,6 +1,5 @@
 import pytest
-from requests import HTTPError
-from requests import Response
+from tests.conftest import create_mock_error
 from tests.conftest import TEST_ACCEPTING_GUID
 from tests.conftest import TEST_BACKUP_SET_ID
 from tests.conftest import TEST_DEVICE_GUID
@@ -23,15 +22,9 @@ def _create_expected_restore_groups(file):
 
 @pytest.fixture
 def mock_restore_connection_with_bad_request(mocker, mock_connection):
-    def side_effect(*args, **kwargs):
-        err = mocker.MagicMock(spec=HTTPError)
-        resp = mocker.MagicMock(spec=Response)
-        resp.text = "CREATE_FAILED"
-        err.response = resp
-        py42_error = Py42BadRequestError(err)
-        raise py42_error
-
-    mock_connection.post.side_effect = side_effect
+    mock_connection.post.side_effect = create_mock_error(
+        Py42BadRequestError, mocker, "CREATE_FAILED"
+    )
     return mock_connection
 
 

--- a/tests/services/test_cases.py
+++ b/tests/services/test_cases.py
@@ -1,4 +1,6 @@
 import pytest
+from tests.conftest import create_mock_error
+from tests.conftest import create_mock_response
 
 import py42.settings
 from py42.exceptions import Py42BadRequestError
@@ -7,8 +9,6 @@ from py42.exceptions import Py42DescriptionLimitExceededError
 from py42.exceptions import Py42InvalidCaseUserError
 from py42.exceptions import Py42UpdateClosedCaseError
 from py42.services.cases import CasesService
-
-from tests.conftest import create_mock_response, create_mock_error
 
 GET_ALL_TEST_RESPONSE = '{"cases":["test"], "totalCount":1}'
 EMPTY_GET_ALL_TEST_RESPONSE = '{"cases": [], "totalCount":0}'

--- a/tests/services/test_cases.py
+++ b/tests/services/test_cases.py
@@ -1,8 +1,4 @@
-import json
-
 import pytest
-from requests import HTTPError
-from requests import Response
 
 import py42.settings
 from py42.exceptions import Py42BadRequestError
@@ -10,33 +6,46 @@ from py42.exceptions import Py42CaseNameExistsError
 from py42.exceptions import Py42DescriptionLimitExceededError
 from py42.exceptions import Py42InvalidCaseUserError
 from py42.exceptions import Py42UpdateClosedCaseError
-from py42.response import Py42Response
 from py42.services.cases import CasesService
 
+from tests.conftest import create_mock_response, create_mock_error
 
-GET_ALL_TEST_RESPONSE = """{"cases":["test"], "totalCount":1}"""
-EMPTY_GET_ALL_TEST_RESPONSE = """{"cases": [], "totalCount":0}"""
-UPDATE_ERROR_RESPONSE = """{"timestamp":"2021-01-06T16:54:44.668+00:00","status":400,"error":"Bad Request","message":"NO_EDITS_ONCE_CLOSED","path":"/api/v1/case"}"""
-GET_CASE_RESPONSE = """
-{"assignee": "string", "assigneeUsername": "string",
-"createdAt": "2021-01-04T08:09:58.832Z", "createdByUserUid": "string",
-"createdByUsername": "string", "lastModifiedByUserUid": "string",
-"lastModifiedByUsername": "string", "name": "string", "number": 0, "status": "OPEN",
-"subject": "string", "subjectUsername": "string",
-"updatedAt": "2021-01-04T08:09:58.832Z"}
+GET_ALL_TEST_RESPONSE = '{"cases":["test"], "totalCount":1}'
+EMPTY_GET_ALL_TEST_RESPONSE = '{"cases": [], "totalCount":0}'
+UPDATE_ERROR_RESPONSE = """{
+    "timestamp": "2021-01-06T16:54:44.668+00:00",
+    "status": 400,
+    "error": "Bad Request",
+    "message": "NO_EDITS_ONCE_CLOSED",
+    "path": "/api/v1/case"
+}
 """
-
-NAME_EXISTS_ERROR_MSG = """{"problem":"NAME_EXISTS","description":null}"""
-DESCRIPTION_TOO_LONG_ERROR_MSG = (
-    """{"problem":"DESCRIPTION_TOO_LONG","description":null}"""
-)
-UNKNOWN_ERROR_MSG = """{"problem":"SURPRISE!"}"""
+GET_CASE_RESPONSE = """
+{
+    "assignee": "string",
+    "assigneeUsername": "string",
+    "createdAt": "2021-01-04T08:09:58.832Z",
+    "createdByUserUid": "string",
+    "createdByUsername": "string",
+    "lastModifiedByUserUid": "string",
+    "lastModifiedByUsername": "string",
+    "name": "string",
+    "number": 0,
+    "status": "OPEN",
+    "subject": "string",
+    "subjectUsername": "string",
+    "updatedAt": "2021-01-04T08:09:58.832Z"
+}
+"""
+NAME_EXISTS_ERROR_MSG = '{"problem":"NAME_EXISTS","description":null}'
+DESCRIPTION_TOO_LONG_ERROR_MSG = '{"problem":"DESCRIPTION_TOO_LONG","description":null}'
+UNKNOWN_ERROR_MSG = '{"problem":"SURPRISE!"}'
 _TEST_CASE_NUMBER = 123456
-_BASE_URI = u"/api/v1/case"
+_BASE_URI = "/api/v1/case"
 
 
 def _get_invalid_user_text(user_type):
-    return """{{"problem":"INVALID_USER","description":"{} validation failed"}}""".format(
+    return '{{"problem":"INVALID_USER","description":"{} validation failed"}}'.format(
         user_type
     )
 
@@ -44,69 +53,15 @@ def _get_invalid_user_text(user_type):
 class TestCasesService:
     @pytest.fixture
     def mock_case_response(self, mocker):
-        response = mocker.MagicMock(spec=Response)
-        response.status_code = 200
-        response.text = GET_ALL_TEST_RESPONSE
-        return Py42Response(response)
+        return create_mock_response(mocker, GET_ALL_TEST_RESPONSE)
 
     @pytest.fixture
     def mock_get_response(self, mocker):
-        response = mocker.MagicMock(spec=Response)
-        response.status_code = 200
-        response.text = GET_CASE_RESPONSE
-        response.data = json.loads(GET_CASE_RESPONSE)
-        return Py42Response(response)
+        return create_mock_response(mocker, GET_CASE_RESPONSE)
 
     @pytest.fixture
     def mock_case_empty_response(self, mocker):
-        response = mocker.MagicMock(spec=Response)
-        response.status_code = 200
-        response.text = EMPTY_GET_ALL_TEST_RESPONSE
-        return Py42Response(response)
-
-    @pytest.fixture
-    def mock_update_failed_response(self, mock_error_response):
-        http_error = HTTPError(UPDATE_ERROR_RESPONSE)
-        http_error.response = mock_error_response
-        http_error.response.text = UPDATE_ERROR_RESPONSE
-        return http_error
-
-    @pytest.fixture
-    def mock_description_too_long_response(self, mock_error_response):
-        http_error = HTTPError(DESCRIPTION_TOO_LONG_ERROR_MSG)
-        http_error.response = mock_error_response
-        http_error.response.text = DESCRIPTION_TOO_LONG_ERROR_MSG
-        return http_error
-
-    @pytest.fixture
-    def mock_invalid_subject_response(self, mock_error_response):
-        text = _get_invalid_user_text("subject")
-        http_error = HTTPError(text)
-        http_error.response = mock_error_response
-        http_error.response.text = text
-        return http_error
-
-    @pytest.fixture
-    def mock_invalid_assignee_response(self, mock_error_response):
-        text = _get_invalid_user_text("assignee")
-        http_error = HTTPError(text)
-        http_error.response = mock_error_response
-        http_error.response.text = text
-        return http_error
-
-    @pytest.fixture
-    def mock_name_exists_response(self, mock_error_response):
-        http_error = HTTPError(NAME_EXISTS_ERROR_MSG)
-        http_error.response = mock_error_response
-        http_error.response.text = NAME_EXISTS_ERROR_MSG
-        return http_error
-
-    @pytest.fixture
-    def mock_unknown_error(self, mock_error_response):
-        http_error = HTTPError(UNKNOWN_ERROR_MSG)
-        http_error.response = mock_error_response
-        http_error.response.text = UNKNOWN_ERROR_MSG
-        return http_error
+        return create_mock_response(mocker, EMPTY_GET_ALL_TEST_RESPONSE)
 
     def test_create_called_with_expected_url_and_params(self, mock_connection):
         cases_service = CasesService(mock_connection)
@@ -124,26 +79,26 @@ class TestCasesService:
         mock_connection.post.assert_called_once_with(_BASE_URI, json=data)
 
     def test_create_when_fails_with_name_exists_error_raises_custom_exception(
-        self, mock_connection, mock_name_exists_response
+        self, mocker, mock_connection
     ):
         cases_service = CasesService(mock_connection)
-        mock_connection.post.side_effect = Py42BadRequestError(
-            mock_name_exists_response
+        mock_connection.post.side_effect = create_mock_error(
+            Py42BadRequestError, mocker, NAME_EXISTS_ERROR_MSG
         )
-        with pytest.raises(Py42CaseNameExistsError) as e:
+        with pytest.raises(Py42CaseNameExistsError) as err:
             cases_service.create("Duplicate")
 
         assert (
-            e.value.args[0]
+            err.value.args[0]
             == u"Case name 'Duplicate' already exists, please set another name"
         )
 
     def test_create_when_fails_with_description_too_long_error_raises_custom_exception(
-        self, mock_connection, mock_description_too_long_response
+        self, mocker, mock_connection
     ):
         cases_service = CasesService(mock_connection)
-        mock_connection.post.side_effect = Py42BadRequestError(
-            mock_description_too_long_response
+        mock_connection.post.side_effect = create_mock_error(
+            Py42BadRequestError, mocker, DESCRIPTION_TOO_LONG_ERROR_MSG
         )
         with pytest.raises(Py42DescriptionLimitExceededError) as e:
             cases_service.create("test", description=u"supposedly too long")
@@ -153,11 +108,11 @@ class TestCasesService:
         )
 
     def test_create_when_fails_with_invalid_subject_raises_custom_exception(
-        self, mock_connection, mock_invalid_subject_response
+        self, mocker, mock_connection
     ):
         cases_service = CasesService(mock_connection)
-        mock_connection.post.side_effect = Py42BadRequestError(
-            mock_invalid_subject_response
+        mock_connection.post.side_effect = create_mock_error(
+            Py42BadRequestError, mocker, _get_invalid_user_text("subject")
         )
         with pytest.raises(Py42InvalidCaseUserError) as e:
             cases_service.create("test", subject="Not a person")
@@ -165,11 +120,11 @@ class TestCasesService:
         assert e.value.args[0] == "The provided subject is not a valid user."
 
     def test_create_when_fails_with_invalid_assignee_raises_custom_exception(
-        self, mock_connection, mock_invalid_assignee_response
+        self, mocker, mock_connection
     ):
         cases_service = CasesService(mock_connection)
-        mock_connection.post.side_effect = Py42BadRequestError(
-            mock_invalid_assignee_response
+        mock_connection.post.side_effect = create_mock_error(
+            Py42BadRequestError, mocker, _get_invalid_user_text("assignee")
         )
         with pytest.raises(Py42InvalidCaseUserError) as e:
             cases_service.create("test", assignee="Not a person")
@@ -177,10 +132,12 @@ class TestCasesService:
         assert e.value.args[0] == "The provided assignee is not a valid user."
 
     def test_create_when_fails_with_unknown_error_raises_exception(
-        self, mock_connection, mock_unknown_error
+        self, mocker, mock_connection
     ):
         cases_service = CasesService(mock_connection)
-        mock_connection.post.side_effect = Py42BadRequestError(mock_unknown_error)
+        mock_connection.post.side_effect = create_mock_error(
+            Py42BadRequestError, mocker, UNKNOWN_ERROR_MSG
+        )
         with pytest.raises(Py42BadRequestError) as e:
             cases_service.create("Case")
         assert e.value.response.status_code == 400
@@ -315,10 +272,12 @@ class TestCasesService:
         )
 
     def test_update_when_fails_with_name_exists_error_raises_custom_exception(
-        self, mock_connection, mock_name_exists_response
+        self, mocker, mock_connection
     ):
         cases_service = CasesService(mock_connection)
-        mock_connection.put.side_effect = Py42BadRequestError(mock_name_exists_response)
+        mock_connection.put.side_effect = create_mock_error(
+            Py42BadRequestError, mocker, NAME_EXISTS_ERROR_MSG
+        )
         with pytest.raises(Py42CaseNameExistsError) as e:
             cases_service.update(_TEST_CASE_NUMBER, "Duplicate")
 
@@ -328,12 +287,12 @@ class TestCasesService:
         )
 
     def test_update_when_case_is_closed_raises_custom_exception(
-        self, mock_connection, mock_get_response, mock_update_failed_response
+        self, mocker, mock_connection, mock_get_response
     ):
         cases_service = CasesService(mock_connection)
         mock_connection.get.return_value = mock_get_response
-        mock_connection.put.side_effect = Py42BadRequestError(
-            mock_update_failed_response
+        mock_connection.put.side_effect = create_mock_error(
+            Py42BadRequestError, mocker, UPDATE_ERROR_RESPONSE
         )
         with pytest.raises(Py42UpdateClosedCaseError) as e:
             cases_service.update(_TEST_CASE_NUMBER, findings=u"x")
@@ -341,12 +300,12 @@ class TestCasesService:
         assert e.value.args[0] == u"Cannot update a closed case."
 
     def test_update_when_fails_with_description_too_long_error_raises_custom_exception(
-        self, mock_connection, mock_get_response, mock_description_too_long_response
+        self, mocker, mock_connection, mock_get_response
     ):
         cases_service = CasesService(mock_connection)
         mock_connection.get.return_value = mock_get_response
-        mock_connection.put.side_effect = Py42BadRequestError(
-            mock_description_too_long_response
+        mock_connection.put.side_effect = create_mock_error(
+            Py42BadRequestError, mocker, DESCRIPTION_TOO_LONG_ERROR_MSG
         )
         with pytest.raises(Py42DescriptionLimitExceededError) as e:
             cases_service.update(_TEST_CASE_NUMBER, description=u"supposedly too long")
@@ -357,11 +316,11 @@ class TestCasesService:
         )
 
     def test_update_when_fails_with_invalid_subject_raises_custom_exception(
-        self, mock_connection, mock_invalid_subject_response
+        self, mocker, mock_connection
     ):
         cases_service = CasesService(mock_connection)
-        mock_connection.put.side_effect = Py42BadRequestError(
-            mock_invalid_subject_response
+        mock_connection.put.side_effect = create_mock_error(
+            Py42BadRequestError, mocker, _get_invalid_user_text("subject")
         )
         with pytest.raises(Py42InvalidCaseUserError) as e:
             cases_service.update(_TEST_CASE_NUMBER, subject="Not a person")
@@ -369,11 +328,11 @@ class TestCasesService:
         assert e.value.args[0] == "The provided subject is not a valid user."
 
     def test_update_when_fails_with_invalid_assignee_raises_custom_exception(
-        self, mock_connection, mock_invalid_assignee_response
+        self, mocker, mock_connection
     ):
         cases_service = CasesService(mock_connection)
-        mock_connection.put.side_effect = Py42BadRequestError(
-            mock_invalid_assignee_response
+        mock_connection.put.side_effect = create_mock_error(
+            Py42BadRequestError, mocker, _get_invalid_user_text("assignee")
         )
         with pytest.raises(Py42InvalidCaseUserError) as e:
             cases_service.update(_TEST_CASE_NUMBER, assignee="Not a person")

--- a/tests/services/test_cases.py
+++ b/tests/services/test_cases.py
@@ -100,11 +100,12 @@ class TestCasesService:
         mock_connection.post.side_effect = create_mock_error(
             Py42BadRequestError, mocker, DESCRIPTION_TOO_LONG_ERROR_MSG
         )
-        with pytest.raises(Py42DescriptionLimitExceededError) as e:
+        with pytest.raises(Py42DescriptionLimitExceededError) as err:
             cases_service.create("test", description=u"supposedly too long")
 
         assert (
-            e.value.args[0] == "Description limit exceeded, max 250 characters allowed."
+            err.value.args[0]
+            == "Description limit exceeded, max 250 characters allowed."
         )
 
     def test_create_when_fails_with_invalid_subject_raises_custom_exception(
@@ -114,10 +115,10 @@ class TestCasesService:
         mock_connection.post.side_effect = create_mock_error(
             Py42BadRequestError, mocker, _get_invalid_user_text("subject")
         )
-        with pytest.raises(Py42InvalidCaseUserError) as e:
+        with pytest.raises(Py42InvalidCaseUserError) as err:
             cases_service.create("test", subject="Not a person")
 
-        assert e.value.args[0] == "The provided subject is not a valid user."
+        assert err.value.args[0] == "The provided subject is not a valid user."
 
     def test_create_when_fails_with_invalid_assignee_raises_custom_exception(
         self, mocker, mock_connection
@@ -126,10 +127,10 @@ class TestCasesService:
         mock_connection.post.side_effect = create_mock_error(
             Py42BadRequestError, mocker, _get_invalid_user_text("assignee")
         )
-        with pytest.raises(Py42InvalidCaseUserError) as e:
+        with pytest.raises(Py42InvalidCaseUserError) as err:
             cases_service.create("test", assignee="Not a person")
 
-        assert e.value.args[0] == "The provided assignee is not a valid user."
+        assert err.value.args[0] == "The provided assignee is not a valid user."
 
     def test_create_when_fails_with_unknown_error_raises_exception(
         self, mocker, mock_connection
@@ -138,9 +139,8 @@ class TestCasesService:
         mock_connection.post.side_effect = create_mock_error(
             Py42BadRequestError, mocker, UNKNOWN_ERROR_MSG
         )
-        with pytest.raises(Py42BadRequestError) as e:
+        with pytest.raises(Py42BadRequestError):
             cases_service.create("Case")
-        assert e.value.response.status_code == 400
 
     def test_get_all_called_expected_number_of_times(
         self, mock_connection, mock_case_response, mock_case_empty_response
@@ -278,11 +278,11 @@ class TestCasesService:
         mock_connection.put.side_effect = create_mock_error(
             Py42BadRequestError, mocker, NAME_EXISTS_ERROR_MSG
         )
-        with pytest.raises(Py42CaseNameExistsError) as e:
+        with pytest.raises(Py42CaseNameExistsError) as err:
             cases_service.update(_TEST_CASE_NUMBER, "Duplicate")
 
         assert (
-            e.value.args[0]
+            err.value.args[0]
             == u"Case name 'Duplicate' already exists, please set another name"
         )
 
@@ -294,10 +294,10 @@ class TestCasesService:
         mock_connection.put.side_effect = create_mock_error(
             Py42BadRequestError, mocker, UPDATE_ERROR_RESPONSE
         )
-        with pytest.raises(Py42UpdateClosedCaseError) as e:
+        with pytest.raises(Py42UpdateClosedCaseError) as err:
             cases_service.update(_TEST_CASE_NUMBER, findings=u"x")
 
-        assert e.value.args[0] == u"Cannot update a closed case."
+        assert err.value.args[0] == u"Cannot update a closed case."
 
     def test_update_when_fails_with_description_too_long_error_raises_custom_exception(
         self, mocker, mock_connection, mock_get_response
@@ -307,11 +307,11 @@ class TestCasesService:
         mock_connection.put.side_effect = create_mock_error(
             Py42BadRequestError, mocker, DESCRIPTION_TOO_LONG_ERROR_MSG
         )
-        with pytest.raises(Py42DescriptionLimitExceededError) as e:
+        with pytest.raises(Py42DescriptionLimitExceededError) as err:
             cases_service.update(_TEST_CASE_NUMBER, description=u"supposedly too long")
 
         assert (
-            e.value.args[0]
+            err.value.args[0]
             == u"Description limit exceeded, max 250 characters allowed."
         )
 
@@ -322,10 +322,10 @@ class TestCasesService:
         mock_connection.put.side_effect = create_mock_error(
             Py42BadRequestError, mocker, _get_invalid_user_text("subject")
         )
-        with pytest.raises(Py42InvalidCaseUserError) as e:
+        with pytest.raises(Py42InvalidCaseUserError) as err:
             cases_service.update(_TEST_CASE_NUMBER, subject="Not a person")
 
-        assert e.value.args[0] == "The provided subject is not a valid user."
+        assert err.value.args[0] == "The provided subject is not a valid user."
 
     def test_update_when_fails_with_invalid_assignee_raises_custom_exception(
         self, mocker, mock_connection
@@ -334,7 +334,7 @@ class TestCasesService:
         mock_connection.put.side_effect = create_mock_error(
             Py42BadRequestError, mocker, _get_invalid_user_text("assignee")
         )
-        with pytest.raises(Py42InvalidCaseUserError) as e:
+        with pytest.raises(Py42InvalidCaseUserError) as err:
             cases_service.update(_TEST_CASE_NUMBER, assignee="Not a person")
 
-        assert e.value.args[0] == "The provided assignee is not a valid user."
+        assert err.value.args[0] == "The provided assignee is not a valid user."

--- a/tests/services/test_casesfileevents.py
+++ b/tests/services/test_casesfileevents.py
@@ -1,39 +1,19 @@
 import pytest
-from requests import HTTPError
 
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42CaseAlreadyHasEventError
 from py42.exceptions import Py42UpdateClosedCaseError
 from py42.services.casesfileevents import CasesFileEventsService
 
+from tests.conftest import create_mock_error
+
 _TEST_CASE_NUMBER = 123456
-UPDATE_ERROR_RESPONSE = """{"problem":"CASE_IS_CLOSED"}"""
-ADDED_SAME_EVENT_AGAIN_ERROR = """{"problem":"CASE_ALREADY_HAS_EVENT"}"""
-UNKNOWN_ERROR = """{"problem":"SURPRISE!"}"""
+UPDATE_ERROR_RESPONSE = '{"problem":"CASE_IS_CLOSED"}'
+ADDED_SAME_EVENT_AGAIN_ERROR = '{"problem":"CASE_ALREADY_HAS_EVENT"}'
+UNKNOWN_ERROR = '{"problem":"SURPRISE!"}'
 
 
 class TestCasesFileEventService:
-    @pytest.fixture
-    def mock_update_failed_response(self, mock_error_response):
-        http_error = HTTPError(UPDATE_ERROR_RESPONSE)
-        http_error.response = mock_error_response
-        http_error.response.text = UPDATE_ERROR_RESPONSE
-        return http_error
-
-    @pytest.fixture
-    def mock_add_same_event_multiple_times(self, mock_error_response):
-        http_error = HTTPError(ADDED_SAME_EVENT_AGAIN_ERROR)
-        http_error.response = mock_error_response
-        http_error.response.text = ADDED_SAME_EVENT_AGAIN_ERROR
-        return http_error
-
-    @pytest.fixture
-    def mock_unknown_error(self, mock_error_response):
-        http_error = HTTPError(UNKNOWN_ERROR)
-        http_error.response = mock_error_response
-        http_error.response.text = UNKNOWN_ERROR
-        return http_error
-
     def test_add_called_with_expected_url_and_params(self, mock_connection):
         case_file_event_service = CasesFileEventsService(mock_connection)
         case_file_event_service.add(_TEST_CASE_NUMBER, "event-id")
@@ -63,55 +43,57 @@ class TestCasesFileEventService:
         ] == u"/api/v1/case/{}/fileevent".format(_TEST_CASE_NUMBER)
 
     def test_add_on_a_closed_case_raises_error(
-        self, mock_connection, mock_update_failed_response
+        self, mocker, mock_connection
     ):
-        case_file_event_service = CasesFileEventsService(mock_connection)
-        mock_connection.post.side_effect = Py42BadRequestError(
-            mock_update_failed_response
+        mock_connection.post.side_effect = create_mock_error(
+            Py42BadRequestError, mocker, UPDATE_ERROR_RESPONSE
         )
-        with pytest.raises(Py42UpdateClosedCaseError) as e:
+        case_file_event_service = CasesFileEventsService(mock_connection)
+        with pytest.raises(Py42UpdateClosedCaseError) as err:
             case_file_event_service.add(_TEST_CASE_NUMBER, event_id=u"x")
 
-        assert e.value.args[0] == u"Cannot update a closed case."
+        assert err.value.args[0] == u"Cannot update a closed case."
 
     def test_delete_on_a_closed_case_raises_error(
-        self, mock_connection, mock_update_failed_response
+        self, mocker, mock_connection
     ):
         case_file_event_service = CasesFileEventsService(mock_connection)
-        mock_connection.delete.side_effect = Py42BadRequestError(
-            mock_update_failed_response
+        mock_connection.delete.side_effect = create_mock_error(
+            Py42BadRequestError, mocker, UPDATE_ERROR_RESPONSE
         )
-        with pytest.raises(Py42UpdateClosedCaseError) as e:
+        with pytest.raises(Py42UpdateClosedCaseError) as err:
             case_file_event_service.delete(_TEST_CASE_NUMBER, event_id=u"x")
 
-        assert e.value.args[0] == u"Cannot update a closed case."
+        assert err.value.args[0] == u"Cannot update a closed case."
 
     def test_add_when_same_event_is_added_multiple_times_raises_error(
-        self, mock_connection, mock_add_same_event_multiple_times
+        self, mocker, mock_connection
     ):
         case_file_event_service = CasesFileEventsService(mock_connection)
-        mock_connection.post.side_effect = Py42BadRequestError(
-            mock_add_same_event_multiple_times
+        mock_connection.post.side_effect = create_mock_error(
+            Py42BadRequestError, mocker, ADDED_SAME_EVENT_AGAIN_ERROR
         )
-        with pytest.raises(Py42CaseAlreadyHasEventError) as e:
+        with pytest.raises(Py42CaseAlreadyHasEventError) as err:
             case_file_event_service.add(_TEST_CASE_NUMBER, event_id=u"x")
 
-        assert e.value.args[0] == u"Event is already associated to the case."
+        assert err.value.args[0] == u"Event is already associated to the case."
 
     def test_add_when_unknown_error_raises_error(
-        self, mock_connection, mock_unknown_error
+        self, mocker, mock_connection
     ):
         case_file_event_service = CasesFileEventsService(mock_connection)
-        mock_connection.post.side_effect = Py42BadRequestError(mock_unknown_error)
-        with pytest.raises(Py42BadRequestError) as e:
+        mock_connection.post.side_effect = create_mock_error(
+            Py42BadRequestError, mocker, UNKNOWN_ERROR
+        )
+        with pytest.raises(Py42BadRequestError):
             case_file_event_service.add(_TEST_CASE_NUMBER, event_id=u"x")
-        assert e.value.response.status_code == 400
 
     def test_delete_when_unknown_error_raises_error(
-        self, mock_connection, mock_unknown_error
+        self, mocker, mock_connection
     ):
         case_file_event_service = CasesFileEventsService(mock_connection)
-        mock_connection.post.side_effect = Py42BadRequestError(mock_unknown_error)
-        with pytest.raises(Py42BadRequestError) as e:
+        mock_connection.post.side_effect = create_mock_error(
+            Py42BadRequestError, mocker, UNKNOWN_ERROR
+        )
+        with pytest.raises(Py42BadRequestError):
             case_file_event_service.add(_TEST_CASE_NUMBER, event_id=u"x")
-        assert e.value.response.status_code == 400

--- a/tests/services/test_casesfileevents.py
+++ b/tests/services/test_casesfileevents.py
@@ -1,11 +1,10 @@
 import pytest
+from tests.conftest import create_mock_error
 
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42CaseAlreadyHasEventError
 from py42.exceptions import Py42UpdateClosedCaseError
 from py42.services.casesfileevents import CasesFileEventsService
-
-from tests.conftest import create_mock_error
 
 _TEST_CASE_NUMBER = 123456
 UPDATE_ERROR_RESPONSE = '{"problem":"CASE_IS_CLOSED"}'
@@ -42,9 +41,7 @@ class TestCasesFileEventService:
             0
         ] == u"/api/v1/case/{}/fileevent".format(_TEST_CASE_NUMBER)
 
-    def test_add_on_a_closed_case_raises_error(
-        self, mocker, mock_connection
-    ):
+    def test_add_on_a_closed_case_raises_error(self, mocker, mock_connection):
         mock_connection.post.side_effect = create_mock_error(
             Py42BadRequestError, mocker, UPDATE_ERROR_RESPONSE
         )
@@ -54,9 +51,7 @@ class TestCasesFileEventService:
 
         assert err.value.args[0] == u"Cannot update a closed case."
 
-    def test_delete_on_a_closed_case_raises_error(
-        self, mocker, mock_connection
-    ):
+    def test_delete_on_a_closed_case_raises_error(self, mocker, mock_connection):
         case_file_event_service = CasesFileEventsService(mock_connection)
         mock_connection.delete.side_effect = create_mock_error(
             Py42BadRequestError, mocker, UPDATE_ERROR_RESPONSE
@@ -78,9 +73,7 @@ class TestCasesFileEventService:
 
         assert err.value.args[0] == u"Event is already associated to the case."
 
-    def test_add_when_unknown_error_raises_error(
-        self, mocker, mock_connection
-    ):
+    def test_add_when_unknown_error_raises_error(self, mocker, mock_connection):
         case_file_event_service = CasesFileEventsService(mock_connection)
         mock_connection.post.side_effect = create_mock_error(
             Py42BadRequestError, mocker, UNKNOWN_ERROR
@@ -88,9 +81,7 @@ class TestCasesFileEventService:
         with pytest.raises(Py42BadRequestError):
             case_file_event_service.add(_TEST_CASE_NUMBER, event_id=u"x")
 
-    def test_delete_when_unknown_error_raises_error(
-        self, mocker, mock_connection
-    ):
+    def test_delete_when_unknown_error_raises_error(self, mocker, mock_connection):
         case_file_event_service = CasesFileEventsService(mock_connection)
         mock_connection.post.side_effect = create_mock_error(
             Py42BadRequestError, mocker, UNKNOWN_ERROR

--- a/tests/services/test_file_event.py
+++ b/tests/services/test_file_event.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
-from requests import HTTPError
-from requests import Response
+from tests.conftest import create_mock_error
 
 from py42._compat import str
 from py42.exceptions import Py42BadRequestError
@@ -20,14 +19,9 @@ def _create_test_query(test_filename=u"*"):
 
 @pytest.fixture()
 def mock_invalid_page_token_connection(mocker, connection):
-    def side_effect(*args, **kwargs):
-        http_error = mocker.MagicMock(spec=HTTPError)
-        response = mocker.MagicMock(spec=Response)
-        response.text = "INVALID_PAGE_TOKEN"
-        http_error.response = response
-        raise Py42BadRequestError(http_error)
-
-    connection.post.side_effect = side_effect
+    connection.post.side_effect = create_mock_error(
+        Py42BadRequestError, mocker, "INVALID_PAGE_TOKEN"
+    )
     return connection
 
 
@@ -68,14 +62,9 @@ class TestFileEventService(object):
     def test_search_when_bad_request_raised_with_token_but_has_not_invalid_token_text_raises_bad_request(
         self, mocker, connection
     ):
-        def side_effect(*args, **kwargs):
-            http_error = mocker.MagicMock(spec=HTTPError)
-            response = mocker.MagicMock(spec=Response)
-            response.text = "DIFFERENT_ERROR"
-            http_error.response = response
-            raise Py42BadRequestError(http_error)
-
-        connection.post.side_effect = side_effect
+        connection.post.side_effect = create_mock_error(
+            Py42BadRequestError, mocker, "DIFFERENT_ERROR"
+        )
         query = _create_test_query()
         query.page_token = "test_page_token"
         service = FileEventService(connection)


### PR DESCRIPTION
### Description of Change ###

Instead of returning a noop 200 response, we could return the response from `get()`. That way, it will contain the same response data as before.

One issue with this is that getting a detection list profile by username is more delayed than getting a profile by ID, for newly created users. However, anybody's script that was calling `create` for newly created users would have already been failing from the API, so this is fine imo.

### Issues Resolved ###
n/a


### Testing Procedure ###
Call the method `sdk.detectionlists.create_user()` and make sure the response is 200 for users that exist.

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
