### PR TITLE
Feature/add sync destination username filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
     method `sdk.detectionlists.create_user()` due to the user not existing in Code42 or
     is already in the process of being created on the back-end.
 
+- `SyncDestinationUsername` filter class to `py42.sdk.queries.fileevents.filters.exposure_filter` module.
+
 ## 1.14.2 - 2021-05-07
 
 ### Fixed

--- a/src/py42/sdk/queries/fileevents/filters/exposure_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/exposure_filter.py
@@ -124,6 +124,10 @@ class SyncDestination(FileEventFilterStringField):
         return get_attribute_keys_from_class(SyncDestination)
 
 
+class SyncDestinationUsername(FileEventFilterStringField):
+    _term = u"syncDestinationUsername"
+
+
 class TabURL(FileEventFilterStringField):
     """Class that filters events based on all the URLs of the browser tabs at the time the file
     contents were read by the browser (applies to ``read by browser or other app`` events only).

--- a/src/py42/sdk/queries/fileevents/filters/exposure_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/exposure_filter.py
@@ -125,7 +125,7 @@ class SyncDestination(FileEventFilterStringField):
 
 
 class SyncDestinationUsername(FileEventFilterStringField):
-    """Class that filters events based on the name of the username associated with the cloud service
+    """Class that filters events based on the username associated with the cloud service
     the file is synced with (applies to ``synced to cloud service`` events only).
     """
 

--- a/src/py42/sdk/queries/fileevents/filters/exposure_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/exposure_filter.py
@@ -125,6 +125,10 @@ class SyncDestination(FileEventFilterStringField):
 
 
 class SyncDestinationUsername(FileEventFilterStringField):
+    """Class that filters events based on the name of the username associated with the cloud service
+    the file is synced with (applies to ``synced to cloud service`` events only).
+    """
+
     _term = u"syncDestinationUsername"
 
 

--- a/tests/sdk/queries/fileevents/filters/test_exposure_filter.py
+++ b/tests/sdk/queries/fileevents/filters/test_exposure_filter.py
@@ -19,6 +19,7 @@ from py42.sdk.queries.fileevents.filters.exposure_filter import (
 from py42.sdk.queries.fileevents.filters.exposure_filter import RemovableMediaVendor
 from py42.sdk.queries.fileevents.filters.exposure_filter import RemovableMediaVolumeName
 from py42.sdk.queries.fileevents.filters.exposure_filter import SyncDestination
+from py42.sdk.queries.fileevents.filters.exposure_filter import SyncDestinationUsername
 from py42.sdk.queries.fileevents.filters.exposure_filter import TabURL
 from py42.sdk.queries.fileevents.filters.exposure_filter import WindowTitle
 
@@ -408,6 +409,44 @@ def test_sync_destination_name_not_in_str_gives_correct_json_representation():
     items = [SyncDestination.GOOGLE_DRIVE, SyncDestination.BOX, SyncDestination.ICLOUD]
     _filter = SyncDestination.not_in(items)
     expected = NOT_IN.format("syncDestination", *sorted(items))
+    assert str(_filter) == expected
+
+
+def test_sync_destination_username_exists_str_gives_correct_json_representation():
+    _filter = SyncDestinationUsername.exists()
+    expected = EXISTS.format("syncDestinationUsername")
+    assert str(_filter) == expected
+
+
+def test_sync_destination_username_not_exists_str_gives_correct_json_representation():
+    _filter = SyncDestinationUsername.not_exists()
+    expected = NOT_EXISTS.format("syncDestinationUsername")
+    assert str(_filter) == expected
+
+
+def test_sync_destination_username_eq_str_gives_correct_json_representation():
+    _filter = SyncDestinationUsername.eq("test_user@gmail.com")
+    expected = IS.format("syncDestinationUsername", "test_user@gmail.com")
+    assert str(_filter) == expected
+
+
+def test_sync_destination_username_not_eq_str_gives_correct_json_representation():
+    _filter = SyncDestinationUsername.not_eq("test_user@gmail.com")
+    expected = IS_NOT.format("syncDestinationUsername", "test_user@gmail.com")
+    assert str(_filter) == expected
+
+
+def test_sync_destination_username_is_in_str_gives_correct_json_representation():
+    items = ["*@hotmail.com", "user1@gmail.com", "user2@gmail.com"]
+    _filter = SyncDestinationUsername.is_in(items)
+    expected = IS_IN.format("syncDestinationUsername", *items)
+    assert str(_filter) == expected
+
+
+def test_sync_destination_username_not_in_str_gives_correct_json_representation():
+    items = ["*@hotmail.com", "user1@gmail.com", "user2@gmail.com"]
+    _filter = SyncDestinationUsername.not_in(items)
+    expected = NOT_IN.format("syncDestinationUsername", *items)
     assert str(_filter) == expected
 
 

--- a/tests/sdk/queries/fileevents/filters/test_exposure_filter.py
+++ b/tests/sdk/queries/fileevents/filters/test_exposure_filter.py
@@ -425,26 +425,26 @@ def test_sync_destination_username_not_exists_str_gives_correct_json_representat
 
 
 def test_sync_destination_username_eq_str_gives_correct_json_representation():
-    _filter = SyncDestinationUsername.eq("test_user@gmail.com")
-    expected = IS.format("syncDestinationUsername", "test_user@gmail.com")
+    _filter = SyncDestinationUsername.eq("test_user@example.com")
+    expected = IS.format("syncDestinationUsername", "test_user@example.com")
     assert str(_filter) == expected
 
 
 def test_sync_destination_username_not_eq_str_gives_correct_json_representation():
-    _filter = SyncDestinationUsername.not_eq("test_user@gmail.com")
-    expected = IS_NOT.format("syncDestinationUsername", "test_user@gmail.com")
+    _filter = SyncDestinationUsername.not_eq("test_user@example.com")
+    expected = IS_NOT.format("syncDestinationUsername", "test_user@example.com")
     assert str(_filter) == expected
 
 
 def test_sync_destination_username_is_in_str_gives_correct_json_representation():
-    items = ["*@hotmail.com", "user1@gmail.com", "user2@gmail.com"]
+    items = ["*@example2.com", "user1@example.com", "user2@example.com"]
     _filter = SyncDestinationUsername.is_in(items)
     expected = IS_IN.format("syncDestinationUsername", *items)
     assert str(_filter) == expected
 
 
 def test_sync_destination_username_not_in_str_gives_correct_json_representation():
-    items = ["*@hotmail.com", "user1@gmail.com", "user2@gmail.com"]
+    items = ["*@example2.com", "user1@example.com", "user2@example.com"]
     _filter = SyncDestinationUsername.not_in(items)
     expected = NOT_IN.format("syncDestinationUsername", *items)
     assert str(_filter) == expected


### PR DESCRIPTION
### Description of Change ###

Add a filter class to allow users to filter file event query results by sync destination username. 

### Issues Resolved ###
- closes #INTEG-1703

### Testing Procedure ###
```
>>> from py42.sdk.queries.fileevents.file_event_query import FileEventQuery
>>> from py42.sdk.queries.fileevents.filters.exposure_filter import SyncDestinationUsername
>>> filter = SyncDestinationUsername.is_in(['*@gmail.com'])
>>> results = sdk.securitydata.search_file_events(FileEventQuery.all(filter))
>>> [e['syncDestinationUsername'][0] for e in results.data['fileEvents']]
```

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
