### PR TITLE
change to main wherever possible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - v*
   pull_request:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -21,7 +21,7 @@ jobs:
           path-to-signatures: '.cla_signatures.json'
           path-to-cla-document: 'https://code42.github.io/code42-cla/Code42_Individual_Contributor_License_Agreement'
           # branch should not be protected
-          branch: 'master'
+          branch: 'main'
           allowlist: alang13,unparalleled-js,kiran-chaudhary,ceciliastevens,DiscoRiver,annie-payseur,amoravec,patelsagar192,peterbriggs42
 
           #below are the optional inputs - If the optional inputs are not given, then default values will be taken

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: docs
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - v*
   pull_request:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -3,7 +3,7 @@ name: style
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - v*
   pull_request:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # py42, the official Code42 Python SDK
 
 ![Build status](https://github.com/code42/py42/workflows/build/badge.svg)
-[![codecov.io](https://codecov.io/github/code42/py42/coverage.svg?branch=master)](https://codecov.io/github/code42/py42?branch=master)
+[![codecov.io](https://codecov.io/github/code42/py42/coverage.svg?branch=main)](https://codecov.io/github/code42/py42?branch=main)
 [![versions](https://img.shields.io/pypi/pyversions/py42.svg)](https://pypi.org/project/py42/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Documentation Status](https://readthedocs.org/projects/py42/badge/?version=latest)](https://py42docs.code42.com/en/latest/?badge=latest)

--- a/docs/userguides/gettingstarted.md
+++ b/docs/userguides/gettingstarted.md
@@ -7,7 +7,7 @@
 
 ## Licensing
 
-This project uses the [MIT License](https://github.com/code42/py42/blob/master/LICENSE.md).
+This project uses the [MIT License](https://github.com/code42/py42/blob/main/LICENSE.md).
 
 ## Installation
 


### PR DESCRIPTION
### Description of Change ###

We want to switch to using `main` as the default base branch.
A main branch is pushed and up to date with the master branch.

This PR:
*  changes github action references from master to main
* changes external linked projects to their main branch (instead of master) in the cases when they exist


After the success of the migration for py42, the same will need to be done for the CLI