### PR TITLE
Honor microseconds in Alert DateObserved query  + fix py2 timestamp unicode bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+### Unreleased
+
+### Added
+
+You can now use microsecond precision
+
 ## 1.15.0 - 2021-06-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - The `DateObserved` alert query filter now parses timestamps using microsecond precision.
 
+### Fixed
+
+- Python2.7 bug where non-unicode `str` timestamps would fail when used in a query filter.
+
 ## 1.15.0 - 2021-06-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Unreleased
 
-### Added
+### Changed
 
-You can now use microsecond precision
+- The `DateObserved` alert query filter now parses timestamps using microsecond precision.
 
 ## 1.15.0 - 2021-06-16
 

--- a/src/py42/_compat.py
+++ b/src/py42/_compat.py
@@ -16,7 +16,9 @@ if is_py2:
     from urlparse import urljoin
     from urlparse import urlparse
 
+    original_str = str
     str = unicode
+    str_options = (original_str, str)
 
     import repr as reprlib
 
@@ -33,6 +35,7 @@ else:
     from urllib.parse import urlencode
 
     str = str
+    str_options = str
 
     import reprlib
 

--- a/src/py42/_compat.py
+++ b/src/py42/_compat.py
@@ -16,9 +16,7 @@ if is_py2:
     from urlparse import urljoin
     from urlparse import urlparse
 
-    _original_str = str
     str = unicode
-    str_options = (_original_str, str)
 
     import repr as reprlib
 
@@ -35,7 +33,6 @@ else:
     from urllib.parse import urlencode
 
     str = str
-    str_options = (str,)
 
     import reprlib
 

--- a/src/py42/_compat.py
+++ b/src/py42/_compat.py
@@ -16,9 +16,9 @@ if is_py2:
     from urlparse import urljoin
     from urlparse import urlparse
 
-    original_str = str
+    _original_str = str
     str = unicode
-    str_options = (original_str, str)
+    str_options = (_original_str, str)
 
     import repr as reprlib
 

--- a/src/py42/_compat.py
+++ b/src/py42/_compat.py
@@ -35,7 +35,7 @@ else:
     from urllib.parse import urlencode
 
     str = str
-    str_options = str
+    str_options = (str,)
 
     import reprlib
 

--- a/src/py42/sdk/queries/alerts/filters/alert_filter.py
+++ b/src/py42/sdk/queries/alerts/filters/alert_filter.py
@@ -3,6 +3,7 @@ from py42.sdk.queries.query_filter import create_query_filter
 from py42.sdk.queries.query_filter import QueryFilterStringField
 from py42.sdk.queries.query_filter import QueryFilterTimestampField
 from py42.util import get_attribute_keys_from_class
+from py42.util import MICROSECOND_FORMAT
 from py42.util import parse_timestamp_to_microseconds_precision
 
 
@@ -81,6 +82,10 @@ class AlertQueryFilterTimestampField(QueryFilterTimestampField):
     @staticmethod
     def _parse_timestamp(value):
         return parse_timestamp_to_microseconds_precision(value)
+
+    @staticmethod
+    def _convert_datetime_to_timestamp(value):
+        return value.strftime(MICROSECOND_FORMAT)
 
 
 class DateObserved(AlertQueryFilterTimestampField):

--- a/src/py42/sdk/queries/alerts/filters/alert_filter.py
+++ b/src/py42/sdk/queries/alerts/filters/alert_filter.py
@@ -3,6 +3,7 @@ from py42.sdk.queries.query_filter import create_query_filter
 from py42.sdk.queries.query_filter import QueryFilterStringField
 from py42.sdk.queries.query_filter import QueryFilterTimestampField
 from py42.util import get_attribute_keys_from_class
+from py42.util import parse_timestamp_to_microseconds_precision
 
 
 def create_contains_filter_group(term, value):
@@ -74,7 +75,15 @@ class AlertQueryFilterStringField(QueryFilterStringField):
         return create_not_contains_filter_group(cls._term, value)
 
 
-class DateObserved(QueryFilterTimestampField):
+class AlertQueryFilterTimestampField(QueryFilterTimestampField):
+    """Helper class for creating alert filters where the search value is a timestamp."""
+
+    @staticmethod
+    def _parse_timestamp(value):
+        return parse_timestamp_to_microseconds_precision(value)
+
+
+class DateObserved(AlertQueryFilterTimestampField):
     """Class that filters alerts based on the timestamp the alert was triggered."""
 
     _term = u"createdAt"

--- a/src/py42/sdk/queries/query_filter.py
+++ b/src/py42/sdk/queries/query_filter.py
@@ -253,6 +253,10 @@ class QueryFilterTimestampField(object):
 
     _term = u"override_timestamp_field_name"
 
+    @staticmethod
+    def _parse_timestamp(value):
+        return parse_timestamp_to_milliseconds_precision(value)
+
     @classmethod
     def on_or_after(cls, value):
         """Returns a :class:`~py42.sdk.queries.query_filter.FilterGroup` that is useful
@@ -265,7 +269,7 @@ class QueryFilterTimestampField(object):
         Returns:
             :class:`~py42.sdk.queries.query_filter.FilterGroup`
         """
-        formatted_timestamp = parse_timestamp_to_milliseconds_precision(value)
+        formatted_timestamp = cls._parse_timestamp(value)
         return create_on_or_after_filter_group(cls._term, formatted_timestamp)
 
     @classmethod
@@ -280,7 +284,7 @@ class QueryFilterTimestampField(object):
         Returns:
             :class:`~py42.sdk.queries.query_filter.FilterGroup`
         """
-        formatted_timestamp = parse_timestamp_to_milliseconds_precision(value)
+        formatted_timestamp = cls._parse_timestamp(value)
         return create_on_or_before_filter_group(cls._term, formatted_timestamp)
 
     @classmethod
@@ -290,14 +294,16 @@ class QueryFilterTimestampField(object):
         the provided ``start_value`` and ``end_value``.
 
         Args:
-            start_value (str or int or float or datetime): The start value used to filter results.
-            end_value (str or int or float or datetime): The end value used to filter results.
+            start_value (str or int or float or datetime): The start value used to
+                filter results.
+            end_value (str or int or float or datetime): The end value used to
+                filter results.
 
         Returns:
             :class:`~py42.sdk.queries.query_filter.FilterGroup`
         """
-        formatted_start_time = parse_timestamp_to_milliseconds_precision(start_value)
-        formatted_end_time = parse_timestamp_to_milliseconds_precision(end_value)
+        formatted_start_time = cls._parse_timestamp(start_value)
+        formatted_end_time = cls._parse_timestamp(end_value)
         return create_in_range_filter_group(
             cls._term, formatted_start_time, formatted_end_time
         )

--- a/src/py42/sdk/queries/query_filter.py
+++ b/src/py42/sdk/queries/query_filter.py
@@ -330,15 +330,10 @@ class QueryFilterTimestampField(object):
             value = convert_datetime_to_epoch(value)
         date_from_value = datetime.utcfromtimestamp(value)
         start_time = datetime(
-            date_from_value.year, date_from_value.month, date_from_value.day, 0, 0, 0,
+            date_from_value.year, date_from_value.month, date_from_value.day, 0, 0, 0
         )
         end_time = datetime(
-            date_from_value.year,
-            date_from_value.month,
-            date_from_value.day,
-            23,
-            59,
-            59,
+            date_from_value.year, date_from_value.month, date_from_value.day, 23, 59, 59
         )
         formatted_start_time = cls._convert_datetime_to_timestamp(start_time)
         formatted_end_time = cls._convert_datetime_to_timestamp(end_time)

--- a/src/py42/sdk/queries/query_filter.py
+++ b/src/py42/sdk/queries/query_filter.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from py42._compat import str
 from py42._compat import string_type
+from py42._compat import string_type
 from py42.util import convert_datetime_to_epoch
 from py42.util import convert_datetime_to_timestamp_str
 from py42.util import DATE_STR_FORMAT
@@ -324,7 +325,7 @@ class QueryFilterTimestampField(object):
         Returns:
             :class:`~py42.sdk.queries.query_filter.FilterGroup`
         """
-        if isinstance(value, str):
+        if isinstance(value, string_type):
             value = convert_datetime_to_epoch(datetime.strptime(value, DATE_STR_FORMAT))
         elif isinstance(value, datetime):
             value = convert_datetime_to_epoch(value)

--- a/src/py42/sdk/queries/query_filter.py
+++ b/src/py42/sdk/queries/query_filter.py
@@ -3,7 +3,6 @@ from datetime import datetime
 
 from py42._compat import str
 from py42._compat import string_type
-from py42._compat import string_type
 from py42.util import convert_datetime_to_epoch
 from py42.util import convert_datetime_to_timestamp_str
 from py42.util import DATE_STR_FORMAT

--- a/src/py42/sdk/queries/query_filter.py
+++ b/src/py42/sdk/queries/query_filter.py
@@ -257,6 +257,10 @@ class QueryFilterTimestampField(object):
     def _parse_timestamp(value):
         return parse_timestamp_to_milliseconds_precision(value)
 
+    @staticmethod
+    def _convert_datetime_to_timestamp(value):
+        return convert_datetime_to_timestamp_str(value)
+
     @classmethod
     def on_or_after(cls, value):
         """Returns a :class:`~py42.sdk.queries.query_filter.FilterGroup` that is useful
@@ -326,13 +330,18 @@ class QueryFilterTimestampField(object):
             value = convert_datetime_to_epoch(value)
         date_from_value = datetime.utcfromtimestamp(value)
         start_time = datetime(
-            date_from_value.year, date_from_value.month, date_from_value.day, 0, 0, 0
+            date_from_value.year, date_from_value.month, date_from_value.day, 0, 0, 0,
         )
         end_time = datetime(
-            date_from_value.year, date_from_value.month, date_from_value.day, 23, 59, 59
+            date_from_value.year,
+            date_from_value.month,
+            date_from_value.day,
+            23,
+            59,
+            59,
         )
-        formatted_start_time = convert_datetime_to_timestamp_str(start_time)
-        formatted_end_time = convert_datetime_to_timestamp_str(end_time)
+        formatted_start_time = cls._convert_datetime_to_timestamp(start_time)
+        formatted_end_time = cls._convert_datetime_to_timestamp(end_time)
         return create_in_range_filter_group(
             cls._term, formatted_start_time, formatted_end_time
         )

--- a/src/py42/util.py
+++ b/src/py42/util.py
@@ -5,7 +5,6 @@ from datetime import datetime
 
 from py42._compat import string_type
 
-MILLISECOND_FORMAT = u"%Y-%m-%dT%H:%M:%S.%f"
 MICROSECOND_FORMAT = u"%Y-%m-%dT%H:%M:%S.%fZ"
 DATE_STR_FORMAT = u"%Y-%m-%d %H:%M:%S"
 
@@ -65,7 +64,7 @@ def convert_datetime_to_timestamp_str(date):
         (str): A str representing the given date. Example output looks like
         '2020-03-25T15:29:04.465Z'.
     """
-    prefix = date.strftime(MILLISECOND_FORMAT)[:-3]
+    prefix = date.strftime(MICROSECOND_FORMAT)[:-4]
     return u"{}Z".format(prefix)
 
 

--- a/src/py42/util.py
+++ b/src/py42/util.py
@@ -65,7 +65,7 @@ def convert_datetime_to_timestamp_str(date):
         (str): A str representing the given date. Example output looks like
         '2020-03-25T15:29:04.465Z'.
     """
-    prefix = date.strftime(u"%Y-%m-%dT%H:%M:%S.%f")[:-3]
+    prefix = date.strftime(MILLISECOND_FORMAT)[:-3]
     return u"{}Z".format(prefix)
 
 

--- a/src/py42/util.py
+++ b/src/py42/util.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import json
 from datetime import datetime
 
-from py42._compat import str
+from py42._compat import str_options
 
 MILLISECOND_FORMAT = u"%Y-%m-%dT%H:%M:%S.%f"
 MICROSECOND_FORMAT = u"%Y-%m-%dT%H:%M:%S.%fZ"
@@ -109,7 +109,7 @@ def parse_timestamp_to_milliseconds_precision(timestamp):
         return convert_timestamp_to_str(timestamp)
     elif isinstance(timestamp, datetime):
         return convert_datetime_to_timestamp_str(timestamp)
-    elif isinstance(timestamp, str):
+    elif isinstance(timestamp, str_options):
         return convert_datetime_to_timestamp_str(
             datetime.strptime(timestamp, DATE_STR_FORMAT)
         )
@@ -120,7 +120,7 @@ def parse_timestamp_to_microseconds_precision(timestamp):
         return datetime.utcfromtimestamp(timestamp).strftime(MICROSECOND_FORMAT)
     elif isinstance(timestamp, datetime):
         return timestamp.strftime(MICROSECOND_FORMAT)
-    elif isinstance(timestamp, str):
+    elif isinstance(timestamp, str_options):
         return datetime.strptime(timestamp, DATE_STR_FORMAT).strftime(
             MICROSECOND_FORMAT
         )

--- a/src/py42/util.py
+++ b/src/py42/util.py
@@ -5,7 +5,8 @@ from datetime import datetime
 
 from py42._compat import str
 
-_MICROSECOND_FORMAT = u"%Y-%m-%dT%H:%M:%S.%fZ"
+MILLISECOND_FORMAT = u"%Y-%m-%dT%H:%M:%S.%f"
+MICROSECOND_FORMAT = u"%Y-%m-%dT%H:%M:%S.%fZ"
 DATE_STR_FORMAT = u"%Y-%m-%d %H:%M:%S"
 
 
@@ -116,10 +117,10 @@ def parse_timestamp_to_milliseconds_precision(timestamp):
 
 def parse_timestamp_to_microseconds_precision(timestamp):
     if isinstance(timestamp, (int, float)):
-        return datetime.utcfromtimestamp(timestamp).strftime(_MICROSECOND_FORMAT)
+        return datetime.utcfromtimestamp(timestamp).strftime(MICROSECOND_FORMAT)
     elif isinstance(timestamp, datetime):
-        return timestamp.strftime(_MICROSECOND_FORMAT)
+        return timestamp.strftime(MICROSECOND_FORMAT)
     elif isinstance(timestamp, str):
         return datetime.strptime(timestamp, DATE_STR_FORMAT).strftime(
-            _MICROSECOND_FORMAT
+            MICROSECOND_FORMAT
         )

--- a/src/py42/util.py
+++ b/src/py42/util.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import json
 from datetime import datetime
 
-from py42._compat import str_options
+from py42._compat import string_type
 
 MILLISECOND_FORMAT = u"%Y-%m-%dT%H:%M:%S.%f"
 MICROSECOND_FORMAT = u"%Y-%m-%dT%H:%M:%S.%fZ"
@@ -109,7 +109,7 @@ def parse_timestamp_to_milliseconds_precision(timestamp):
         return convert_timestamp_to_str(timestamp)
     elif isinstance(timestamp, datetime):
         return convert_datetime_to_timestamp_str(timestamp)
-    elif isinstance(timestamp, str_options):
+    elif isinstance(timestamp, string_type):
         return convert_datetime_to_timestamp_str(
             datetime.strptime(timestamp, DATE_STR_FORMAT)
         )
@@ -120,7 +120,7 @@ def parse_timestamp_to_microseconds_precision(timestamp):
         return datetime.utcfromtimestamp(timestamp).strftime(MICROSECOND_FORMAT)
     elif isinstance(timestamp, datetime):
         return timestamp.strftime(MICROSECOND_FORMAT)
-    elif isinstance(timestamp, str_options):
+    elif isinstance(timestamp, string_type):
         return datetime.strptime(timestamp, DATE_STR_FORMAT).strftime(
             MICROSECOND_FORMAT
         )

--- a/tests/sdk/queries/alerts/filters/test_alert_filter.py
+++ b/tests/sdk/queries/alerts/filters/test_alert_filter.py
@@ -2,8 +2,6 @@ from datetime import datetime
 from time import time
 
 from tests.sdk.queries.conftest import CONTAINS
-from tests.sdk.queries.conftest import format_datetime
-from tests.sdk.queries.conftest import format_timestamp
 from tests.sdk.queries.conftest import IN_RANGE
 from tests.sdk.queries.conftest import IS
 from tests.sdk.queries.conftest import IS_IN
@@ -27,6 +25,18 @@ from py42.sdk.queries.alerts.filters.alert_filter import create_contains_filter_
 from py42.sdk.queries.alerts.filters.alert_filter import (
     create_not_contains_filter_group,
 )
+from py42.util import MICROSECOND_FORMAT
+
+
+def format_timestamp_with_microseconds(test_time):
+    test_date = datetime.utcfromtimestamp(test_time)
+    return format_datetime_with_microseconds(test_date)
+
+
+def format_datetime_with_microseconds(test_date):
+    prefix = test_date.strftime(MICROSECOND_FORMAT)
+    timestamp_str = "{}".format(prefix)
+    return timestamp_str
 
 
 def test_create_contains_filter_group_returns_filter_group_with_correct_json_representation():
@@ -52,7 +62,7 @@ def test_create_not_contains_filter_group_returns_filter_group_with_correct_json
 
 def test_date_observed_on_or_after_str_gives_correct_json_representation():
     test_time = time()
-    formatted = format_timestamp(test_time)
+    formatted = format_timestamp_with_microseconds(test_time)
     _filter = DateObserved.on_or_after(test_time)
     expected = ON_OR_AFTER.format("createdAt", formatted)
     assert str(_filter) == expected
@@ -60,7 +70,7 @@ def test_date_observed_on_or_after_str_gives_correct_json_representation():
 
 def test_date_observed_on_or_before_str_gives_correct_json_representation():
     test_time = time()
-    formatted = format_timestamp(test_time)
+    formatted = format_timestamp_with_microseconds(test_time)
     _filter = DateObserved.on_or_before(test_time)
     expected = ON_OR_BEFORE.format("createdAt", formatted)
     assert str(_filter) == expected
@@ -73,8 +83,8 @@ def test_date_observed_does_not_have_within_the_last_option():
 def test_date_observed_in_range_str_gives_correct_json_representation():
     test_before_time = time()
     test_after_time = time() + 30  # make sure timestamps are actually different
-    formatted_before = format_timestamp(test_before_time)
-    formatted_after = format_timestamp(test_after_time)
+    formatted_before = format_timestamp_with_microseconds(test_before_time)
+    formatted_after = format_timestamp_with_microseconds(test_after_time)
     _filter = DateObserved.in_range(test_before_time, test_after_time)
     expected = IN_RANGE.format("createdAt", formatted_before, formatted_after)
     assert str(_filter) == expected
@@ -85,8 +95,8 @@ def test_date_observed_on_same_day_str_gives_correct_json_representation():
     test_date = datetime.utcfromtimestamp(test_time)
     start_time = datetime(test_date.year, test_date.month, test_date.day, 0, 0, 0)
     end_time = datetime(test_date.year, test_date.month, test_date.day, 23, 59, 59)
-    formatted_before = format_datetime(start_time)
-    formatted_after = format_datetime(end_time)
+    formatted_before = format_datetime_with_microseconds(start_time)
+    formatted_after = format_datetime_with_microseconds(end_time)
     _filter = DateObserved.on_same_day(test_time)
     expected = IN_RANGE.format("createdAt", formatted_before, formatted_after)
     assert str(_filter) == expected

--- a/tests/sdk/queries/conftest.py
+++ b/tests/sdk/queries/conftest.py
@@ -5,7 +5,7 @@ import pytest
 
 from py42.sdk.queries.query_filter import FilterGroup
 from py42.sdk.queries.query_filter import QueryFilter
-from py42.util import MILLISECOND_FORMAT
+from py42.util import MICROSECOND_FORMAT
 
 EVENT_FILTER_FIELD_NAME = "filter_field_name"
 OPERATOR_STRING = "IS_IN"
@@ -62,6 +62,6 @@ def format_timestamp(test_time):
 
 
 def format_datetime(test_date):
-    prefix = test_date.strftime(MILLISECOND_FORMAT)[:-3]
+    prefix = test_date.strftime(MICROSECOND_FORMAT)[:-4]
     timestamp_str = "{}Z".format(prefix)
     return timestamp_str

--- a/tests/sdk/queries/conftest.py
+++ b/tests/sdk/queries/conftest.py
@@ -5,6 +5,7 @@ import pytest
 
 from py42.sdk.queries.query_filter import FilterGroup
 from py42.sdk.queries.query_filter import QueryFilter
+from py42.util import MILLISECOND_FORMAT
 
 EVENT_FILTER_FIELD_NAME = "filter_field_name"
 OPERATOR_STRING = "IS_IN"
@@ -61,6 +62,6 @@ def format_timestamp(test_time):
 
 
 def format_datetime(test_date):
-    prefix = test_date.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]
+    prefix = test_date.strftime(MILLISECOND_FORMAT)[:-3]
     timestamp_str = "{}Z".format(prefix)
     return timestamp_str

--- a/tests/sdk/queries/test_query_filter.py
+++ b/tests/sdk/queries/test_query_filter.py
@@ -111,9 +111,9 @@ def test_filter_group_from_dict_gives_correct_json_representation(query_filter):
         "filterClause": "AND",
         "filters": [{"operator": "IS", "term": "testterm", "value": "testval"}],
     }
-    filter_group_json_str = '{"filterClause":"AND", "filters":[{"operator":"IS", "term":"testterm", "value":"testval"}]}'
+    expected = '{"filterClause":"AND", "filters":[{"operator":"IS", "term":"testterm", "value":"testval"}]}'
     filter_group = FilterGroup.from_dict(filter_group_dict)
-    assert str(filter_group) == filter_group_json_str
+    assert str(filter_group) == expected
 
 
 def test_filter_group_dict_gives_expected_dict_representation(query_filter):
@@ -157,10 +157,10 @@ def test_filter_group_with_multiple_filters_and_specified_str_gives_correct_json
 def test_filter_group_with_duplicate_filters_and_specified_str_gives_correct_json_representation(
     query_filter,
 ):
-    json_single_filter_group = JSON_FILTER_GROUP_BASE.format("AND", JSON_QUERY_FILTER)
+    expected = JSON_FILTER_GROUP_BASE.format("AND", JSON_QUERY_FILTER)
     assert (
         str(create_filter_group([query_filter, query_filter, query_filter], "AND"))
-        == json_single_filter_group
+        == expected
     )
 
 
@@ -177,10 +177,10 @@ def test_filter_group_with_multiple_filters_or_specified_str_gives_correct_json_
 def test_filter_group_with_duplicate_filters_or_specified_str_gives_correct_json_representation(
     query_filter,
 ):
-    json_single_filter_group = JSON_FILTER_GROUP_BASE.format("OR", JSON_QUERY_FILTER)
+    expected = JSON_FILTER_GROUP_BASE.format("OR", JSON_QUERY_FILTER)
     assert (
         str(create_filter_group([query_filter, query_filter, query_filter], "OR"))
-        == json_single_filter_group
+        == expected
     )
 
 
@@ -432,7 +432,7 @@ class TestQueryFilterTimestampField:
         ],
     )
     def test_on_or_after(self, timestamp):
-        filter_query = {
+        expected = {
             "filterClause": "AND",
             "filters": [
                 {
@@ -444,7 +444,7 @@ class TestQueryFilterTimestampField:
         }
 
         qf = QueryFilterTimestampField.on_or_after(timestamp)
-        assert dict(qf) == filter_query
+        assert dict(qf) == expected
 
     @pytest.mark.parametrize(
         "timestamp",
@@ -456,7 +456,7 @@ class TestQueryFilterTimestampField:
         ],
     )
     def test_on_or_before(self, timestamp):
-        filter_query = {
+        expected = {
             "filterClause": "AND",
             "filters": [
                 {
@@ -466,7 +466,7 @@ class TestQueryFilterTimestampField:
                 }
             ],
         }
-        assert dict(QueryFilterTimestampField.on_or_before(timestamp)) == filter_query
+        assert dict(QueryFilterTimestampField.on_or_before(timestamp)) == expected
 
     @pytest.mark.parametrize(
         "start_timestamp, end_timestamp",
@@ -481,7 +481,7 @@ class TestQueryFilterTimestampField:
         ],
     )
     def test_in_range(self, start_timestamp, end_timestamp):
-        filter_query = {
+        expected = {
             "filterClause": "AND",
             "filters": [
                 {
@@ -499,7 +499,7 @@ class TestQueryFilterTimestampField:
 
         assert (
             dict(QueryFilterTimestampField.in_range(start_timestamp, end_timestamp))
-            == filter_query
+            == expected
         )
 
     @pytest.mark.parametrize(
@@ -512,7 +512,7 @@ class TestQueryFilterTimestampField:
         ],
     )
     def test_on_same_day(self, timestamp):
-        filter_query = {
+        expected = {
             "filterClause": "AND",
             "filters": [
                 {
@@ -527,10 +527,10 @@ class TestQueryFilterTimestampField:
                 },
             ],
         }
-        assert dict(QueryFilterTimestampField.on_same_day(timestamp)) == filter_query
+        assert dict(QueryFilterTimestampField.on_same_day(timestamp)) == expected
 
     def test_on_or_after_with_decimals(self):
-        filter_query = {
+        expected = {
             "filterClause": "AND",
             "filters": [
                 {
@@ -542,10 +542,10 @@ class TestQueryFilterTimestampField:
         }
 
         qf = QueryFilterTimestampField.on_or_after(1599736333.123456)
-        assert dict(qf) == filter_query
+        assert dict(qf) == expected
 
     def test_on_or_before_with_decimals(self):
-        filter_query = {
+        expected = {
             "filterClause": "AND",
             "filters": [
                 {
@@ -556,12 +556,11 @@ class TestQueryFilterTimestampField:
             ],
         }
         assert (
-            dict(QueryFilterTimestampField.on_or_before(1599736333.123456))
-            == filter_query
+            dict(QueryFilterTimestampField.on_or_before(1599736333.123456)) == expected
         )
 
     def test_in_range_with_decimals(self):
-        filter_query = {
+        expected = {
             "filterClause": "AND",
             "filters": [
                 {
@@ -579,5 +578,5 @@ class TestQueryFilterTimestampField:
 
         assert (
             dict(QueryFilterTimestampField.in_range(1599736333.123456, 1599739994.6789))
-            == filter_query
+            == expected
         )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -34,57 +34,42 @@ def test_to_list():
 
 
 def test_parse_timestamp_to_milliseconds_precision_returns_expected_timestamp_with_epoch_time():
-    assert (
-        util.parse_timestamp_to_milliseconds_precision(1599653541)
-        == "2020-09-09T12:12:21.000Z"
-    )
+    actual = util.parse_timestamp_to_milliseconds_precision(1599653541)
+    assert actual == "2020-09-09T12:12:21.000Z"
 
 
 def test_parse_timestamp_to_milliseconds_precision_returns_expected_timestamp_with_str_format_time():
-    assert (
-        util.parse_timestamp_to_milliseconds_precision("2020-09-09 12:12:21")
-        == "2020-09-09T12:12:21.000Z"
-    )
+    actual = util.parse_timestamp_to_milliseconds_precision("2020-09-09 12:12:21")
+    assert actual == "2020-09-09T12:12:21.000Z"
 
 
 def test_parse_timestamp_to_milliseconds_precision_returns_expected_timestamp_with_datetime_time():
     dt = datetime.strptime("2020-09-09 12:12:21", "%Y-%m-%d %H:%M:%S")
-    assert (
-        util.parse_timestamp_to_milliseconds_precision(dt) == "2020-09-09T12:12:21.000Z"
-    )
+    actual = util.parse_timestamp_to_milliseconds_precision(dt)
+    assert actual == "2020-09-09T12:12:21.000Z"
 
 
 def test_parse_timestamp_to_microseconds_precision_returns_expected_timestamp_with_epoch_time():
-    assert (
-        util.parse_timestamp_to_microseconds_precision(1599653541)
-        == "2020-09-09T12:12:21.000000Z"
-    )
+    actual = util.parse_timestamp_to_microseconds_precision(1599653541)
+    assert actual == "2020-09-09T12:12:21.000000Z"
 
 
 def test_parse_timestamp_to_microseconds_precision_returns_expected_timestamp_with_str_format_time():
-    assert (
-        util.parse_timestamp_to_microseconds_precision("2020-09-09 12:12:21")
-        == "2020-09-09T12:12:21.000000Z"
-    )
+    actual = util.parse_timestamp_to_microseconds_precision("2020-09-09 12:12:21")
+    assert actual == "2020-09-09T12:12:21.000000Z"
 
 
 def test_parse_timestamp_to_microseconds_precision_returns_expected_timestamp_with_datetime_time():
     dt = datetime.strptime("2020-09-09 12:12:21", "%Y-%m-%d %H:%M:%S")
-    assert (
-        util.parse_timestamp_to_microseconds_precision(dt)
-        == "2020-09-09T12:12:21.000000Z"
-    )
+    actual = util.parse_timestamp_to_microseconds_precision(dt)
+    assert actual == "2020-09-09T12:12:21.000000Z"
 
 
 def test_parse_timestamp_to_microseconds_precision_returns_expected_timestamp_with_float_time():
-    assert (
-        util.parse_timestamp_to_microseconds_precision(1599653541.001002)
-        == "2020-09-09T12:12:21.001002Z"
-    )
+    actual = util.parse_timestamp_to_microseconds_precision(1599653541.001002)
+    assert actual == "2020-09-09T12:12:21.001002Z"
 
 
 def test_parse_timestamp_to_milliseconds_precision_returns_expected_timestamp_with_float_time():
-    assert (
-        util.parse_timestamp_to_milliseconds_precision(1599653541.001002)
-        == "2020-09-09T12:12:21.001Z"
-    )
+    actual = util.parse_timestamp_to_milliseconds_precision(1599653541.001002)
+    assert actual == "2020-09-09T12:12:21.001Z"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -43,6 +43,11 @@ def test_parse_timestamp_to_milliseconds_precision_returns_expected_timestamp_wi
     assert actual == "2020-09-09T12:12:21.000Z"
 
 
+def test_parse_timestamp_to_milliseconds_precision_when_given_unicode_returns_expected_timestamp_with_str_format_time():
+    actual = util.parse_timestamp_to_milliseconds_precision(u"2020-09-09 12:12:21")
+    assert actual == "2020-09-09T12:12:21.000Z"
+
+
 def test_parse_timestamp_to_milliseconds_precision_returns_expected_timestamp_with_datetime_time():
     dt = datetime.strptime("2020-09-09 12:12:21", "%Y-%m-%d %H:%M:%S")
     actual = util.parse_timestamp_to_milliseconds_precision(dt)
@@ -56,6 +61,11 @@ def test_parse_timestamp_to_microseconds_precision_returns_expected_timestamp_wi
 
 def test_parse_timestamp_to_microseconds_precision_returns_expected_timestamp_with_str_format_time():
     actual = util.parse_timestamp_to_microseconds_precision("2020-09-09 12:12:21")
+    assert actual == "2020-09-09T12:12:21.000000Z"
+
+
+def test_parse_timestamp_to_microseconds_precision_when_given_unicode_returns_expected_timestamp_with_str_format_time():
+    actual = util.parse_timestamp_to_microseconds_precision(u"2020-09-09 12:12:21")
     assert actual == "2020-09-09T12:12:21.000000Z"
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -42,7 +42,7 @@ def test_parse_timestamp_to_milliseconds_precision_returns_expected_timestamp_wi
 
 def test_parse_timestamp_to_milliseconds_precision_returns_expected_timestamp_with_str_format_time():
     assert (
-        util.parse_timestamp_to_milliseconds_precision(u"2020-09-09 12:12:21")
+        util.parse_timestamp_to_milliseconds_precision("2020-09-09 12:12:21")
         == "2020-09-09T12:12:21.000Z"
     )
 
@@ -63,7 +63,7 @@ def test_parse_timestamp_to_microseconds_precision_returns_expected_timestamp_wi
 
 def test_parse_timestamp_to_microseconds_precision_returns_expected_timestamp_with_str_format_time():
     assert (
-        util.parse_timestamp_to_microseconds_precision(u"2020-09-09 12:12:21")
+        util.parse_timestamp_to_microseconds_precision("2020-09-09 12:12:21")
         == "2020-09-09T12:12:21.000000Z"
     )
 


### PR DESCRIPTION
### Description of Change ###

I noticed this bug while working on Phantom.
Alert Search output contains `createdAt` with microsecond precision, such as `"2021-04-18T10:02:36.3198680Z"`.
However, when I would plug an equivalent float timestamp into the Action for search alerts, it would shorten it unnecessarily to `"2021-04-18T10:02:36.319Z"`. The bug appears to be in py42 and this PR addresses it. The API supports this level of precision, so we should allow it in our SDK, or we could potentially be missing alerts.

Additionallty, fixed a PR in py42 when using python2.7 that forced users to have to use unicode strings when crafting queries

A CLI Pr will need to be merged as well, opening that next to prevent failing nightly builds.

### Testing Procedure ###
Make a filter and notice it is using microsecond precision:

First, open the code42cli shell:

```bash
code42 shell
```

```python
test_epoch = 1599653541.001002
test_filter = DateObserved.on_or_after(test_epoch)
print(test_filter)

>>> {"filterClause":"AND", "filters":[{"operator":"ON_OR_AFTER", "term":"createdAt", "value":"2020-09-09T12:12:21.001002Z"}]}


# Create a filter and execute the search and notice that it works and stuff
test_query = AlertQuery(test_filter)
sdk.alerts.search(test_query)
```

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
