### PR TITLE
Chore/update token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 ### Changed
 
 - The `DateObserved` alert query filter now parses timestamps using microsecond precision.
+- Change JWT auth token label from `v3_user_token` to `Bearer` when authenticating against the `/c42api/v3/auth/jwt` endpoint.
 
 ### Fixed
 

--- a/src/py42/sdk/__init__.py
+++ b/src/py42/sdk/__init__.py
@@ -12,7 +12,7 @@ from py42.clients.detectionlists import DetectionListsClient
 from py42.clients.securitydata import SecurityDataClient
 from py42.services import Services
 from py42.services._auth import CustomJWTAuth
-from py42.services._auth import V3Auth
+from py42.services._auth import BearerAuth
 from py42.services._connection import Connection
 from py42.services._keyvaluestore import KeyValueStoreService
 from py42.services.administration import AdministrationService
@@ -108,10 +108,10 @@ class SDKClient(object):
         if username and password:
             basic_auth = HTTPBasicAuth(username, password)
         auth_connection = Connection.from_host_address(host_address, auth=basic_auth)
-        v3_auth = V3Auth(auth_connection, totp)
-        main_connection = Connection.from_host_address(host_address, auth=v3_auth)
+        bearer_auth = BearerAuth(auth_connection, totp)
+        main_connection = Connection.from_host_address(host_address, auth=bearer_auth)
 
-        return cls(main_connection, v3_auth)
+        return cls(main_connection, bearer_auth)
 
     @classmethod
     def from_jwt_provider(cls, host_address, jwt_provider):

--- a/src/py42/sdk/__init__.py
+++ b/src/py42/sdk/__init__.py
@@ -11,8 +11,8 @@ from py42.clients.cases import CasesClient
 from py42.clients.detectionlists import DetectionListsClient
 from py42.clients.securitydata import SecurityDataClient
 from py42.services import Services
-from py42.services._auth import CustomJWTAuth
 from py42.services._auth import BearerAuth
+from py42.services._auth import CustomJWTAuth
 from py42.services._connection import Connection
 from py42.services._keyvaluestore import KeyValueStoreService
 from py42.services.administration import AdministrationService

--- a/src/py42/services/_auth.py
+++ b/src/py42/services/_auth.py
@@ -28,9 +28,9 @@ class C42RenewableAuth(AuthBase):
         raise NotImplementedError()
 
 
-class V3Auth(C42RenewableAuth):
+class BearerAuth(C42RenewableAuth):
     def __init__(self, auth_connection, totp=None):
-        super(V3Auth, self).__init__()
+        super(BearerAuth, self).__init__()
         self._auth_connection = auth_connection
         self._totp = totp if callable(totp) else lambda: totp
 
@@ -40,7 +40,7 @@ class V3Auth(C42RenewableAuth):
         current_token = self._totp()
         headers = {"totp-auth": str(current_token)} if current_token else None
         response = self._auth_connection.get(uri, params=params, headers=headers)
-        return u"v3_user_token {}".format(response["v3_user_token"])
+        return u"Bearer {}".format(response["v3_user_token"])
 
 
 class CustomJWTAuth(C42RenewableAuth):
@@ -49,4 +49,4 @@ class CustomJWTAuth(C42RenewableAuth):
         self._jwt_provider = jwt_provider
 
     def _get_credentials(self):
-        return u"v3_user_token {}".format(self._jwt_provider())
+        return u"Bearer {}".format(self._jwt_provider())

--- a/tests/services/test_auth.py
+++ b/tests/services/test_auth.py
@@ -1,8 +1,8 @@
 import pytest
 from requests import Request
 
-from py42.services._auth import CustomJWTAuth
 from py42.services._auth import BearerAuth
+from py42.services._auth import CustomJWTAuth
 
 
 @pytest.fixture

--- a/tests/services/test_auth.py
+++ b/tests/services/test_auth.py
@@ -2,7 +2,7 @@ import pytest
 from requests import Request
 
 from py42.services._auth import CustomJWTAuth
-from py42.services._auth import V3Auth
+from py42.services._auth import BearerAuth
 
 
 @pytest.fixture
@@ -31,19 +31,19 @@ class TestV3Auth(object):
     def test_call_returns_request_with_expected_header(
         self, mock_v3_conn, mock_request
     ):
-        auth = V3Auth(mock_v3_conn)
+        auth = BearerAuth(mock_v3_conn)
         request = auth(mock_request)
-        assert request.headers["Authorization"] == "v3_user_token TEST_TOKEN_VALUE"
+        assert request.headers["Authorization"] == "Bearer TEST_TOKEN_VALUE"
 
     def test_call_only_calls_auth_api_first_time(self, mock_v3_conn, mock_request):
-        auth = V3Auth(mock_v3_conn)
+        auth = BearerAuth(mock_v3_conn)
         auth(mock_request)
         assert mock_v3_conn.get.call_count == 1
         auth(mock_request)
         assert mock_v3_conn.get.call_count == 1
 
     def test_call_calls_auth_api_with_expected_url(self, mock_v3_conn, mock_request):
-        auth = V3Auth(mock_v3_conn)
+        auth = BearerAuth(mock_v3_conn)
         auth(mock_request)
         params = {"useBody": True}
         headers = None
@@ -58,7 +58,7 @@ class TestV3Auth(object):
     def test_call_calls_auth_api_with_totp_header(
         self, mock_v3_conn, mock_request, totp, expected
     ):
-        auth = V3Auth(mock_v3_conn, totp)
+        auth = BearerAuth(mock_v3_conn, totp)
         auth(mock_request)
         params = {"useBody": True}
         headers = {"totp-auth": expected}
@@ -69,7 +69,7 @@ class TestV3Auth(object):
     def test_clear_credentials_causes_auth_api_to_be_called_on_subsequent_calls(
         self, mock_v3_conn, mock_request
     ):
-        auth = V3Auth(mock_v3_conn)
+        auth = BearerAuth(mock_v3_conn)
         auth(mock_request)
         assert mock_v3_conn.get.call_count == 1
         auth.clear_credentials()
@@ -81,4 +81,4 @@ class TestCustomJWTAuth(object):
     def test_get_credentials_returns_jwt_string(self, mock_custom_auth_function):
         auth = CustomJWTAuth(mock_custom_auth_function)
         jwt_string = auth.get_credentials()
-        assert jwt_string == "v3_user_token token-string"
+        assert jwt_string == "Bearer token-string"


### PR DESCRIPTION
### Description of Change ###

Change JWT auth token label from `v3_user_token` to `Bearer` when authenticating against the `/c42api/v3/auth/jwt` endpoint.

### Issues Resolved ###
Fixes INTEG-1718


### Testing Procedure ###
Authenticate against the backend using both methods:
`>>> sdk = py42.sdk.from_local_account("https://console.us.code42.com", "john.doe", "password")`
and
`>>> sdk = py42.sdk.from_jwt_provider("https://console.us.code42.com", jwt_provider_function)`

These methods are described at greater length in the README.md document

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [N/A] Add docstrings for any new public parameters / methods / classes
