### PR TITLE
newline between latest Changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 ### Changed
 
 - The `DateObserved` alert query filter now parses timestamps using microsecond precision.
+
 - Change JWT auth token label from `v3_user_token` to `Bearer` when authenticating against the `/c42api/v3/auth/jwt` endpoint.
 
 ### Fixed


### PR DESCRIPTION
These entries kind-of look like they are related but they are not, a simple newline between them fixes that.