### PR TITLE
Escape unescaped double-quotes in tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Fixed
+
+- `sdk.securitydata.search_all_file_events()` automatically escapes double-quote characters in the `page_token` param when passed.
+
 ## 1.15.1 - 2021-06-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Fixed
 
-- `sdk.securitydata.search_all_file_events()` automatically escapes double-quote characters in the `page_token` param when passed.
+- `sdk.securitydata.search_all_file_events()` now automatically escapes double-quote characters in the `page_token` param when passed.
 
 ## 1.15.1 - 2021-06-22
 

--- a/src/py42/clients/securitydata.py
+++ b/src/py42/clients/securitydata.py
@@ -471,7 +471,7 @@ class PlanStorageInfo(object):
         return self._node_guid
 
 
-def _escape_quote_chars_in_token(string):
+def _escape_quote_chars_in_token(token):
     """
     The `nextPgToken` returned in Forensic Search requests with > 10k results is the eventId
     of the last event returned in the response. Some eventIds have double-quote chars in
@@ -482,5 +482,5 @@ def _escape_quote_chars_in_token(string):
     return re.sub(
         pattern=unescaped_quote_pattern,
         repl=lambda match: match.group().replace('"', r'\"'),
-        string=string
+        string=token
     )

--- a/src/py42/clients/securitydata.py
+++ b/src/py42/clients/securitydata.py
@@ -481,6 +481,6 @@ def _escape_quote_chars_in_token(token):
 
     return re.sub(
         pattern=unescaped_quote_pattern,
-        repl=lambda match: match.group().replace(u'"', r'\"'),
-        string=token
+        repl=lambda match: match.group().replace(u'"', r"\""),
+        string=token,
     )

--- a/src/py42/clients/securitydata.py
+++ b/src/py42/clients/securitydata.py
@@ -481,6 +481,6 @@ def _escape_quote_chars_in_token(token):
 
     return re.sub(
         pattern=unescaped_quote_pattern,
-        repl=lambda match: match.group().replace('"', r'\"'),
+        repl=lambda match: match.group().replace(u'"', r'\"'),
         string=token
     )

--- a/src/py42/clients/securitydata.py
+++ b/src/py42/clients/securitydata.py
@@ -481,6 +481,6 @@ def _escape_quote_chars_in_token(string):
 
     return re.sub(
         pattern=unescaped_quote_pattern,
-        repl=lambda match: match.group().replace('"', '\\"'),
+        repl=lambda match: match.group().replace('"', r'\"'),
         string=string
     )

--- a/tests/clients/test_securitydata.py
+++ b/tests/clients/test_securitydata.py
@@ -1388,8 +1388,8 @@ class TestSecurityClient(object):
     @pytest.mark.parametrize(
         "token",
         [
-            ('1234_"abcde"', '1234_\\"abcde\\"'),
-            ('1234_\\"abcde\\"', '1234_\\"abcde\\"'),
+            ('1234_"abcde"', r'1234_\"abcde\"'),
+            (r'1234_\"abcde\"', r'1234_\"abcde\"'),
         ],
     )
     def test_search_all_file_events_handles_unescaped_quote_chars_in_token(

--- a/tests/clients/test_securitydata.py
+++ b/tests/clients/test_securitydata.py
@@ -1387,10 +1387,7 @@ class TestSecurityClient(object):
 
     @pytest.mark.parametrize(
         "token",
-        [
-            ('1234_"abcde"', r'1234_\"abcde\"'),
-            (r'1234_\"abcde\"', r'1234_\"abcde\"'),
-        ],
+        [('1234_"abcde"', r"1234_\"abcde\""), (r"1234_\"abcde\"", r"1234_\"abcde\"")],
     )
     def test_search_all_file_events_handles_unescaped_quote_chars_in_token(
         self,
@@ -1412,5 +1409,7 @@ class TestSecurityClient(object):
         security_client.search_all_file_events(FileEventQuery.all(), token[0])
         connection.post.assert_called_once_with(
             FILE_EVENT_URI,
-            data='{{"groupClause":"AND", "groups":[], "pgToken":"{0}", "pgSize":10000}}'.format(token[1]),
+            data='{{"groupClause":"AND", "groups":[], "pgToken":"{0}", "pgSize":10000}}'.format(
+                token[1]
+            ),
         )

--- a/tests/clients/test_securitydata.py
+++ b/tests/clients/test_securitydata.py
@@ -1412,5 +1412,5 @@ class TestSecurityClient(object):
         security_client.search_all_file_events(FileEventQuery.all(), token[0])
         connection.post.assert_called_once_with(
             FILE_EVENT_URI,
-            data=f'{{"groupClause":"AND", "groups":[], "pgToken":"{token[1]}", "pgSize":10000}}',
+            data='{{"groupClause":"AND", "groups":[], "pgToken":"{0}", "pgSize":10000}}'.format(token[1]),
         )

--- a/tests/clients/test_securitydata.py
+++ b/tests/clients/test_securitydata.py
@@ -21,7 +21,7 @@ FILE_EVENT_URI = "/forensic-search/queryservice/api/v1/fileevent"
 RAW_QUERY = "RAW JSON QUERY"
 USER_UID = "user-uid"
 PDS_EXCEPTION_MESSAGE = (
-    u"No file with hash {0} available for download on any storage node."
+    "No file with hash {0} available for download on any storage node."
 )
 GET_SECURITY_EVENT_LOCATIONS_RESPONSE_BODY_ONE_LOCATION = """{
         "securityPlanLocationsByDestination": [
@@ -967,7 +967,7 @@ class TestSecurityClient(object):
         with pytest.raises(Py42ChecksumNotFoundError) as e:
             security_client.stream_file_by_sha256("shahash")
 
-        assert u"No files found with SHA256 checksum" in e.value.args[0]
+        assert "No files found with SHA256 checksum" in e.value.args[0]
 
     def test_stream_file_by_sha256_when_file_versions_returns_empty_response_gets_version_from_other_location(
         self,
@@ -1206,7 +1206,7 @@ class TestSecurityClient(object):
         with pytest.raises(Py42ChecksumNotFoundError) as e:
             security_client.stream_file_by_md5("mdhash")
 
-        assert u"No files found with MD5 checksum" in e.value.args[0]
+        assert "No files found with MD5 checksum" in e.value.args[0]
 
     def test_stream_file_by_md5_when_file_versions_returns_empty_response_gets_version_from_other_location(
         self,
@@ -1384,3 +1384,33 @@ class TestSecurityClient(object):
             data='{"groupClause":"AND", "groups":[], "pgToken":"abc", "pgSize":10000}',
         )
         assert response is successful_response
+
+    @pytest.mark.parametrize(
+        "token",
+        [
+            ('1234_"abcde"', '1234_\\"abcde\\"'),
+            ('1234_\\"abcde\\"', '1234_\\"abcde\\"'),
+        ],
+    )
+    def test_search_all_file_events_handles_unescaped_quote_chars_in_token(
+        self,
+        token,
+        connection,
+        security_service,
+        preservation_data_service,
+        saved_search_service,
+        storage_service_factory,
+    ):
+        file_event_service = FileEventService(connection)
+        security_client = SecurityDataClient(
+            security_service,
+            file_event_service,
+            preservation_data_service,
+            saved_search_service,
+            storage_service_factory,
+        )
+        security_client.search_all_file_events(FileEventQuery.all(), token[0])
+        connection.post.assert_called_once_with(
+            FILE_EVENT_URI,
+            data=f'{{"groupClause":"AND", "groups":[], "pgToken":"{token[1]}", "pgSize":10000}}',
+        )


### PR DESCRIPTION
### Description of Change ###

Automatically escapes unescaped double-quote characters in page_tokens, allowing end-users to just pass the received token from previous request without having to worry about modifying it themselves. As some eventIds (which is what the `nextPgToken` value is) contain double-quote characters. 

### Testing Procedure ###
Build an FFS query that returns more than 10k results (or lower page size to allow for response to generate a `nextPgToken` value. Run subsequent requests until a `nextPgToken` value contains a `"` character.  Example eventId:

```
1XpE25X_jybWQVvWDPYlRLDdB5qbV0sET_"iIuugeBvajEpS7jVVV6bKPtQvJb9NR0eDfu6E-hDxr8/jE0vdQ411emJ4__ipmdtOfyGiwQ"
```

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [N/A] Add docstrings for any new public parameters / methods / classes
