### PR TITLE
Bugfix: Allow sorting on queries with page tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Fixed
 
-- `sdk.securitydata.search_all_file_events()` now automatically escapes double-quote characters in the `page_token` param when passed.
+- `sdk.securitydata.search_all_file_events()` now automatically escapes double-quote characters in the `page_token` param
+  when passed.
+
+- An issue where `FileEventQuery.sort_direction` and `FileEventQuery.sort_key` properties were not applied to searches
+  when a `page_token` was passed in calls to `sdk.securitydata.search_all_file_events()`.
 
 ## 1.15.1 - 2021-06-22
 

--- a/src/py42/clients/securitydata.py
+++ b/src/py42/clients/securitydata.py
@@ -196,8 +196,7 @@ class SecurityDataClient(object):
             page_token (str, optional): A token used to indicate the starting point for
                 additional page results. For the first page, do not pass ``page_token``. For
                 all consecutive pages, pass the token from the previous response from
-                field ``nextPgToken``. When using ``page_token``, any sorting parameters from
-                the `FileEventQuery` will be ignored. Defaults to empty string.
+                field ``nextPgToken``. Defaults to empty string.
 
         Returns:
             :class:`py42.response.Py42Response`: A response containing page of events.

--- a/src/py42/sdk/queries/fileevents/file_event_query.py
+++ b/src/py42/sdk/queries/fileevents/file_event_query.py
@@ -35,7 +35,7 @@ class FileEventQuery(BaseQuery):
             str(group_item) for group_item in self._filter_group_list
         )
         if self.page_token is not None:
-            paging_prop = u'"pgToken":"{}"'.format(self.page_token)
+            paging_prop = u'"srtDir": "{}", "srtKey": "{}", "pgToken":"{}"'.format(self.sort_direction, self.sort_key, self.page_token)
 
         else:
             paging_prop = u'"srtDir":"{}", "srtKey":"{}", "pgNum":{}'.format(

--- a/src/py42/sdk/queries/fileevents/file_event_query.py
+++ b/src/py42/sdk/queries/fileevents/file_event_query.py
@@ -35,7 +35,9 @@ class FileEventQuery(BaseQuery):
             str(group_item) for group_item in self._filter_group_list
         )
         if self.page_token is not None:
-            paging_prop = u'"srtDir": "{}", "srtKey": "{}", "pgToken":"{}"'.format(self.sort_direction, self.sort_key, self.page_token)
+            paging_prop = u'"srtDir": "{}", "srtKey": "{}", "pgToken":"{}"'.format(
+                self.sort_direction, self.sort_key, self.page_token
+            )
 
         else:
             paging_prop = u'"srtDir":"{}", "srtKey":"{}", "pgNum":{}'.format(

--- a/src/py42/sdk/queries/fileevents/file_event_query.py
+++ b/src/py42/sdk/queries/fileevents/file_event_query.py
@@ -35,7 +35,7 @@ class FileEventQuery(BaseQuery):
             str(group_item) for group_item in self._filter_group_list
         )
         if self.page_token is not None:
-            paging_prop = u'"srtDir": "{}", "srtKey": "{}", "pgToken":"{}"'.format(
+            paging_prop = u'"srtDir":"{}", "srtKey":"{}", "pgToken":"{}"'.format(
                 self.sort_direction, self.sort_key, self.page_token
             )
 

--- a/tests/clients/test_securitydata.py
+++ b/tests/clients/test_securitydata.py
@@ -1349,7 +1349,7 @@ class TestSecurityClient(object):
         response = security_client.search_all_file_events(query)
         connection.post.assert_called_once_with(
             FILE_EVENT_URI,
-            data='{"groupClause":"AND", "groups":[], "srtDir": "asc", "srtKey": "eventId", "pgToken":"", "pgSize":10000}',
+            data='{"groupClause":"AND", "groups":[], "srtDir":"asc", "srtKey":"eventId", "pgToken":"", "pgSize":10000}',
         )
         assert response is successful_response
 
@@ -1381,7 +1381,7 @@ class TestSecurityClient(object):
         response = security_client.search_all_file_events(query, "abc")
         connection.post.assert_called_once_with(
             FILE_EVENT_URI,
-            data='{"groupClause":"AND", "groups":[], "srtDir": "asc", "srtKey": "eventId", "pgToken":"abc", "pgSize":10000}',
+            data='{"groupClause":"AND", "groups":[], "srtDir":"asc", "srtKey":"eventId", "pgToken":"abc", "pgSize":10000}',
         )
         assert response is successful_response
 
@@ -1406,7 +1406,7 @@ class TestSecurityClient(object):
         security_client.search_all_file_events(FileEventQuery.all(), unescaped_token)
         connection.post.assert_called_once_with(
             FILE_EVENT_URI,
-            data='{{"groupClause":"AND", "groups":[], "srtDir": "asc", "srtKey": "eventId", "pgToken":"{0}", "pgSize":10000}}'.format(
+            data='{{"groupClause":"AND", "groups":[], "srtDir":"asc", "srtKey":"eventId", "pgToken":"{0}", "pgSize":10000}}'.format(
                 escaped_token
             ),
         )
@@ -1431,7 +1431,7 @@ class TestSecurityClient(object):
         security_client.search_all_file_events(FileEventQuery.all(), escaped_token)
         connection.post.assert_called_once_with(
             FILE_EVENT_URI,
-            data='{{"groupClause":"AND", "groups":[], "srtDir": "asc", "srtKey": "eventId", "pgToken":"{0}", "pgSize":10000}}'.format(
+            data='{{"groupClause":"AND", "groups":[], "srtDir":"asc", "srtKey":"eventId", "pgToken":"{0}", "pgSize":10000}}'.format(
                 escaped_token
             ),
         )

--- a/tests/clients/test_securitydata.py
+++ b/tests/clients/test_securitydata.py
@@ -1349,7 +1349,7 @@ class TestSecurityClient(object):
         response = security_client.search_all_file_events(query)
         connection.post.assert_called_once_with(
             FILE_EVENT_URI,
-            data='{"groupClause":"AND", "groups":[], "pgToken":"", "pgSize":10000}',
+            data='{"groupClause":"AND", "groups":[], "srtDir": "asc", "srtKey": "eventId", "pgToken":"", "pgSize":10000}',
         )
         assert response is successful_response
 
@@ -1381,7 +1381,7 @@ class TestSecurityClient(object):
         response = security_client.search_all_file_events(query, "abc")
         connection.post.assert_called_once_with(
             FILE_EVENT_URI,
-            data='{"groupClause":"AND", "groups":[], "pgToken":"abc", "pgSize":10000}',
+            data='{"groupClause":"AND", "groups":[], "srtDir": "asc", "srtKey": "eventId", "pgToken":"abc", "pgSize":10000}',
         )
         assert response is successful_response
 
@@ -1406,7 +1406,7 @@ class TestSecurityClient(object):
         security_client.search_all_file_events(FileEventQuery.all(), unescaped_token)
         connection.post.assert_called_once_with(
             FILE_EVENT_URI,
-            data='{{"groupClause":"AND", "groups":[], "pgToken":"{0}", "pgSize":10000}}'.format(
+            data='{{"groupClause":"AND", "groups":[], "srtDir": "asc", "srtKey": "eventId", "pgToken":"{0}", "pgSize":10000}}'.format(
                 escaped_token
             ),
         )
@@ -1431,7 +1431,7 @@ class TestSecurityClient(object):
         security_client.search_all_file_events(FileEventQuery.all(), escaped_token)
         connection.post.assert_called_once_with(
             FILE_EVENT_URI,
-            data='{{"groupClause":"AND", "groups":[], "pgToken":"{0}", "pgSize":10000}}'.format(
+            data='{{"groupClause":"AND", "groups":[], "srtDir": "asc", "srtKey": "eventId", "pgToken":"{0}", "pgSize":10000}}'.format(
                 escaped_token
             ),
         )

--- a/tests/sdk/queries/fileevents/test_file_event_query.py
+++ b/tests/sdk/queries/fileevents/test_file_event_query.py
@@ -159,5 +159,5 @@ def test_file_event_str_gives_correct_json_representation_when_pg_token_is_set(
     query.page_token = "abc"
     assert (
         str(query)
-        == u'{"groupClause":"AND", "groups":[], "pgToken":"abc", "pgSize":10000}'
+        == u'{"groupClause":"AND", "groups":[], "srtDir":"asc", "srtKey":"eventId", "pgToken":"abc", "pgSize":10000}'
     )


### PR DESCRIPTION
### Description of Change ###

Preserves `sort_key` and `sort_direction` properties of a query when `page_token` is used. Now only `page_number` is dropped from the query when `page_token` is present.

### Testing Procedure ###
- Build a query that returns a `nextPgToken` value in the response (can set `page_size` to a low number)
- Set the `.sort_key` property of the query to something other than default `eventId` (e.g. `insertionTimestamp`)
- Set the `.sort_direction` property of the query to `desc` (default is `asc`).
- Run the initial `sdk.securitydata.search_all_file_events(query)` request, get the `nextPgToken` from the response
- Run the second search with the same query object, using the page token. 
- Either through having debug logging enabled, or accessing the `._response.request.body` property of the response, validate the `srtKey` and `srtDir` properties are correctly passed in the request's JSON body.

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [N/A] Add docstrings for any new public parameters / methods / classes
