### PR TITLE
honor microseconds in auditlog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# OS files
+.DS_Store
+
 # compiled docs
 docs/_build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 - An issue where `FileEventQuery.sort_direction` and `FileEventQuery.sort_key` properties were not applied to searches
   when a `page_token` was passed in calls to `sdk.securitydata.search_all_file_events()`.
 
+- Methods `sdk.auditlogs.get_all()` and `sdk.auditlogs.get_page()` now honor microseconds when parameters
+  `begin_time` or `end_time` are epoch times.
+
 ## 1.15.1 - 2021-06-22
 
 ### Changed

--- a/src/py42/services/auditlogs.py
+++ b/src/py42/services/auditlogs.py
@@ -1,7 +1,7 @@
 from py42 import settings
 from py42.services import BaseService
 from py42.services.util import get_all_pages
-from py42.util import parse_timestamp_to_milliseconds_precision
+from py42.util import parse_timestamp_to_microseconds_precision
 from py42.util import to_list
 
 _FILTER_PARAMS = (
@@ -38,11 +38,11 @@ class AuditLogsService(BaseService):
     ):
         date_range = {}
         if begin_time:
-            date_range[u"startTime"] = parse_timestamp_to_milliseconds_precision(
+            date_range[u"startTime"] = parse_timestamp_to_microseconds_precision(
                 begin_time
             )
         if end_time:
-            date_range[u"endTime"] = parse_timestamp_to_milliseconds_precision(end_time)
+            date_range[u"endTime"] = parse_timestamp_to_microseconds_precision(end_time)
 
         uri = u"/rpc/search/search-audit-log"
         page_size = page_size or settings.items_per_page

--- a/tests/services/test_auditlogs.py
+++ b/tests/services/test_auditlogs.py
@@ -23,7 +23,7 @@ class TestAuditLogService(object):
             "/rpc/search/search-audit-log", json=expected_data, headers=None
         )
 
-    def test_get_all_passes_valid_date_range_param_when_begin_and_end_times_are_given(
+    def test_get_all_when_begin_and_end_times_are_given_passes_valid_date_range_param(
         self, mock_connection
     ):
         service = AuditLogsService(mock_connection)
@@ -36,8 +36,8 @@ class TestAuditLogService(object):
             "page": 0,
             "pageSize": 500,
             "dateRange": {
-                "startTime": "2020-06-06T00:00:00.000Z",
-                "endTime": "2020-09-09T12:12:21.000Z",
+                "startTime": "2020-06-06T00:00:00.000000Z",
+                "endTime": "2020-09-09T12:12:21.000000Z",
             },
             "eventTypes": [],
             "actorIds": [],
@@ -206,7 +206,7 @@ class TestAuditLogService(object):
             "/rpc/search/search-audit-log", json=expected_data, headers=None
         )
 
-    def test_get_page_passes_csv_headers_and_params_when_format_is_specified(
+    def test_get_page_when_format_is_specified_passes_csv_headers_and_params(
         self, mock_connection
     ):
         service = AuditLogsService(mock_connection)
@@ -240,7 +240,7 @@ class TestAuditLogService(object):
             headers={"Accept": "text/csv"},
         )
 
-    def test_get_page_passes_cef_headers_and_params_when_format_is_specified(
+    def test_get_page_when_format_is_specified_passes_cef_headers_and_params(
         self, mock_connection
     ):
         service = AuditLogsService(mock_connection)
@@ -274,7 +274,7 @@ class TestAuditLogService(object):
             headers={"Accept": "text/x-cef"},
         )
 
-    def test_get_page_passes_no_headers_and_params_when_invalid_format_is_specified(
+    def test_get_page_when_invalid_format_is_specified_passes_no_headers_and_params(
         self, mock_connection
     ):
         service = AuditLogsService(mock_connection)
@@ -306,7 +306,7 @@ class TestAuditLogService(object):
             "/rpc/search/search-audit-log", json=expected_data, headers=None
         )
 
-    def test_get_all_passes_valid_date_range_param_when_begin_and_end_time_are_string_type(
+    def test_get_all_when_begin_and_end_time_are_string_type_passes_valid_date_range_param(
         self, mock_connection
     ):
         service = AuditLogsService(mock_connection)
@@ -319,8 +319,8 @@ class TestAuditLogService(object):
             "page": 0,
             "pageSize": 500,
             "dateRange": {
-                "startTime": "2020-06-06T00:00:00.000Z",
-                "endTime": "2020-09-09T12:12:21.000Z",
+                "startTime": "2020-06-06T00:00:00.000000Z",
+                "endTime": "2020-09-09T12:12:21.000000Z",
             },
             "eventTypes": [],
             "actorIds": [],
@@ -346,8 +346,8 @@ class TestAuditLogService(object):
             "page": 0,
             "pageSize": 500,
             "dateRange": {
-                "startTime": "2020-06-06T00:00:00.000Z",
-                "endTime": "2020-09-09T12:12:21.000Z",
+                "startTime": "2020-06-06T00:00:00.000000Z",
+                "endTime": "2020-09-09T12:12:21.000000Z",
             },
             "eventTypes": [],
             "actorIds": [],

--- a/tests/services/test_auditlogs.py
+++ b/tests/services/test_auditlogs.py
@@ -333,7 +333,7 @@ class TestAuditLogService(object):
             "/rpc/search/search-audit-log", json=expected_data, headers=None
         )
 
-    def test_get_all_passes_valid_date_range_param_when_begin_and_end_time_are_epoch(
+    def test_get_all_when_begin_and_end_time_are_epoch_passes_valid_date_range_param(
         self, mock_connection
     ):
         service = AuditLogsService(mock_connection)
@@ -348,6 +348,60 @@ class TestAuditLogService(object):
             "dateRange": {
                 "startTime": "2020-06-06T00:00:00.000Z",
                 "endTime": "2020-09-09T12:12:21.000Z",
+            },
+            "eventTypes": [],
+            "actorIds": [],
+            "actorNames": [],
+            "actorIpAddresses": [],
+            "affectedUserIds": [],
+            "affectedUserNames": [],
+        }
+        mock_connection.post.assert_called_once_with(
+            "/rpc/search/search-audit-log", json=expected_data, headers=None
+        )
+
+    def test_get_all_when_begin_and_end_time_are_epoch_with_milliseconds_passes_valid_date_range_param(
+        self, mock_connection
+    ):
+        service = AuditLogsService(mock_connection)
+
+        start_time = 1591401600.123  # 2020-06-06 00:00:00.123456"
+        end_time = 1599653541.443  # 2020-09-09 12:12:21.443234"
+        for _ in service.get_all(begin_time=start_time, end_time=end_time):
+            pass
+        expected_data = {
+            "page": 0,
+            "pageSize": 500,
+            "dateRange": {
+                "startTime": "2020-06-06T00:00:00.123000Z",
+                "endTime": "2020-09-09T12:12:21.443000Z",
+            },
+            "eventTypes": [],
+            "actorIds": [],
+            "actorNames": [],
+            "actorIpAddresses": [],
+            "affectedUserIds": [],
+            "affectedUserNames": [],
+        }
+        mock_connection.post.assert_called_once_with(
+            "/rpc/search/search-audit-log", json=expected_data, headers=None
+        )
+
+    def test_get_all_when_begin_and_end_time_are_epoch_with_microseconds_passes_valid_date_range_param(
+        self, mock_connection
+    ):
+        service = AuditLogsService(mock_connection)
+
+        start_time = 1591401600.123456  # 2020-06-06 00:00:00.123456"
+        end_time = 1599653541.443234  # 2020-09-09 12:12:21.443234"
+        for _ in service.get_all(begin_time=start_time, end_time=end_time):
+            pass
+        expected_data = {
+            "page": 0,
+            "pageSize": 500,
+            "dateRange": {
+                "startTime": "2020-06-06T00:00:00.123456Z",
+                "endTime": "2020-09-09T12:12:21.443234Z",
             },
             "eventTypes": [],
             "actorIds": [],


### PR DESCRIPTION
### Description of Change ###

Noticed this bug when working in Splunk.
The API allows us to use microseconds for querying audit logs. This change makes it so that if epoch times include microseconds for audit_log method `get_page()` and `get_all()`, it will honors those in the query.

For example:

```
{
	"page": 0,
	"pageSize": 500,
	"dateRange": {
		"startTime": "2021-07-01T18:32:19.931000Z"
	},
	"eventTypes": [],
	"actorIds": [],
	"actorNames": [],
	"actorIpAddresses": [],
	"affectedUserIds": [],
	"affectedUserNames": []
}
```

^ Shows a single event for me in Postman, where as 

```
{
	"page": 0,
	"pageSize": 500,
	"dateRange": {
		"startTime": "2021-07-01T18:32:19.931001Z"
	},
	"eventTypes": [],
	"actorIds": [],
	"actorNames": [],
	"actorIpAddresses": [],
	"affectedUserIds": [],
	"affectedUserNames": []
}
```

^ shows 0 events.

### Issues Resolved ###
n/a

- closes #

### Testing Procedure ###
Make a query with a epoch timestamp including microseconds, such as 1591401600.123456

e.g.
`sdk.auditlogs.get_all(begin_time=1591401600.123456)`

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
