### PR TITLE
3 custom errors for update user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 - Methods `sdk.auditlogs.get_all()` and `sdk.auditlogs.get_page()` now honor microseconds when parameters
   `begin_time` or `end_time` are epoch times.
 
+### Added
+
+- Custom exception `Py42InvalidEmailError` when providing an invalid email to `sdk.users.update_user()`.
+
+- Custom exception `Py42InvalidPasswordError` when providing an invalid password to `sdk.users.update_user()`.
+
+- Custom exception `Py42InvalidUsernameError` when providing an invalid username to `sdk.users.update_user()`.
+
 ## 1.15.1 - 2021-06-22
 
 ### Changed

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -237,6 +237,30 @@ class Py42UsernameMustBeEmailError(Py42InternalServerError):
         super(Py42UsernameMustBeEmailError, self).__init__(exception, message)
 
 
+class Py42InvalidEmailError(Py42InternalServerError):
+    """An exception raised when trying to set an invalid email as a user's email."""
+
+    def __init__(self, email, exception):
+        message = u"'{}' is not a valid email.".format(email)
+        super(Py42InvalidEmailError, self).__init__(exception, message)
+
+
+class Py42InvalidPasswordError(Py42InternalServerError):
+    """An exception raised when a password is not valid."""
+
+    def __init__(self, exception):
+        message = u"Invalid password."
+        super(Py42InvalidPasswordError, self).__init__(exception, message)
+
+
+class Py42InvalidUsernameError(Py42InternalServerError):
+    """An exception raised when a username is not valid."""
+
+    def __init__(self, exception):
+        message = u"Invalid username."
+        super(Py42InvalidUsernameError, self).__init__(exception, message)
+
+
 class Py42CloudAliasLimitExceededError(Py42BadRequestError):
     """An Exception raised when trying to add a cloud alias to a user when that user
     already has the max amount of supported cloud aliases."""

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -246,7 +246,7 @@ class Py42InvalidEmailError(Py42InternalServerError):
 
 
 class Py42InvalidPasswordError(Py42InternalServerError):
-    """An exception raised when a password is not valid."""
+    """An exception raised when trying to set an invalid password as a user's password."""
 
     def __init__(self, exception):
         message = u"Invalid password."
@@ -254,7 +254,7 @@ class Py42InvalidPasswordError(Py42InternalServerError):
 
 
 class Py42InvalidUsernameError(Py42InternalServerError):
-    """An exception raised when a username is not valid."""
+    """An exception raised when trying to set an invalid username as a user's username."""
 
     def __init__(self, exception):
         message = u"Invalid username."

--- a/src/py42/services/users.py
+++ b/src/py42/services/users.py
@@ -2,6 +2,9 @@ from py42 import settings
 from py42._compat import quote
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42InternalServerError
+from py42.exceptions import Py42InvalidEmailError
+from py42.exceptions import Py42InvalidPasswordError
+from py42.exceptions import Py42InvalidUsernameError
 from py42.exceptions import Py42OrgNotFoundError
 from py42.exceptions import Py42UserAlreadyExistsError
 from py42.exceptions import Py42UsernameMustBeEmailError
@@ -13,7 +16,6 @@ from py42.services.util import get_all_pages
 class UserService(BaseService):
     """A service for interacting with Code42 user APIs. Use the UserService to create and retrieve
     users. You can also use it to block and deactivate users.
-
     """
 
     def create_user(
@@ -379,6 +381,13 @@ class UserService(BaseService):
         try:
             return self._connection.put(uri, json=data)
         except Py42InternalServerError as err:
-            if u"USERNAME_NOT_AN_EMAIL" in str(err.response.text):
+            response_text = str(err.response.text)
+            if u"USERNAME_NOT_AN_EMAIL" in response_text:
                 raise Py42UsernameMustBeEmailError(err)
+            elif u"EMAIL_INVALID" in response_text:
+                raise Py42InvalidEmailError(email, err)
+            elif u"NEW_PASSWORD_INVALID" in response_text:
+                raise Py42InvalidPasswordError(err)
+            elif u"INVALID_USERNAME" in response_text:
+                raise Py42InvalidUsernameError(err)
             raise

--- a/tests/services/test_users.py
+++ b/tests/services/test_users.py
@@ -330,8 +330,10 @@ class TestUserService(object):
     ):
         user_service = UserService(mock_connection)
         mock_connection.put.side_effect = username_must_be_email_error_response
-        with pytest.raises(Py42UsernameMustBeEmailError):
+        with pytest.raises(Py42UsernameMustBeEmailError) as err:
             user_service.update_user("123", username="foo")
+
+        assert str(err.value) == "Username must be an email address."
 
     def test_update_user_when_get_internal_server_error_containing_email_invalid_raises_expected_error(
         self, mock_connection, invalid_email_error_response


### PR DESCRIPTION
### Description of Change ###

3 new custom errors for users.update_user() that are needed for the CLI to also leverage.

This came up during testing of the CLI feature for updating users from QA.

### Issues Resolved ###
n/a

### Testing Procedure ###
Call the methods where email is already-taken, password is not complex enough, username is blank, and email is not in an email format.

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
