### PR TITLE
fixes/utilize-requests-json-param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Fixed
+
+- Issue where debug logs double-stringified JSON data while logging requests.
+
 ## 1.16.0 - 2021-07-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - Issue where debug logs double-stringified JSON data while logging requests.
 
+- Issue where `UnicodeError` would get raised when using unicode values in py42.
+
 ## 1.16.0 - 2021-07-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - Issue where debug logs double-stringified JSON data while logging requests.
 
-- Issue where `UnicodeError` would get raised when using unicode values in py42.
+- Issue where `sdk.securitydata.search_file_evens()` and `sdk.alerts.search()` would raise `UnicodeError`
+  when queries included certain unicode characters.
 
 ## 1.16.0 - 2021-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - Issue where debug logs double-stringified JSON data while logging requests.
 
-- Issue where `sdk.securitydata.search_file_evens()` and `sdk.alerts.search()` would raise `UnicodeError`
+- Issue where `sdk.securitydata.search_file_events()` and `sdk.alerts.search()` would raise `UnicodeError`
   when queries included certain unicode characters.
 
 ## 1.16.0 - 2021-07-08

--- a/src/py42/sdk/queries/fileevents/file_event_query.py
+++ b/src/py42/sdk/queries/fileevents/file_event_query.py
@@ -53,12 +53,16 @@ class FileEventQuery(BaseQuery):
         output_dict = {
             u"groupClause": self._group_clause,
             u"groups": filter_group_list,
-            u"pgNum": self.page_number,
             u"pgSize": self.page_size,
             u"srtDir": self.sort_direction,
             u"srtKey": self.sort_key,
-            u"pgToken": self.page_token,
         }
+
+        if self.page_token is not None:
+            output_dict["pgToken"] = self.page_token
+        else:
+            output_dict["pgSize"] = self.page_size
+
         for key in output_dict:
             yield key, output_dict[key]
 

--- a/src/py42/sdk/queries/fileevents/file_event_query.py
+++ b/src/py42/sdk/queries/fileevents/file_event_query.py
@@ -61,7 +61,7 @@ class FileEventQuery(BaseQuery):
         if self.page_token is not None:
             output_dict["pgToken"] = self.page_token
         else:
-            output_dict["pgSize"] = self.page_size
+            output_dict["pgNum"] = self.page_number
 
         for key in output_dict:
             yield key, output_dict[key]

--- a/src/py42/services/_connection.py
+++ b/src/py42/services/_connection.py
@@ -231,6 +231,8 @@ class Connection(object):
 
         if json is not None:
             data = json_lib.dumps(json)
+        elif data is not None:
+            json = json_lib.loads(data)
 
         headers = headers or {}
         headers.update(self._headers)
@@ -251,7 +253,7 @@ class Connection(object):
             hooks=hooks,
         )
 
-        _print_request(method, url, params=params, data=data)
+        _print_request(method, url, params=params, data=json)
         return self._session.prepare_request(request)
 
     def _get_host_address(self):

--- a/src/py42/services/_connection.py
+++ b/src/py42/services/_connection.py
@@ -233,9 +233,8 @@ class Connection(object):
         if json is not None:
             data = json_lib.dumps(json)
 
-        if data is not None:
-            if isinstance(data, str):
-                data = data.encode("utf-8")
+        if isinstance(data, str):
+            data = data.encode("utf-8")
 
         headers = headers or {}
         headers.update(self._headers)

--- a/src/py42/services/_connection.py
+++ b/src/py42/services/_connection.py
@@ -246,7 +246,7 @@ class Connection(object):
             url=url,
             headers=headers,
             files=files,
-            data=data,
+            data=data.encode("utf-8") if data else data,
             params=params,
             auth=auth or self._auth,
             cookies=cookies,

--- a/src/py42/services/_connection.py
+++ b/src/py42/services/_connection.py
@@ -235,8 +235,6 @@ class Connection(object):
 
         if data is not None:
             if isinstance(data, str):
-                if json is None:
-                    json = json_lib.loads(data)
                 data = data.encode("utf-8")
 
         headers = headers or {}
@@ -258,7 +256,7 @@ class Connection(object):
             hooks=hooks,
         )
 
-        _print_request(method, url, params=params, data=json)
+        _print_request(method, url, params=params, data=data)
         return self._session.prepare_request(request)
 
     def _get_host_address(self):
@@ -300,4 +298,5 @@ def _print_request(method, url, params=None, data=None):
     if params:
         debug.logger.debug(format_dict(params, u"  params"))
     if data:
-        debug.logger.debug(format_dict(data, u"  data"))
+        data_dict = json_lib.loads(data)
+        debug.logger.debug(format_dict(data_dict, u"  data"))

--- a/src/py42/services/_connection.py
+++ b/src/py42/services/_connection.py
@@ -11,6 +11,7 @@ from requests.sessions import Session
 import py42.settings as settings
 from py42._compat import urljoin
 from py42._compat import urlparse
+from py42._compat import string_type
 from py42.exceptions import Py42DeviceNotConnectedError
 from py42.exceptions import Py42Error
 from py42.exceptions import Py42FeatureUnavailableError
@@ -231,8 +232,12 @@ class Connection(object):
 
         if json is not None:
             data = json_lib.dumps(json)
-        elif data is not None:
-            json = json_lib.loads(data)
+
+        if data is not None:
+            if isinstance(data, str):
+                if json is None:
+                    json = json_lib.loads(data)
+                data = data.encode("utf-8")
 
         headers = headers or {}
         headers.update(self._headers)
@@ -246,7 +251,7 @@ class Connection(object):
             url=url,
             headers=headers,
             files=files,
-            data=data.encode("utf-8") if data else data,
+            data=data,
             params=params,
             auth=auth or self._auth,
             cookies=cookies,

--- a/src/py42/services/_connection.py
+++ b/src/py42/services/_connection.py
@@ -233,9 +233,6 @@ class Connection(object):
         if json is not None:
             data = json_lib.dumps(json)
 
-        if isinstance(data, string_type):
-            data = data.encode("utf-8")
-
         headers = headers or {}
         headers.update(self._headers)
         if data and u"Content-Type" not in headers:
@@ -243,6 +240,12 @@ class Connection(object):
         if u"Accept" not in headers:
             headers.update({u"Accept": u"application/json"})
         headers = _create_user_headers(headers)
+
+        _print_request(method, url, params=params, data=data)
+
+        if isinstance(data, string_type):
+            data = data.encode("utf-8")
+
         request = Request(
             method=method,
             url=url,
@@ -255,7 +258,6 @@ class Connection(object):
             hooks=hooks,
         )
 
-        _print_request(method, url, params=params, data=data)
         return self._session.prepare_request(request)
 
     def _get_host_address(self):

--- a/src/py42/services/_connection.py
+++ b/src/py42/services/_connection.py
@@ -9,9 +9,9 @@ from requests.models import Request
 from requests.sessions import Session
 
 import py42.settings as settings
+from py42._compat import string_type
 from py42._compat import urljoin
 from py42._compat import urlparse
-from py42._compat import string_type
 from py42.exceptions import Py42DeviceNotConnectedError
 from py42.exceptions import Py42Error
 from py42.exceptions import Py42FeatureUnavailableError
@@ -233,7 +233,7 @@ class Connection(object):
         if json is not None:
             data = json_lib.dumps(json)
 
-        if isinstance(data, str):
+        if isinstance(data, string_type):
             data = data.encode("utf-8")
 
         headers = headers or {}

--- a/src/py42/services/_connection.py
+++ b/src/py42/services/_connection.py
@@ -140,14 +140,14 @@ class Connection(object):
     def head(self, url, **kwargs):
         return self.request(u"HEAD", url, **kwargs)
 
-    def post(self, url, data=None, **kwargs):
-        return self.request(u"POST", url, data=data, **kwargs)
+    def post(self, url, data=None, json=None, **kwargs):
+        return self.request(u"POST", url, data=data, json=json, **kwargs)
 
-    def put(self, url, data=None, **kwargs):
-        return self.request(u"PUT", url, data=data, **kwargs)
+    def put(self, url, data=None, json=None, **kwargs):
+        return self.request(u"PUT", url, data=data, json=json, **kwargs)
 
-    def patch(self, url, data=None, **kwargs):
-        return self.request(u"PATCH", url, data=data, **kwargs)
+    def patch(self, url, data=None, json=None, **kwargs):
+        return self.request(u"PATCH", url, data=data, json=json, **kwargs)
 
     def delete(self, url, **kwargs):
         return self.request(u"DELETE", url, **kwargs)
@@ -230,9 +230,6 @@ class Connection(object):
         self._session.proxies = settings.proxies
         self._session.verify = settings.verify_ssl_certs
 
-        if json is not None:
-            data = json_lib.dumps(json)
-
         headers = headers or {}
         headers.update(self._headers)
         if data and u"Content-Type" not in headers:
@@ -241,7 +238,7 @@ class Connection(object):
             headers.update({u"Accept": u"application/json"})
         headers = _create_user_headers(headers)
 
-        _print_request(method, url, params=params, data=data)
+        _print_request(method, url, params=params, data=data, json=json)
 
         if isinstance(data, string_type):
             data = data.encode("utf-8")
@@ -252,6 +249,7 @@ class Connection(object):
             headers=headers,
             files=files,
             data=data,
+            json=json,
             params=params,
             auth=auth or self._auth,
             cookies=cookies,
@@ -294,10 +292,11 @@ def _handle_error(method, url, response):
         raise_py42_error(ex)
 
 
-def _print_request(method, url, params=None, data=None):
+def _print_request(method, url, params=None, data=None, json=None):
     debug.logger.info(u"{}{}".format(method.ljust(8), url))
     if params:
         debug.logger.debug(format_dict(params, u"  params"))
+    if json:
+        debug.logger.debug(format_dict(json, u"  json"))
     if data:
-        data_dict = json_lib.loads(data)
-        debug.logger.debug(format_dict(data_dict, u"  data"))
+        debug.logger.debug(data, u"  data")

--- a/src/py42/services/alerts.py
+++ b/src/py42/services/alerts.py
@@ -24,14 +24,14 @@ class AlertService(BaseService):
             query.page_size = page_size
         query = self._add_tenant_id_if_missing(query)
         uri = self._uri_prefix.format(u"query-alerts")
-        return self._connection.post(uri, data=query)
+        return self._connection.post(uri, json=query)
 
     def get_search_page(self, query, page_num, page_size):
         query.page_number = page_num - 1
         query.page_size = page_size
         uri = self._uri_prefix.format(u"query-alerts")
         query = self._add_tenant_id_if_missing(query)
-        return self._connection.post(uri, data=query)
+        return self._connection.post(uri, json=query)
 
     def search_all_pages(self, query):
         return get_all_pages(
@@ -64,13 +64,13 @@ class AlertService(BaseService):
         return self._connection.post(uri, json=data)
 
     def _add_tenant_id_if_missing(self, query):
-        query_dict = json.loads(str(query))
+        query_dict = dict(query)
         tenant_id = query_dict.get(u"tenantId", None)
         if tenant_id is None:
             query_dict[u"tenantId"] = self._user_context.get_current_tenant_id()
-            return json.dumps(query_dict)
+            return query_dict
         else:
-            return str(query)
+            return query_dict
 
     def get_rules_page(
         self, page_num, groups=None, sort_key=None, sort_direction=None, page_size=None

--- a/src/py42/services/fileevent.py
+++ b/src/py42/services/fileevent.py
@@ -37,7 +37,7 @@ class FileEventService(BaseService):
             return self._connection.post(uri, json=query)
         except Py42BadRequestError as err:
             if u"INVALID_PAGE_TOKEN" in str(err.response.text):
-                page_token = query.page_token
+                page_token = query.get("pgToken")
                 if page_token:
                     raise Py42InvalidPageTokenError(err, page_token)
             raise

--- a/src/py42/services/fileevent.py
+++ b/src/py42/services/fileevent.py
@@ -1,4 +1,7 @@
+import json
+
 from py42._compat import str
+from py42._compat import string_type
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42InvalidPageTokenError
 from py42.services import BaseService
@@ -16,16 +19,22 @@ class FileEventService(BaseService):
         `REST Documentation <https://forensicsearch-east.us.code42.com/forensic-search/queryservice/swagger-ui.html#/file-event-controller/searchEventsUsingPOST>`__
 
         Args:
-            query (:class:`~py42.sdk.queries.fileevents.file_event_query.FileEventQuery` or str):
+            query (:class:`~py42.sdk.queries.fileevents.file_event_query.FileEventQuery` or str or unicode):
                 A composed :class:`~py42.sdk.queries.fileevents.file_event_query.FileEventQuery`
                 object or the raw query as a JSON formatted string.
 
         Returns:
             :class:`py42.response.Py42Response`: A response containing the query results.
         """
+
+        if isinstance(query, string_type):
+            query = json.loads(query)
+        else:
+            query = dict(query)
+
         try:
             uri = u"/forensic-search/queryservice/api/v1/fileevent"
-            return self._connection.post(uri, json=dict(query))
+            return self._connection.post(uri, json=query)
         except Py42BadRequestError as err:
             if u"INVALID_PAGE_TOKEN" in str(err.response.text):
                 page_token = query.page_token

--- a/src/py42/services/fileevent.py
+++ b/src/py42/services/fileevent.py
@@ -24,9 +24,8 @@ class FileEventService(BaseService):
             :class:`py42.response.Py42Response`: A response containing the query results.
         """
         try:
-            query_str = str(query)
             uri = u"/forensic-search/queryservice/api/v1/fileevent"
-            return self._connection.post(uri, data=query_str)
+            return self._connection.post(uri, json=dict(query))
         except Py42BadRequestError as err:
             if u"INVALID_PAGE_TOKEN" in str(err.response.text):
                 page_token = query.page_token

--- a/tests/clients/test_securitydata.py
+++ b/tests/clients/test_securitydata.py
@@ -1419,7 +1419,7 @@ class TestSecurityClient(object):
             "srtDir": "asc",
             "srtKey": "eventId",
             "pgToken": escaped_token,
-            "pgSize": 1000,
+            "pgSize": 10000,
         }
         connection.post.assert_called_once_with(FILE_EVENT_URI, json=expected)
 

--- a/tests/clients/test_securitydata.py
+++ b/tests/clients/test_securitydata.py
@@ -1347,10 +1347,15 @@ class TestSecurityClient(object):
         )
         query = FileEventQuery.all()
         response = security_client.search_all_file_events(query)
-        connection.post.assert_called_once_with(
-            FILE_EVENT_URI,
-            data='{"groupClause":"AND", "groups":[], "srtDir":"asc", "srtKey":"eventId", "pgToken":"", "pgSize":10000}',
-        )
+        expected = {
+            "groupClause": "AND",
+            "groups": [],
+            "srtDir": "asc",
+            "srtKey": "eventId",
+            "pgToken": "",
+            "pgSize": 10000,
+        }
+        connection.post.assert_called_once_with(FILE_EVENT_URI, json=expected)
         assert response is successful_response
 
     def test_search_all_file_events_calls_search_with_expected_params_when_pg_token_is_passed(
@@ -1361,7 +1366,6 @@ class TestSecurityClient(object):
         saved_search_service,
         storage_service_factory,
     ):
-
         file_event_service = FileEventService(connection)
         successful_response = {
             "totalCount": None,
@@ -1379,10 +1383,15 @@ class TestSecurityClient(object):
         )
         query = FileEventQuery.all()
         response = security_client.search_all_file_events(query, "abc")
-        connection.post.assert_called_once_with(
-            FILE_EVENT_URI,
-            data='{"groupClause":"AND", "groups":[], "srtDir":"asc", "srtKey":"eventId", "pgToken":"abc", "pgSize":10000}',
-        )
+        expected = {
+            "groupClause": "AND",
+            "groups": [],
+            "srtDir": "asc",
+            "srtKey": "eventId",
+            "pgToken": "abc",
+            "pgSize": 10000,
+        }
+        connection.post.assert_called_once_with(FILE_EVENT_URI, json=expected)
         assert response is successful_response
 
     def test_search_all_file_events_handles_unescaped_quote_chars_in_token(
@@ -1404,12 +1413,15 @@ class TestSecurityClient(object):
         unescaped_token = '1234_"abcde"'
         escaped_token = r"1234_\"abcde\""
         security_client.search_all_file_events(FileEventQuery.all(), unescaped_token)
-        connection.post.assert_called_once_with(
-            FILE_EVENT_URI,
-            data='{{"groupClause":"AND", "groups":[], "srtDir":"asc", "srtKey":"eventId", "pgToken":"{0}", "pgSize":10000}}'.format(
-                escaped_token
-            ),
-        )
+        expected = {
+            "groupClause": "AND",
+            "groups": [],
+            "srtDir": "asc",
+            "srtKey": "eventId",
+            "pgToken": escaped_token,
+            "pgSize": 1000,
+        }
+        connection.post.assert_called_once_with(FILE_EVENT_URI, json=expected)
 
     def test_search_all_file_events_handles_escaped_quote_chars_in_token(
         self,
@@ -1429,9 +1441,12 @@ class TestSecurityClient(object):
         )
         escaped_token = r"1234_\"abcde\""
         security_client.search_all_file_events(FileEventQuery.all(), escaped_token)
-        connection.post.assert_called_once_with(
-            FILE_EVENT_URI,
-            data='{{"groupClause":"AND", "groups":[], "srtDir":"asc", "srtKey":"eventId", "pgToken":"{0}", "pgSize":10000}}'.format(
-                escaped_token
-            ),
-        )
+        expected = {
+            "groupClause": "AND",
+            "groups": [],
+            "srtDir": "asc",
+            "srtKey": "eventId",
+            "pgToken": escaped_token,
+            "pgSize": 10000,
+        }
+        connection.post.assert_called_once_with(FILE_EVENT_URI, json=expected)

--- a/tests/services/test_alerts.py
+++ b/tests/services/test_alerts.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 from requests import Response
 from tests.conftest import TENANT_ID_FROM_RESPONSE
@@ -77,7 +75,7 @@ class TestAlertService(object):
         _filter = AlertState.eq("OPEN")
         query = AlertQuery(_filter)
         alert_service.search(query)
-        post_data = json.loads(mock_connection.post.call_args[1]["data"])
+        post_data = mock_connection.post.call_args[1]["json"]
         assert (
             post_data["tenantId"] == TENANT_ID_FROM_RESPONSE
             and post_data["groupClause"] == "AND"
@@ -378,7 +376,7 @@ class TestAlertService(object):
 
         assert mock_connection.post.call_count == 1
         assert mock_connection.post.call_args[0][0] == "/svc/api/v1/query-alerts"
-        post_data = json.loads(mock_connection.post.call_args[1]["data"])
+        post_data = mock_connection.post.call_args[1]["json"]
         assert (
             post_data["tenantId"] == TENANT_ID_FROM_RESPONSE
             and post_data["groupClause"] == "AND"
@@ -403,7 +401,7 @@ class TestAlertService(object):
 
         assert mock_connection.post.call_count == 1
         assert mock_connection.post.call_args[0][0] == "/svc/api/v1/query-alerts"
-        post_data = json.loads(mock_connection.post.call_args[1]["data"])
+        post_data = mock_connection.post.call_args[1]["json"]
         assert (
             post_data["tenantId"] == TENANT_ID_FROM_RESPONSE
             and post_data["groupClause"] == "AND"

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -189,7 +189,9 @@ class TestConnection(object):
     ):
         connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
         connection.put(URL, data=DATA_VALUE)
-        expected = MockPreparedRequest("PUT", HOST_ADDRESS + URL, DATA_VALUE)
+        expected = MockPreparedRequest(
+            "PUT", HOST_ADDRESS + URL, DATA_VALUE.encode("utf-8")
+        )
         success_requests_session.prepare_request.assert_called_once_with(expected)
 
     def test_connection_post_calls_requests_with_post(
@@ -197,7 +199,9 @@ class TestConnection(object):
     ):
         connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
         connection.post(URL, data=DATA_VALUE)
-        expected = MockPreparedRequest("POST", HOST_ADDRESS + URL, DATA_VALUE)
+        expected = MockPreparedRequest(
+            "POST", HOST_ADDRESS + URL, DATA_VALUE.encode("utf-8")
+        )
         success_requests_session.prepare_request.assert_called_once_with(expected)
 
     def test_connection_patch_calls_requests_with_patch(
@@ -205,7 +209,9 @@ class TestConnection(object):
     ):
         connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
         connection.patch(URL, data=DATA_VALUE)
-        expected = MockPreparedRequest("PATCH", HOST_ADDRESS + URL, DATA_VALUE)
+        expected = MockPreparedRequest(
+            "PATCH", HOST_ADDRESS + URL, DATA_VALUE.encode("utf-8")
+        )
         success_requests_session.prepare_request.assert_called_once_with(expected)
 
     def test_connection_delete_calls_requests_with_delete(
@@ -238,7 +244,7 @@ class TestConnection(object):
         connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
         connection.post(URL, json=JSON_VALUE)
         expected = MockPreparedRequest(
-            "POST", HOST_ADDRESS + URL, json.dumps(JSON_VALUE)
+            "POST", HOST_ADDRESS + URL, json.dumps(JSON_VALUE).encode("utf-8")
         )
         success_requests_session.prepare_request.assert_called_once_with(expected)
 
@@ -248,7 +254,7 @@ class TestConnection(object):
         connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
         connection.post(URL, data=DATA_VALUE, json=JSON_VALUE)
         expected = MockPreparedRequest(
-            "POST", HOST_ADDRESS + URL, json.dumps(JSON_VALUE)
+            "POST", HOST_ADDRESS + URL, json.dumps(JSON_VALUE).encode("utf-8")
         )
         success_requests_session.prepare_request.assert_called_once_with(expected)
 

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -29,7 +29,7 @@ default_kwargs = {
 }
 HOST_ADDRESS = "http://example.com"
 URL = "/api/resource"
-DATA_VALUE = "value"
+DATA_VALUE = '{"test": "data"}'
 JSON_VALUE = {"key": "value"}
 KWARGS_INDEX = 1
 DATA_KEY = "data"
@@ -188,24 +188,24 @@ class TestConnection(object):
         self, mock_host_resolver, mock_auth, success_requests_session
     ):
         connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
-        connection.put(URL, data="testdata")
-        expected = MockPreparedRequest("PUT", HOST_ADDRESS + URL, "testdata")
+        connection.put(URL, data=DATA_VALUE)
+        expected = MockPreparedRequest("PUT", HOST_ADDRESS + URL, DATA_VALUE)
         success_requests_session.prepare_request.assert_called_once_with(expected)
 
     def test_connection_post_calls_requests_with_post(
         self, mock_host_resolver, mock_auth, success_requests_session
     ):
         connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
-        connection.post(URL, data="testdata")
-        expected = MockPreparedRequest("POST", HOST_ADDRESS + URL, "testdata")
+        connection.post(URL, data=DATA_VALUE)
+        expected = MockPreparedRequest("POST", HOST_ADDRESS + URL, DATA_VALUE)
         success_requests_session.prepare_request.assert_called_once_with(expected)
 
     def test_connection_patch_calls_requests_with_patch(
         self, mock_host_resolver, mock_auth, success_requests_session
     ):
         connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
-        connection.patch(URL, data="testdata")
-        expected = MockPreparedRequest("PATCH", HOST_ADDRESS + URL, "testdata")
+        connection.patch(URL, data=DATA_VALUE)
+        expected = MockPreparedRequest("PATCH", HOST_ADDRESS + URL, DATA_VALUE)
         success_requests_session.prepare_request.assert_called_once_with(expected)
 
     def test_connection_delete_calls_requests_with_delete(

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 from requests import Response
 from tests.conftest import TEST_DEVICE_GUID
@@ -97,10 +95,11 @@ def proxy_set():
 
 
 class MockPreparedRequest(object):
-    def __init__(self, method, url, data=None):
+    def __init__(self, method, url, data=None, json=None):
         self._method = method
         self._url = url
         self._data = data or []
+        self._json = json or {}
 
     def __eq__(self, other):
         return (
@@ -181,7 +180,7 @@ class TestConnection(object):
     ):
         connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
         connection.get(URL)
-        expected = MockPreparedRequest("GET", HOST_ADDRESS + URL, None)
+        expected = MockPreparedRequest("GET", HOST_ADDRESS + URL)
         success_requests_session.prepare_request.assert_called_once_with(expected)
 
     def test_connection_put_calls_requests_with_put(
@@ -190,7 +189,7 @@ class TestConnection(object):
         connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
         connection.put(URL, data=DATA_VALUE)
         expected = MockPreparedRequest(
-            "PUT", HOST_ADDRESS + URL, DATA_VALUE.encode("utf-8")
+            "PUT", HOST_ADDRESS + URL, data=DATA_VALUE.encode("utf-8")
         )
         success_requests_session.prepare_request.assert_called_once_with(expected)
 
@@ -200,7 +199,7 @@ class TestConnection(object):
         connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
         connection.post(URL, data=DATA_VALUE)
         expected = MockPreparedRequest(
-            "POST", HOST_ADDRESS + URL, DATA_VALUE.encode("utf-8")
+            "POST", HOST_ADDRESS + URL, data=DATA_VALUE.encode("utf-8")
         )
         success_requests_session.prepare_request.assert_called_once_with(expected)
 
@@ -210,7 +209,7 @@ class TestConnection(object):
         connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
         connection.patch(URL, data=DATA_VALUE)
         expected = MockPreparedRequest(
-            "PATCH", HOST_ADDRESS + URL, DATA_VALUE.encode("utf-8")
+            "PATCH", HOST_ADDRESS + URL, data=DATA_VALUE.encode("utf-8")
         )
         success_requests_session.prepare_request.assert_called_once_with(expected)
 
@@ -238,23 +237,13 @@ class TestConnection(object):
         expected = MockPreparedRequest("HEAD", HOST_ADDRESS + URL)
         success_requests_session.prepare_request.assert_called_once_with(expected)
 
-    def test_connection_post_with_json_prepares_request_with_string_encoded_json_body(
+    def test_connection_post_with_json_prepares_request_with_json(
         self, mock_host_resolver, mock_auth, success_requests_session
     ):
         connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
         connection.post(URL, json=JSON_VALUE)
         expected = MockPreparedRequest(
-            "POST", HOST_ADDRESS + URL, json.dumps(JSON_VALUE).encode("utf-8")
-        )
-        success_requests_session.prepare_request.assert_called_once_with(expected)
-
-    def test_connection_post_with_data_and_json_params_overwrites_data_with_json(
-        self, mock_host_resolver, mock_auth, success_requests_session
-    ):
-        connection = Connection(mock_host_resolver, mock_auth, success_requests_session)
-        connection.post(URL, data=DATA_VALUE, json=JSON_VALUE)
-        expected = MockPreparedRequest(
-            "POST", HOST_ADDRESS + URL, json.dumps(JSON_VALUE).encode("utf-8")
+            "POST", HOST_ADDRESS + URL, data=None, json=JSON_VALUE
         )
         success_requests_session.prepare_request.assert_called_once_with(expected)
 

--- a/tests/services/test_file_event.py
+++ b/tests/services/test_file_event.py
@@ -37,7 +37,7 @@ class TestFileEventService(object):
         connection.post.return_value = successful_response
         query = _create_test_query()
         service.search(query)
-        connection.post.assert_called_once_with(FILE_EVENT_URI, data=str(query))
+        connection.post.assert_called_once_with(FILE_EVENT_URI, json=dict(query))
 
     def test_search_when_given_page_token_and_bad_request_with_invalid_page_token_occurs_raises_invalid_page_token_error(
         self, mock_invalid_page_token_connection
@@ -77,9 +77,9 @@ class TestFileEventService(object):
         service = FileEventService(connection)
         connection.post.return_value = successful_response
         query = _create_test_query(u"我能吞")
-        expected = str(query)
+        expected = dict(query)
         service.search(query)
-        connection.post.assert_called_once_with(FILE_EVENT_URI, data=expected)
+        connection.post.assert_called_once_with(FILE_EVENT_URI, json=expected)
 
     def test_get_file_location_detail_by_sha256_calls_get_with_hash(
         self, connection, successful_response

--- a/tests/services/test_fileevent.py
+++ b/tests/services/test_fileevent.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import json
+
 import pytest
 from tests.conftest import create_mock_error
 
@@ -38,6 +40,16 @@ class TestFileEventService(object):
         query = _create_test_query()
         service.search(query)
         connection.post.assert_called_once_with(FILE_EVENT_URI, json=dict(query))
+
+    def test_search_when_given_str_type_query_calls_post_with_uri_and_query(
+        self, connection, successful_response
+    ):
+        service = FileEventService(connection)
+        connection.post.return_value = successful_response
+        query = str(_create_test_query())
+        service.search(query)
+        expected = json.loads(query)
+        connection.post.assert_called_once_with(FILE_EVENT_URI, json=expected)
 
     def test_search_when_given_page_token_and_bad_request_with_invalid_page_token_occurs_raises_invalid_page_token_error(
         self, mock_invalid_page_token_connection

--- a/tests/services/test_savedsearch.py
+++ b/tests/services/test_savedsearch.py
@@ -1,5 +1,3 @@
-import json
-
 from py42 import settings
 from py42.services.fileevent import FileEventService
 from py42.services.savedsearch import SavedSearchService
@@ -53,7 +51,7 @@ class TestSavedSearchService(object):
         saved_search_service = SavedSearchService(mock_connection, file_event_service)
         saved_search_service.execute(u"test-id")
         assert mock_connection.post.call_count == 1
-        posted_data = json.loads(mock_connection.post.call_args[1]["data"])
+        posted_data = mock_connection.post.call_args[1]["json"]
         assert (
             posted_data["pgSize"] == 10000
             and posted_data[u"pgNum"] == 1
@@ -74,7 +72,7 @@ class TestSavedSearchService(object):
             u"test-id", page_number=test_custom_page_num,
         )
         assert mock_connection.post.call_count == 1
-        posted_data = json.loads(mock_connection.post.call_args[1]["data"])
+        posted_data = mock_connection.post.call_args[1]["json"]
         settings.security_events_per_page = 10000
         assert (
             posted_data[u"pgSize"] == 5000
@@ -99,7 +97,7 @@ class TestSavedSearchService(object):
             page_size=test_custom_page_size,
         )
         assert mock_connection.post.call_count == 1
-        posted_data = json.loads(mock_connection.post.call_args[1]["data"])
+        posted_data = mock_connection.post.call_args[1]["json"]
         settings.security_events_per_page = 10000
         assert (
             posted_data[u"pgSize"] == 5000


### PR DESCRIPTION
### Description of Change ###

Debug logging assumed a dictionary for data during the logging call, which messed with the output format of the logs. This fixes that and makes the data logging the same as the params logging.

### Issues Resolved ###
n/a

### Testing Procedure ###
Turn on debugging (or use `-d` in the CLI and notice the logs look nicer now for data-based requests.
You can add a print statement in `_print_request()` before these changes to verify the type of data before it is passed to json.dumps (it was a str, but json.dumps assumes it is dictionary).
After these changes, it is now a dictionary.

### PR Checklist ###
Did you remember to do the below?

- [n/a] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [n/a] Add docstrings for any new public parameters / methods / classes
