### PR TITLE
Add risk indicator filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Added
+
+- `RiskIndicator` and `RiskSeverity` filters class to new `py42.sdk.queries.fileevents.filters.risk_filter` module.
+
 ## 1.16.1 - 2021-07-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Added
 
-- `RiskIndicator` and `RiskSeverity` filters class to new `py42.sdk.queries.fileevents.filters.risk_filter` module.
+- `RiskIndicator` and `RiskSeverity` filter classes to new `py42.sdk.queries.fileevents.filters.risk_filter` module.
 
 ## 1.16.1 - 2021-07-20
 

--- a/docs/methoddocs/filleeventqueries.md
+++ b/docs/methoddocs/filleeventqueries.md
@@ -378,3 +378,19 @@ See [Executing Searches](../userguides/searches.md) for more on building search 
     :inherited-members:
     :show-inheritance:
 ```
+
+### Risk Filters
+
+```eval_rst
+.. autoclass:: py42.sdk.queries.fileevents.filters.risk_filter.RiskIndicator
+    :members:
+    :inherited-members:
+    :show-inheritance:
+```
+
+```eval_rst
+.. autoclass:: py42.sdk.queries.fileevents.filters.risk_filter.RiskSeverity
+    :members:
+    :inherited-members:
+    :show-inheritance:
+```

--- a/src/py42/sdk/queries/fileevents/filters/__init__.py
+++ b/src/py42/sdk/queries/fileevents/filters/__init__.py
@@ -6,3 +6,4 @@ from py42.sdk.queries.fileevents.filters.event_filter import *
 from py42.sdk.queries.fileevents.filters.exposure_filter import *
 from py42.sdk.queries.fileevents.filters.file_filter import *
 from py42.sdk.queries.fileevents.filters.print_filter import *
+from py42.sdk.queries.fileevents.filters.risk_filter import *

--- a/src/py42/sdk/queries/fileevents/filters/risk_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/risk_filter.py
@@ -3,7 +3,71 @@ from py42.util import get_attribute_keys_from_class
 
 
 class RiskIndicator(FileEventFilterStringField):
-    """Class that filters events by risk indicator."""
+    """Class that filters events by risk indicator.
+
+    Available options are provided as class attributes:
+        - :attr:`RiskIndicator.CloudDataExposures.PUBLIC_CORPORATE_BOX`
+        - :attr:`RiskIndicator.CloudDataExposures.PUBLIC_CORPORATE_GOOGLE_DRIVE`
+        - :attr:`RiskIndicator.CloudDataExposures.PUBLIC_CORPORATE_ONEDRIVE`
+        - :attr:`RiskIndicator.CloudDataExposures.SENT_CORPORATE_GMAIL`
+        - :attr:`RiskIndicator.CloudDataExposures.SHARED_CORPORATE_BOX`
+        - :attr:`RiskIndicator.CloudDataExposures.SHARED_CORPORATE_GOOGLE_DRIVE`
+        - :attr:`RiskIndicator.CloudDataExposures.SHARED_CORPORATE_ONEDRIVE`
+        - :attr:`RiskIndicator.CloudStorageUploads.AMAZON_DRIVE`
+        - :attr:`RiskIndicator.CloudStorageUploads.BOX`
+        - :attr:`RiskIndicator.CloudStorageUploads.DROPBOX`
+        - :attr:`RiskIndicator.CloudStorageUploads.GOOGLE_DRIVE`
+        - :attr:`RiskIndicator.CloudStorageUploads.ICLOUD`
+        - :attr:`RiskIndicator.CloudStorageUploads.MEGA`
+        - :attr:`RiskIndicator.CloudStorageUploads.ONEDRIVE`
+        - :attr:`RiskIndicator.CloudStorageUploads.ZOHO`
+        - :attr:`RiskIndicator.CodeRepositoryUploads.BITBUCKET`
+        - :attr:`RiskIndicator.CodeRepositoryUploads.GITHUB`
+        - :attr:`RiskIndicator.CodeRepositoryUploads.GITLAB`
+        - :attr:`RiskIndicator.CodeRepositoryUploads.SOURCEFORGE`
+        - :attr:`RiskIndicator.CodeRepositoryUploads.STASH`
+        - :attr:`RiskIndicator.EmailServiceUploads.ONESIXTHREE_DOT_COM`
+        - :attr:`RiskIndicator.EmailServiceUploads.ONETWOSIX_DOT_COM`
+        - :attr:`RiskIndicator.EmailServiceUploads.AOL`
+        - :attr:`RiskIndicator.EmailServiceUploads.COMCAST`
+        - :attr:`RiskIndicator.EmailServiceUploads.GMAIL`
+        - :attr:`RiskIndicator.EmailServiceUploads.ICLOUD`
+        - :attr:`RiskIndicator.EmailServiceUploads.MAIL_DOT_COM`
+        - :attr:`RiskIndicator.EmailServiceUploads.OUTLOOK`
+        - :attr:`RiskIndicator.EmailServiceUploads.PROTONMAIL`
+        - :attr:`RiskIndicator.EmailServiceUploads.QQMAIL`
+        - :attr:`RiskIndicator.EmailServiceUploads.SINA_MAIL`
+        - :attr:`RiskIndicator.EmailServiceUploads.SOHU_MAIl`
+        - :attr:`RiskIndicator.EmailServiceUploads.YAHOO`
+        - :attr:`RiskIndicator.EmailServiceUploads.ZOHO_MAIL`
+        - :attr:`RiskIndicator.RemovableMedia.AIRDROP`
+        - :attr:`RiskIndicator.RemovableMedia.REMOVABLE_MEDIA`
+        - :attr:`RiskIndicator.FileCategories.AUDIO`
+        - :attr:`RiskIndicator.FileCategories.DOCUMENT`
+        - :attr:`RiskIndicator.FileCategories.EXECUTABLE`
+        - :attr:`RiskIndicator.FileCategories.IMAGE`
+        - :attr:`RiskIndicator.FileCategories.PDF`
+        - :attr:`RiskIndicator.FileCategories.PRESENTATION`
+        - :attr:`RiskIndicator.FileCategories.SCRIPT`
+        - :attr:`RiskIndicator.FileCategories.SOURCE_CODE`
+        - :attr:`RiskIndicator.FileCategories.SPREADSHEET`
+        - :attr:`RiskIndicator.FileCategories.VIDEO`
+        - :attr:`RiskIndicator.FileCategories.VIRTUAL_DISK_IMAGE`
+        - :attr:`RiskIndicator.FileCategories.ZIP`
+        - :attr:`RiskIndicator.MessagingServiceUploads.FACEBOOK_MESSENGER`
+        - :attr:`RiskIndicator.MessagingServiceUploads.MICROSOFT_TEAMS`
+        - :attr:`RiskIndicator.MessagingServiceUploads.SLACK`
+        - :attr:`RiskIndicator.MessagingServiceUploads.WHATSAPP`
+        - :attr:`RiskIndicator.Other.OTHER`
+        - :attr:`RiskIndicator.MessagingServiceUploads.UNKNOWN`
+        - :attr:`RiskIndicator.SocialMediaUploads.FACEBOOK`
+        - :attr:`RiskIndicator.SocialMediaUploads.LINKEDIN`
+        - :attr:`RiskIndicator.SocialMediaUploads.REDDIT`
+        - :attr:`RiskIndicator.SocialMediaUploads.TWITTER`
+        - :attr:`RiskIndicator.UserBehavior.FILE_MISMATCH`
+        - :attr:`RiskIndicator.UserBehavior.OFF_HOURS`
+        - :attr:`RiskIndicator.UserBehavior.REMOTE`
+    """
 
     _term = u"riskIndicatorNames"
 
@@ -145,7 +209,15 @@ class RiskIndicator(FileEventFilterStringField):
 
 
 class RiskSeverity(FileEventFilterStringField):
-    """Class that filters events by risk severity."""
+    """Class that filters events by risk severity.
+
+    Available options are provided as class attributes:
+        - :attr:`RiskSeverity.LOW`
+        - :attr:`RiskSeverity.MODERATE`
+        - :attr:`RiskSeverity.HIGH`
+        - :attr:`RiskSeverity.CRITICAL`
+        - :attr:`RiskSeverity.NO_RISK_INDICATED`
+    """
 
     _term = u"riskSeverity"
 

--- a/src/py42/sdk/queries/fileevents/filters/risk_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/risk_filter.py
@@ -1,0 +1,150 @@
+from py42.sdk.queries.fileevents.file_event_query import FileEventFilterStringField
+from py42.util import get_attribute_keys_from_class
+
+
+class RiskIndicator(FileEventFilterStringField):
+    """Class that filters events by risk indicator."""
+
+    _term = u"riskIndicatorNames"
+
+    @staticmethod
+    def choices():
+        return (
+            RiskIndicator.CloudDataExposures.choices()
+            + RiskIndicator.CloudStorageUploads.choices()
+            + RiskIndicator.CodeRepositoryUploads.choices()
+            + RiskIndicator.EmaiServiceUploads.choices()
+            + RiskIndicator.ExternalDevices.choices()
+            + RiskIndicator.FileCategories.choices()
+            + RiskIndicator.MessagingServiceUploads.choices()
+            + RiskIndicator.Other.choices()
+            + RiskIndicator.SocialMediaUploads.choices()
+            + RiskIndicator.UserBehavior.choices()
+        )
+
+    class CloudDataExposures(object):
+        PUBLIC_CORPORATE_BOX = "Public link from corporate Box"
+        PUBLIC_CORPORATE_GOOGLE_DRIVE = "Public link from corporate Google Drive"
+        PUBLIC_CORPORATE_ONEDRIVE = "Public link from corporate OneDrive"
+        SENT_CORPORATE_GMAIL = "Sent from corporate Gmail"
+        SHARED_CORPORATE_BOX = "Shared from corporate Box"
+        SHARED_CORPORATE_GOOGLE_DRIVE = "Shared from corporate Google Drive"
+        SHARED_CORPORATE_ONEDRIVE = "Shared from corporate OneDrive"
+
+        @staticmethod
+        def choices():
+            return get_attribute_keys_from_class(RiskIndicator.CloudDataExposures)
+
+    class CloudStorageUploads(object):
+        AMAZON_DRIVE = "Amazon Drive upload"
+        BOX = "Box upload"
+        DROPBOX = "Dropbox upload"
+        GOOGLE_DRIVE = "Google Drive upload"
+        ICLOUD = "iCloud upload"
+        MEGA = "Mega upload"
+        ONEDRIVE = "OneDrive upload"
+        ZOHO = "Zoho WorkDrive upload"
+
+        @staticmethod
+        def choices():
+            return get_attribute_keys_from_class(RiskIndicator.CloudStorageUploads)
+
+    class CodeRepositoryUploads(object):
+        BITBUCKET = "Bitbucket upload"
+        GITHUB = "GitHub upload"
+        GITLAB = "GitLab upload"
+        SOURCEFORGE = "SourceForge upload"
+        STASH = "Stash upload"
+
+        @staticmethod
+        def choices():
+            return get_attribute_keys_from_class(RiskIndicator.CodeRepositoryUploads)
+
+    class EmaiServiceUploads(object):
+        ONESIXTHREE_DOT_COM = "163.com upload"
+        ONETWOSIX_DOT_COM = "126.com upload"
+        AOL = "AOL upload"
+        COMCAST = "Comcast upload"
+        GMAIL = "Gmail upload"
+        ICLOUD = "iCloud Mail upload"
+        MAIL_DOT_COM = "Mail.com upload"
+        OUTLOOK = "Outlook upload"
+        PROTONMAIL = "ProtonMail upload"
+        QQMAIL = "QQMail upload"
+        SINA_MAIL = "Sina Mail upload"
+        SOHU_MAIl = "Sohu Mail upload"
+        YAHOO = "Yahoo upload"
+        ZOHO_MAIL = "Zoho Mail upload"
+
+        @staticmethod
+        def choices():
+            return get_attribute_keys_from_class(RiskIndicator.EmaiServiceUploads)
+
+    class ExternalDevices(object):
+        AIRDROP = "AirDrop"
+        REMOVABLE_MEDIA = "Removable media"
+
+        @staticmethod
+        def choices():
+            return get_attribute_keys_from_class(RiskIndicator.ExternalDevices)
+
+    class FileCategories(object):
+        AUDIO = "Audio"
+        DOCUMENT = "Document"
+        EXECUTABLE = "Executable"
+        IMAGE = "Image"
+        PDF = "PDF"
+        PRESENTATION = "Presentation"
+        SCRIPT = "Script"
+        SOURCE_CODE = "Source code"
+        SPREADSHEET = "Spreadsheet"
+        VIDEO = "Video"
+        VIRTUAL_DISK_IMAGE = "Virtual Disk Image"
+        ZIP = "Zip"
+
+        @staticmethod
+        def choices():
+            return get_attribute_keys_from_class(RiskIndicator.FileCategories)
+
+    class MessagingServiceUploads(object):
+        FACEBOOK_MESSENGER = "Facebook Messenger upload"
+        MICROSOFT_TEAMS = "Microsoft Teams upload"
+        SLACK = "Slack upload"
+        WHATSAPP = "WhatsApp upload"
+
+        @staticmethod
+        def choices():
+            return get_attribute_keys_from_class(RiskIndicator.MessagingServiceUploads)
+
+    class Other(object):
+        OTHER = "Other destination"
+        UNKNOWN = "Unknown destination"
+
+        @staticmethod
+        def choices():
+            return get_attribute_keys_from_class(RiskIndicator.Other)
+
+    class SocialMediaUploads(object):
+        FACEBOOK = "Facebook upload"
+        LINKEDIN = "LinkedIn upload"
+        REDDIT = "Reddit upload"
+        TWITTER = "Twitter upload"
+
+        @staticmethod
+        def choices():
+            return get_attribute_keys_from_class(RiskIndicator.SocialMediaUploads)
+
+    class UserBehavior(object):
+        FILE_MISMATCH = "File mismatch"
+        OFF_HOURS = "Off hours"
+        REMOTE = "Remote"
+
+        @staticmethod
+        def choices():
+            return get_attribute_keys_from_class(RiskIndicator.UserBehavior)
+
+
+class RiskSeverity(FileEventFilterStringField):
+    """Class that filters events by risk severity."""
+
+    _term = u"riskSeverity"

--- a/src/py42/sdk/queries/fileevents/filters/risk_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/risk_filter.py
@@ -59,7 +59,7 @@ class RiskIndicator(FileEventFilterStringField):
         - :attr:`RiskIndicator.MessagingServiceUploads.SLACK`
         - :attr:`RiskIndicator.MessagingServiceUploads.WHATSAPP`
         - :attr:`RiskIndicator.Other.OTHER`
-        - :attr:`RiskIndicator.MessagingServiceUploads.UNKNOWN`
+        - :attr:`RiskIndicator.Other.UNKNOWN`
         - :attr:`RiskIndicator.SocialMediaUploads.FACEBOOK`
         - :attr:`RiskIndicator.SocialMediaUploads.LINKEDIN`
         - :attr:`RiskIndicator.SocialMediaUploads.REDDIT`

--- a/src/py42/sdk/queries/fileevents/filters/risk_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/risk_filter.py
@@ -36,108 +36,108 @@ class RiskIndicator(FileEventFilterStringField):
             return get_attribute_keys_from_class(RiskIndicator.CloudDataExposures)
 
     class CloudStorageUploads(object):
-        AMAZON_DRIVE = "Amazon Drive upload"
-        BOX = "Box upload"
-        DROPBOX = "Dropbox upload"
-        GOOGLE_DRIVE = "Google Drive upload"
-        ICLOUD = "iCloud upload"
-        MEGA = "Mega upload"
-        ONEDRIVE = "OneDrive upload"
-        ZOHO = "Zoho WorkDrive upload"
+        AMAZON_DRIVE = u"Amazon Drive upload"
+        BOX = u"Box upload"
+        DROPBOX = u"Dropbox upload"
+        GOOGLE_DRIVE = u"Google Drive upload"
+        ICLOUD = u"iCloud upload"
+        MEGA = u"Mega upload"
+        ONEDRIVE = u"OneDrive upload"
+        ZOHO = u"Zoho WorkDrive upload"
 
         @staticmethod
         def choices():
             return get_attribute_keys_from_class(RiskIndicator.CloudStorageUploads)
 
     class CodeRepositoryUploads(object):
-        BITBUCKET = "Bitbucket upload"
-        GITHUB = "GitHub upload"
-        GITLAB = "GitLab upload"
-        SOURCEFORGE = "SourceForge upload"
-        STASH = "Stash upload"
+        BITBUCKET = u"Bitbucket upload"
+        GITHUB = u"GitHub upload"
+        GITLAB = u"GitLab upload"
+        SOURCEFORGE = u"SourceForge upload"
+        STASH = u"Stash upload"
 
         @staticmethod
         def choices():
             return get_attribute_keys_from_class(RiskIndicator.CodeRepositoryUploads)
 
     class EmaiServiceUploads(object):
-        ONESIXTHREE_DOT_COM = "163.com upload"
-        ONETWOSIX_DOT_COM = "126.com upload"
-        AOL = "AOL upload"
-        COMCAST = "Comcast upload"
-        GMAIL = "Gmail upload"
-        ICLOUD = "iCloud Mail upload"
-        MAIL_DOT_COM = "Mail.com upload"
-        OUTLOOK = "Outlook upload"
-        PROTONMAIL = "ProtonMail upload"
-        QQMAIL = "QQMail upload"
-        SINA_MAIL = "Sina Mail upload"
-        SOHU_MAIl = "Sohu Mail upload"
-        YAHOO = "Yahoo upload"
-        ZOHO_MAIL = "Zoho Mail upload"
+        ONESIXTHREE_DOT_COM = u"163.com upload"
+        ONETWOSIX_DOT_COM = u"126.com upload"
+        AOL = u"AOL upload"
+        COMCAST = u"Comcast upload"
+        GMAIL = u"Gmail upload"
+        ICLOUD = u"iCloud Mail upload"
+        MAIL_DOT_COM = u"Mail.com upload"
+        OUTLOOK = u"Outlook upload"
+        PROTONMAIL = u"ProtonMail upload"
+        QQMAIL = u"QQMail upload"
+        SINA_MAIL = u"Sina Mail upload"
+        SOHU_MAIl = u"Sohu Mail upload"
+        YAHOO = u"Yahoo upload"
+        ZOHO_MAIL = u"Zoho Mail upload"
 
         @staticmethod
         def choices():
             return get_attribute_keys_from_class(RiskIndicator.EmaiServiceUploads)
 
     class ExternalDevices(object):
-        AIRDROP = "AirDrop"
-        REMOVABLE_MEDIA = "Removable media"
+        AIRDROP = u"AirDrop"
+        REMOVABLE_MEDIA = u"Removable media"
 
         @staticmethod
         def choices():
             return get_attribute_keys_from_class(RiskIndicator.ExternalDevices)
 
     class FileCategories(object):
-        AUDIO = "Audio"
-        DOCUMENT = "Document"
-        EXECUTABLE = "Executable"
-        IMAGE = "Image"
-        PDF = "PDF"
-        PRESENTATION = "Presentation"
-        SCRIPT = "Script"
-        SOURCE_CODE = "Source code"
-        SPREADSHEET = "Spreadsheet"
-        VIDEO = "Video"
-        VIRTUAL_DISK_IMAGE = "Virtual Disk Image"
-        ZIP = "Zip"
+        AUDIO = u"Audio"
+        DOCUMENT = u"Document"
+        EXECUTABLE = u"Executable"
+        IMAGE = u"Image"
+        PDF = u"PDF"
+        PRESENTATION = u"Presentation"
+        SCRIPT = u"Script"
+        SOURCE_CODE = u"Source code"
+        SPREADSHEET = u"Spreadsheet"
+        VIDEO = u"Video"
+        VIRTUAL_DISK_IMAGE = u"Virtual Disk Image"
+        ZIP = u"Zip"
 
         @staticmethod
         def choices():
             return get_attribute_keys_from_class(RiskIndicator.FileCategories)
 
     class MessagingServiceUploads(object):
-        FACEBOOK_MESSENGER = "Facebook Messenger upload"
-        MICROSOFT_TEAMS = "Microsoft Teams upload"
-        SLACK = "Slack upload"
-        WHATSAPP = "WhatsApp upload"
+        FACEBOOK_MESSENGER = u"Facebook Messenger upload"
+        MICROSOFT_TEAMS = u"Microsoft Teams upload"
+        SLACK = u"Slack upload"
+        WHATSAPP = u"WhatsApp upload"
 
         @staticmethod
         def choices():
             return get_attribute_keys_from_class(RiskIndicator.MessagingServiceUploads)
 
     class Other(object):
-        OTHER = "Other destination"
-        UNKNOWN = "Unknown destination"
+        OTHER = u"Other destination"
+        UNKNOWN = u"Unknown destination"
 
         @staticmethod
         def choices():
             return get_attribute_keys_from_class(RiskIndicator.Other)
 
     class SocialMediaUploads(object):
-        FACEBOOK = "Facebook upload"
-        LINKEDIN = "LinkedIn upload"
-        REDDIT = "Reddit upload"
-        TWITTER = "Twitter upload"
+        FACEBOOK = u"Facebook upload"
+        LINKEDIN = u"LinkedIn upload"
+        REDDIT = u"Reddit upload"
+        TWITTER = u"Twitter upload"
 
         @staticmethod
         def choices():
             return get_attribute_keys_from_class(RiskIndicator.SocialMediaUploads)
 
     class UserBehavior(object):
-        FILE_MISMATCH = "File mismatch"
-        OFF_HOURS = "Off hours"
-        REMOTE = "Remote"
+        FILE_MISMATCH = u"File mismatch"
+        OFF_HOURS = u"Off hours"
+        REMOTE = u"Remote"
 
         @staticmethod
         def choices():
@@ -149,11 +149,11 @@ class RiskSeverity(FileEventFilterStringField):
 
     _term = u"riskSeverity"
 
-    CRITICAL = "CRITICAL"
-    HIGH = "HIGH"
-    MODERATE = "MODERATE"
-    LOW = "LOW"
-    NO_RISK_INDICATED = "NO_RISK_INDICATED"
+    CRITICAL = u"CRITICAL"
+    HIGH = u"HIGH"
+    MODERATE = u"MODERATE"
+    LOW = u"LOW"
+    NO_RISK_INDICATED = u"NO_RISK_INDICATED"
 
     @staticmethod
     def choices():

--- a/src/py42/sdk/queries/fileevents/filters/risk_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/risk_filter.py
@@ -148,3 +148,13 @@ class RiskSeverity(FileEventFilterStringField):
     """Class that filters events by risk severity."""
 
     _term = u"riskSeverity"
+
+    CRITICAL = "CRITICAL"
+    HIGH = "HIGH"
+    MODERATE = "MODERATE"
+    LOW = "LOW"
+    NO_RISK_INDICATED = "NO_RISK_INDICATED"
+
+    @staticmethod
+    def choices():
+        return get_attribute_keys_from_class(RiskSeverity)

--- a/tests/sdk/queries/fileevents/filters/test_risk_filter.py
+++ b/tests/sdk/queries/fileevents/filters/test_risk_filter.py
@@ -3,7 +3,8 @@ from tests.sdk.queries.conftest import IS_IN
 from tests.sdk.queries.conftest import IS_NOT
 from tests.sdk.queries.conftest import NOT_IN
 
-from py42.sdk.queries.fileevents.filters.risk_filter import RiskIndicator, RiskSeverity
+from py42.sdk.queries.fileevents.filters.risk_filter import RiskIndicator
+from py42.sdk.queries.fileevents.filters.risk_filter import RiskSeverity
 
 
 def test_risk_indicator_eq_str_gives_correct_json_representation():
@@ -19,14 +20,22 @@ def test_risk_indicator_not_eq_str_gives_correct_json_representation():
 
 
 def test_risk_indicator_is_in_str_gives_correct_json_representation():
-    items = [RiskIndicator.FileCategories.EXECUTABLE, RiskIndicator.FileCategories.IMAGE, RiskIndicator.FileCategories.PDF]
+    items = [
+        RiskIndicator.FileCategories.EXECUTABLE,
+        RiskIndicator.FileCategories.IMAGE,
+        RiskIndicator.FileCategories.PDF,
+    ]
     _filter = RiskIndicator.is_in(items)
     expected = IS_IN.format("riskIndicatorNames", *items)
     assert str(_filter) == expected
 
 
 def test_risk_indicator_not_in_str_gives_correct_json_representation():
-    items = [RiskIndicator.FileCategories.EXECUTABLE, RiskIndicator.FileCategories.IMAGE, RiskIndicator.FileCategories.PDF]
+    items = [
+        RiskIndicator.FileCategories.EXECUTABLE,
+        RiskIndicator.FileCategories.IMAGE,
+        RiskIndicator.FileCategories.PDF,
+    ]
     _filter = RiskIndicator.not_in(items)
     expected = NOT_IN.format("riskIndicatorNames", *items)
     assert str(_filter) == expected

--- a/tests/sdk/queries/fileevents/filters/test_risk_filter.py
+++ b/tests/sdk/queries/fileevents/filters/test_risk_filter.py
@@ -8,51 +8,51 @@ from py42.sdk.queries.fileevents.filters.risk_filter import RiskIndicator, RiskS
 
 def test_risk_indicator_eq_str_gives_correct_json_representation():
     _filter = RiskIndicator.eq(RiskIndicator.CloudDataExposures.PUBLIC_CORPORATE_BOX)
-    expected = IS.format("riskIndicators", "Public link from corporate Box")
+    expected = IS.format("riskIndicatorNames", "Public link from corporate Box")
     assert str(_filter) == expected
 
 
 def test_risk_indicator_not_eq_str_gives_correct_json_representation():
     _filter = RiskIndicator.not_eq(RiskIndicator.CloudStorageUploads.AMAZON_DRIVE)
-    expected = IS_NOT.format("riskIndicators", "Amazon Drive upload")
+    expected = IS_NOT.format("riskIndicatorNames", "Amazon Drive upload")
     assert str(_filter) == expected
 
 
 def test_risk_indicator_is_in_str_gives_correct_json_representation():
     items = [RiskIndicator.FileCategories.EXECUTABLE, RiskIndicator.FileCategories.IMAGE, RiskIndicator.FileCategories.PDF]
     _filter = RiskIndicator.is_in(items)
-    expected = IS_IN.format("riskIndicators", *items)
+    expected = IS_IN.format("riskIndicatorNames", *items)
     assert str(_filter) == expected
 
 
 def test_risk_indicator_not_in_str_gives_correct_json_representation():
     items = [RiskIndicator.FileCategories.EXECUTABLE, RiskIndicator.FileCategories.IMAGE, RiskIndicator.FileCategories.PDF]
     _filter = RiskIndicator.not_in(items)
-    expected = NOT_IN.format("riskIndicators", *items)
+    expected = NOT_IN.format("riskIndicatorNames", *items)
     assert str(_filter) == expected
 
 
 def test_risk_severity_eq_str_gives_correct_json_representation():
-    _filter = RiskIndicator.eq(RiskIndicator.CloudDataExposures.PUBLIC_CORPORATE_BOX)
-    expected = IS.format("riskIndicators", "Public link from corporate Box")
+    _filter = RiskSeverity.eq(RiskSeverity.HIGH)
+    expected = IS.format("riskSeverity", "HIGH")
     assert str(_filter) == expected
 
 
 def test_risk_severity_not_eq_str_gives_correct_json_representation():
-    _filter = RiskIndicator.not_eq(RiskIndicator.CloudStorageUploads.AMAZON_DRIVE)
-    expected = IS_NOT.format("riskIndicators", "Amazon Drive upload")
+    _filter = RiskSeverity.not_eq(RiskSeverity.CRITICAL)
+    expected = IS_NOT.format("riskSeverity", "CRITICAL")
     assert str(_filter) == expected
 
 
 def test_risk_severity_is_in_str_gives_correct_json_representation():
-    items = [RiskIndicator.FileCategories.EXECUTABLE, RiskIndicator.FileCategories.IMAGE, RiskIndicator.FileCategories.PDF]
-    _filter = RiskIndicator.is_in(items)
-    expected = IS_IN.format("riskIndicators", *items)
+    items = [RiskSeverity.HIGH, RiskSeverity.LOW, RiskSeverity.MODERATE]
+    _filter = RiskSeverity.is_in(items)
+    expected = IS_IN.format("riskSeverity", *items)
     assert str(_filter) == expected
 
 
 def test_risk_severity_not_in_str_gives_correct_json_representation():
-    items = [RiskIndicator.FileCategories.EXECUTABLE, RiskIndicator.FileCategories.IMAGE, RiskIndicator.FileCategories.PDF]
-    _filter = RiskIndicator.not_in(items)
-    expected = NOT_IN.format("riskIndicators", *items)
+    items = [RiskSeverity.HIGH, RiskSeverity.LOW, RiskSeverity.MODERATE]
+    _filter = RiskSeverity.not_in(items)
+    expected = NOT_IN.format("riskSeverity", *items)
     assert str(_filter) == expected

--- a/tests/sdk/queries/fileevents/filters/test_risk_filter.py
+++ b/tests/sdk/queries/fileevents/filters/test_risk_filter.py
@@ -1,0 +1,58 @@
+from tests.sdk.queries.conftest import IS
+from tests.sdk.queries.conftest import IS_IN
+from tests.sdk.queries.conftest import IS_NOT
+from tests.sdk.queries.conftest import NOT_IN
+
+from py42.sdk.queries.fileevents.filters.risk_filter import RiskIndicator, RiskSeverity
+
+
+def test_risk_indicator_eq_str_gives_correct_json_representation():
+    _filter = RiskIndicator.eq(RiskIndicator.CloudDataExposures.PUBLIC_CORPORATE_BOX)
+    expected = IS.format("riskIndicators", "Public link from corporate Box")
+    assert str(_filter) == expected
+
+
+def test_risk_indicator_not_eq_str_gives_correct_json_representation():
+    _filter = RiskIndicator.not_eq(RiskIndicator.CloudStorageUploads.AMAZON_DRIVE)
+    expected = IS_NOT.format("riskIndicators", "Amazon Drive upload")
+    assert str(_filter) == expected
+
+
+def test_risk_indicator_is_in_str_gives_correct_json_representation():
+    items = [RiskIndicator.FileCategories.EXECUTABLE, RiskIndicator.FileCategories.IMAGE, RiskIndicator.FileCategories.PDF]
+    _filter = RiskIndicator.is_in(items)
+    expected = IS_IN.format("riskIndicators", *items)
+    assert str(_filter) == expected
+
+
+def test_risk_indicator_not_in_str_gives_correct_json_representation():
+    items = [RiskIndicator.FileCategories.EXECUTABLE, RiskIndicator.FileCategories.IMAGE, RiskIndicator.FileCategories.PDF]
+    _filter = RiskIndicator.not_in(items)
+    expected = NOT_IN.format("riskIndicators", *items)
+    assert str(_filter) == expected
+
+
+def test_risk_severity_eq_str_gives_correct_json_representation():
+    _filter = RiskIndicator.eq(RiskIndicator.CloudDataExposures.PUBLIC_CORPORATE_BOX)
+    expected = IS.format("riskIndicators", "Public link from corporate Box")
+    assert str(_filter) == expected
+
+
+def test_risk_severity_not_eq_str_gives_correct_json_representation():
+    _filter = RiskIndicator.not_eq(RiskIndicator.CloudStorageUploads.AMAZON_DRIVE)
+    expected = IS_NOT.format("riskIndicators", "Amazon Drive upload")
+    assert str(_filter) == expected
+
+
+def test_risk_severity_is_in_str_gives_correct_json_representation():
+    items = [RiskIndicator.FileCategories.EXECUTABLE, RiskIndicator.FileCategories.IMAGE, RiskIndicator.FileCategories.PDF]
+    _filter = RiskIndicator.is_in(items)
+    expected = IS_IN.format("riskIndicators", *items)
+    assert str(_filter) == expected
+
+
+def test_risk_severity_not_in_str_gives_correct_json_representation():
+    items = [RiskIndicator.FileCategories.EXECUTABLE, RiskIndicator.FileCategories.IMAGE, RiskIndicator.FileCategories.PDF]
+    _filter = RiskIndicator.not_in(items)
+    expected = NOT_IN.format("riskIndicators", *items)
+    assert str(_filter) == expected

--- a/tox.ini
+++ b/tox.ini
@@ -23,9 +23,10 @@ commands =
 
 [testenv:docs]
 deps =
-    sphinx
-    recommonmark
-    sphinx_rtd_theme
+    sphinx == 4.1.1
+    recommonmark == 0.7.1
+    sphinx_rtd_theme == 0.5.2
+    docutils == 0.16
 
 whitelist_externals = bash
 


### PR DESCRIPTION
### Description of Change ###

Adds RiskIndicator and and RiskSeverity filters to file event searches

### Issues Resolved ###
INTEG-1714

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test that this change works as intended. What functions should be run? How can testers obtain valid parameters to test those functions? Where in the console can the actions of the functions be verified? -->

```python
import py42
from py42.sdk.queries.fileevents.filters import *
from py42.sdk.queries.fileevents.file_event_query import FileEventQuery

# use se demo account credentials
sdk = py42.sdk.from_local_account("https://console.us.code42.com", "username", "password")

sev_query = RiskSeverity.is_in([RiskSeverity.HIGH, RiskSeverity.LOW])
sev_results = sdk.securitydata.search_file_events(sev_query)

# There are many RiskIndicator constants. You don't need to test all of them, but it's worth trying a couple different ones
# to make sure different results are returned for each one.
# see https://github.com/code42/py42/blob/361e0348543648201cca346e61b0160852b66ed2/src/py42/sdk/queries/fileevents/filters/risk_filter.py
indicator_query = RiskIndicator.is_in([RiskIndicator.ExternalDevices.REMOVABLE_MEDIA, RiskIndicator.ExternalDevices.AIRDROP])
indicator_results = sdk.securitydata.search_file_events(indicator_query)
```

verify that the results are returned without errors and the result count and general content is the same for equivalent queries made in the Forensic Search UI.

### PR Checklist ###
Did you remember to do the below?

- [X] Add unit tests to verify this change
- [X] Add an entry to CHANGELOG.md describing this change
- [X] Add docstrings for any new public parameters / methods / classes
