### PR TITLE
Feature / alert details helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 - `RiskIndicator` and `RiskSeverity` filter classes to new `py42.sdk.queries.fileevents.filters.risk_filter` module.
 
+- New method `sdk.alerts.get_all_alert_details()` as a helper to make getting alerts with details easier (combines `sdk.alerts.search_all_pages()` and `sdk.alerts.get_details()`).
+
 ## 1.16.1 - 2021-07-20
 
 ### Fixed

--- a/src/py42/clients/alerts.py
+++ b/src/py42/clients/alerts.py
@@ -140,7 +140,8 @@ class AlertsClient(object):
     def get_all_alert_details(self, query, ascending=True):
         """
         Helper method that combines `.get_all_pages()` and `.get_details()`.
-        Returns an iterator of all alert details in chronological order.
+        Returns an iterator of alert detail objects in chronological order by alert
+        creation date.
 
         Args:
             query (:class:`py42.sdk.queries.alerts.alert_query.AlertQuery`): An alert query.
@@ -153,6 +154,7 @@ class AlertsClient(object):
         """
         query.page_size = 100
         query.sort_direction = "asc" if ascending else "desc"
+        query.sort_key = "CreatedAt"
         pages = self._alert_service.search_all_pages(query)
         for page in pages:
             alert_ids = [alert["id"] for alert in page["alerts"]]

--- a/src/py42/clients/alerts.py
+++ b/src/py42/clients/alerts.py
@@ -139,7 +139,7 @@ class AlertsClient(object):
 
     def get_all_alert_details(self, query, ascending=True):
         """
-        Helper method that combines `.get_all_pages()` and `.get_details()`.
+        Helper method that combines :func:`.get_all_pages()` and :func:`.get_details()`.
         Returns an iterator of alert detail objects in chronological order by alert
         creation date.
 

--- a/src/py42/clients/alerts.py
+++ b/src/py42/clients/alerts.py
@@ -139,8 +139,13 @@ class AlertsClient(object):
 
     def get_all_alert_details(self, query):
         """
-        Helper method that combines :func:`.search_all_pages()` and :func:`.get_details()`.
+        Helper method that combines :func:`.search_all_pages()` and :func:`.get_details()`
+        methods to get alert objects with alert "observations" details populated.
         Returns an iterator of alert detail objects.
+
+        Note: automatically overrides the `page_size` property on the query object to limit
+        search to 100 results per page, as that is the max that :func:`.get_details()` can
+        request at a time.
 
         Args:
             query (:class:`py42.sdk.queries.alerts.alert_query.AlertQuery`): An alert query.
@@ -158,6 +163,6 @@ class AlertsClient(object):
             alert_ids = [alert["id"] for alert in page["alerts"]]
             alert_details = self._alert_service.get_details(alert_ids)
             for alert in sorted(
-                alert_details["alerts"], key=lambda x: x[sort_key], reverse=reverse,
+                alert_details["alerts"], key=lambda x: x.get(sort_key), reverse=reverse,
             ):
                 yield alert

--- a/src/py42/clients/alerts.py
+++ b/src/py42/clients/alerts.py
@@ -154,6 +154,8 @@ class AlertsClient(object):
         """
         query.page_size = 100
         sort_key = query.sort_key[0].lower() + query.sort_key[1:]
+        if sort_key == "alertId":
+            sort_key = "id"
         reverse = query.sort_direction == "desc"
         pages = self._alert_service.search_all_pages(query)
         for page in pages:

--- a/src/py42/clients/alerts.py
+++ b/src/py42/clients/alerts.py
@@ -137,7 +137,7 @@ class AlertsClient(object):
         """
         return self._alert_service.get_aggregate_data(alert_id)
 
-    def get_all_alert_details(self, query, ascending=True):
+    def get_all_alert_details(self, query):
         """
         Helper method that combines :func:`.get_all_pages()` and :func:`.get_details()`.
         Returns an iterator of alert detail objects in chronological order by alert
@@ -153,15 +153,13 @@ class AlertsClient(object):
             generator: An object that iterates over alert detail items.
         """
         query.page_size = 100
-        query.sort_direction = "asc" if ascending else "desc"
-        query.sort_key = "CreatedAt"
+        sort_key = query.sort_key[0].lower() + query.sort_key[1:]
+        reverse = query.sort_direction == "desc"
         pages = self._alert_service.search_all_pages(query)
         for page in pages:
             alert_ids = [alert["id"] for alert in page["alerts"]]
             alert_details = self._alert_service.get_details(alert_ids)
             for alert in sorted(
-                alert_details["alerts"],
-                key=lambda x: x["createdAt"],
-                reverse=not ascending,
+                alert_details["alerts"], key=lambda x: x[sort_key], reverse=reverse,
             ):
                 yield alert

--- a/src/py42/clients/alerts.py
+++ b/src/py42/clients/alerts.py
@@ -139,7 +139,7 @@ class AlertsClient(object):
 
     def get_all_alert_details(self, query):
         """
-        Helper method that combines :func:`.get_all_pages()` and :func:`.get_details()`.
+        Helper method that combines :func:`.search_all_pages()` and :func:`.get_details()`.
         Returns an iterator of alert detail objects in chronological order by alert
         creation date.
 

--- a/src/py42/clients/alerts.py
+++ b/src/py42/clients/alerts.py
@@ -152,7 +152,7 @@ class AlertsClient(object):
                 based on alert creation time. Defaults to True.
 
         Returns:
-            generator: An object that iterates over alert detail result items.
+            generator: An object that iterates over alert detail items.
         """
         if isinstance(query, string_type):
             query = AlertQuery.from_dict(json.loads(query))

--- a/src/py42/clients/alerts.py
+++ b/src/py42/clients/alerts.py
@@ -140,14 +140,10 @@ class AlertsClient(object):
     def get_all_alert_details(self, query):
         """
         Helper method that combines :func:`.search_all_pages()` and :func:`.get_details()`.
-        Returns an iterator of alert detail objects in chronological order by alert
-        creation date.
+        Returns an iterator of alert detail objects.
 
         Args:
             query (:class:`py42.sdk.queries.alerts.alert_query.AlertQuery`): An alert query.
-            ascending (bool): Determines if sort ordering should be ascending/descending
-                based on alert creation time (overrides the sort order on the query object).
-                Defaults to True.
 
         Returns:
             generator: An object that iterates over alert detail items.

--- a/src/py42/clients/alerts.py
+++ b/src/py42/clients/alerts.py
@@ -141,7 +141,7 @@ class AlertsClient(object):
         """
         return self._alert_service.get_aggregate_data(alert_id)
 
-    def iter_all_alert_details(self, query, ascending=True):
+    def get_all_alert_details(self, query, ascending=True):
         """
         Helper method that combines `.get_all_pages()` and `.get_details()`.
         Returns an iterator of all alert details in chronological order.

--- a/src/py42/clients/alerts.py
+++ b/src/py42/clients/alerts.py
@@ -149,16 +149,14 @@ class AlertsClient(object):
         Args:
             query (:class:`py42.sdk.queries.alerts.alert_query.AlertQuery`): An alert query.
             ascending (bool): Determines if sort ordering should be ascending/descending
-                based on alert creation time. Defaults to True.
+                based on alert creation time (overrides the sort order on the query object).
+                Defaults to True.
 
         Returns:
             generator: An object that iterates over alert detail items.
         """
-        if isinstance(query, string_type):
-            query = AlertQuery.from_dict(json.loads(query))
         query.page_size = 100
-        if ascending:
-            query.sort_direction = "asc"
+        query.sort_direction = "asc" if ascending else "desc"
         pages = self._alert_service.search_all_pages(query)
         for page in pages:
             alert_ids = [alert["id"] for alert in page["alerts"]]

--- a/src/py42/clients/alerts.py
+++ b/src/py42/clients/alerts.py
@@ -1,8 +1,4 @@
-import json
-
 from py42.sdk.queries.alerts.filters import AlertState
-from py42.sdk.queries.alerts.alert_query import AlertQuery
-from py42._compat import string_type
 
 
 class AlertsClient(object):

--- a/tests/clients/test_alerts.py
+++ b/tests/clients/test_alerts.py
@@ -8,12 +8,132 @@ from py42.sdk.queries.alerts.alert_query import AlertQuery
 from py42.services.alertrules import AlertRulesService
 from py42.services.alerts import AlertService
 
-ALERT_A = {"id": "A", "createdAt": "2021-01-01T09:40:05.2837100Z"}
-ALERT_B = {"id": "B", "createdAt": "2021-02-02T18:24:15.5284760Z"}
-ALERT_C = {"id": "C", "createdAt": "2021-03-03T09:40:26.6477830Z"}
-ALERT_D = {"id": "D", "createdAt": "2021-04-04T09:40:50.7749710Z"}
-ALERT_E = {"id": "E", "createdAt": "2021-05-05T21:29:34.5510380Z"}
-ALERT_F = {"id": "F", "createdAt": "2021-06-06T21:24:50.7541390Z"}
+ALERT_A = {
+    "id": "A",
+    "createdAt": "2021-01-01T09:40:05.2837100Z",
+    "actor": "A",
+    "type": "A",
+    "name": "A",
+    "description": "A",
+    "actorId": "A",
+    "target": "A",
+    "severity": "A",
+    "ruleSource": "A",
+    "observations": "A",
+    "notes": "A",
+    "state": "A",
+    "stateLastModifiedAt": "2021-01-01T09:40:05.2837100Z",
+    "stateLastModifiedBy": "A",
+    "lastModifiedTime": "2021-01-01T09:40:05.2837100Z",
+    "lastModifiedBy": "A",
+    "ruleId": "A",
+    "tenantId": "A",
+}
+ALERT_B = {
+    "id": "B",
+    "createdAt": "2021-02-02T18:24:15.5284760Z",
+    "actor": "B",
+    "type": "B",
+    "name": "B",
+    "description": "B",
+    "actorId": "B",
+    "target": "B",
+    "severity": "B",
+    "ruleSource": "B",
+    "observations": "B",
+    "notes": "B",
+    "state": "B",
+    "stateLastModifiedAt": "2021-02-02T18:24:15.5284760Z",
+    "stateLastModifiedBy": "B",
+    "lastModifiedTime": "2021-02-02T18:24:15.5284760Z",
+    "lastModifiedBy": "B",
+    "ruleId": "B",
+    "tenantId": "B",
+}
+ALERT_C = {
+    "id": "C",
+    "createdAt": "2021-03-03T09:40:26.6477830Z",
+    "actor": "C",
+    "type": "C",
+    "name": "C",
+    "description": "C",
+    "actorId": "C",
+    "target": "C",
+    "severity": "C",
+    "ruleSource": "C",
+    "observations": "C",
+    "notes": "C",
+    "state": "C",
+    "stateLastModifiedAt": "2021-03-03T09:40:26.6477830Z",
+    "stateLastModifiedBy": "C",
+    "lastModifiedTime": "2021-03-03T09:40:26.6477830Z",
+    "lastModifiedBy": "C",
+    "ruleId": "C",
+    "tenantId": "C",
+}
+ALERT_D = {
+    "id": "D",
+    "createdAt": "2021-04-04T09:40:50.7749710Z",
+    "actor": "D",
+    "type": "D",
+    "name": "D",
+    "description": "D",
+    "actorId": "D",
+    "target": "D",
+    "severity": "D",
+    "ruleSource": "D",
+    "observations": "D",
+    "notes": "D",
+    "state": "D",
+    "stateLastModifiedAt": "2021-04-04T09:40:50.7749710Z",
+    "stateLastModifiedBy": "D",
+    "lastModifiedTime": "2021-04-04T09:40:50.7749710Z",
+    "lastModifiedBy": "D",
+    "ruleId": "D",
+    "tenantId": "D",
+}
+ALERT_E = {
+    "id": "E",
+    "createdAt": "2021-05-05T21:29:34.5510380Z",
+    "actor": "E",
+    "type": "E",
+    "name": "E",
+    "description": "E",
+    "actorId": "E",
+    "target": "E",
+    "severity": "E",
+    "ruleSource": "E",
+    "observations": "E",
+    "notes": "E",
+    "state": "E",
+    "stateLastModifiedAt": "2021-05-05T21:29:34.5510380Z",
+    "stateLastModifiedBy": "E",
+    "lastModifiedTime": "2021-05-05T21:29:34.5510380Z",
+    "lastModifiedBy": "E",
+    "ruleId": "E",
+    "tenantId": "E",
+}
+ALERT_F = {
+    "id": "F",
+    "createdAt": "2021-06-06T21:24:50.7541390Z",
+    "actor": "F",
+    "type": "F",
+    "name": "F",
+    "description": "F",
+    "actorId": "F",
+    "target": "F",
+    "severity": "F",
+    "ruleSource": "F",
+    "observations": "F",
+    "notes": "F",
+    "state": "F",
+    "stateLastModifiedAt": "2021-06-06T21:24:50.7541390Z",
+    "stateLastModifiedBy": "F",
+    "lastModifiedTime": "2021-06-06T21:24:50.7541390Z",
+    "lastModifiedBy": "F",
+    "ruleId": "F",
+    "tenantId": "F",
+}
 TEST_ALERTS = [ALERT_A, ALERT_B, ALERT_C, ALERT_D, ALERT_E, ALERT_F]
 
 
@@ -157,39 +277,82 @@ class TestAlertsClient(object):
             "F",
         ]
 
-    def test_alerts_client_get_all_alert_details_sorts_results_ascending_by_default(
-        self, mock_alerts_service_with_pages, mock_alert_rules_service, mock_details
+    @pytest.mark.parametrize(
+        "sort_key",
+        [
+            "AlertId",
+            "TenantId",
+            "Type",
+            "Name",
+            "Description",
+            "Actor",
+            "ActorId",
+            "Target",
+            "Severity",
+            "RuleSource",
+            "CreatedAt",
+            "Observations",
+            "Notes",
+            "State",
+            "StateLastModifiedAt",
+            "StateLastModifiedBy",
+            "LastModifiedTime",
+            "LastModifiedBy",
+            "RuleId",
+        ],
+    )
+    def test_alerts_client_get_all_alert_details_sorts_results_according_to_query_sort_key(
+        self,
+        mock_alerts_service_with_pages,
+        mock_alert_rules_service,
+        mock_details,
+        sort_key,
     ):
         mock_alerts_service = mock_alerts_service_with_pages(ascending=True)
         mock_alerts_service.get_details = mock_details
         alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
         query = AlertQuery()
+        query.sort_direction = "asc"
+        query.sort_key = sort_key
         results = list(alert_client.get_all_alert_details(query))
         assert results == [ALERT_A, ALERT_B, ALERT_C, ALERT_D, ALERT_E, ALERT_F]
 
+    @pytest.mark.parametrize(
+        "sort_key",
+        [
+            "AlertId",
+            "TenantId",
+            "Type",
+            "Name",
+            "Description",
+            "Actor",
+            "ActorId",
+            "Target",
+            "Severity",
+            "RuleSource",
+            "CreatedAt",
+            "Observations",
+            "Notes",
+            "State",
+            "StateLastModifiedAt",
+            "StateLastModifiedBy",
+            "LastModifiedTime",
+            "LastModifiedBy",
+            "RuleId",
+        ],
+    )
     def test_alerts_client_get_all_alert_details_sorts_results_descending_when_specified(
-        self, mock_alerts_service_with_pages, mock_alert_rules_service, mock_details
+        self,
+        mock_alerts_service_with_pages,
+        mock_alert_rules_service,
+        mock_details,
+        sort_key,
     ):
         mock_alerts_service = mock_alerts_service_with_pages(ascending=False)
         mock_alerts_service.get_details = mock_details
         alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
         query = AlertQuery()
-        results = list(alert_client.get_all_alert_details(query, ascending=False))
+        query.sort_direction = "desc"
+        query.sort_key = sort_key
+        results = list(alert_client.get_all_alert_details(query))
         assert results == [ALERT_F, ALERT_E, ALERT_D, ALERT_C, ALERT_B, ALERT_A]
-
-    def test_alerts_client_get_all_alert_details_overrides_query_page_size_and_sorting_properties(
-        self, mock_alerts_service_with_pages, mock_alert_rules_service, mock_details
-    ):
-        mock_alerts_service = mock_alerts_service_with_pages(ascending=True)
-        mock_alerts_service.get_details = mock_details
-        alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
-        query = AlertQuery()
-        query.page_size = 1000
-
-        list(alert_client.get_all_alert_details(query, ascending=False))
-        assert query.page_size == 100
-        assert query.sort_direction == "desc"
-        assert query.sort_key == "CreatedAt"
-
-        list(alert_client.get_all_alert_details(query, ascending=True))
-        assert query.sort_direction == "asc"

--- a/tests/clients/test_alerts.py
+++ b/tests/clients/test_alerts.py
@@ -1,9 +1,20 @@
+import json
+
 import pytest
 
+from .conftest import create_mock_response
 from py42.clients.alerts import AlertsClient
 from py42.sdk.queries.alerts.alert_query import AlertQuery
 from py42.services.alertrules import AlertRulesService
 from py42.services.alerts import AlertService
+
+ALERT_A = {"id": "A", "createdAt": "2021-01-01T09:40:05.2837100Z"}
+ALERT_B = {"id": "B", "createdAt": "2021-02-02T18:24:15.5284760Z"}
+ALERT_C = {"id": "C", "createdAt": "2021-03-03T09:40:26.6477830Z"}
+ALERT_D = {"id": "D", "createdAt": "2021-04-04T09:40:50.7749710Z"}
+ALERT_E = {"id": "E", "createdAt": "2021-05-05T21:29:34.5510380Z"}
+ALERT_F = {"id": "F", "createdAt": "2021-06-06T21:24:50.7541390Z"}
+TEST_ALERTS = [ALERT_A, ALERT_B, ALERT_C, ALERT_D, ALERT_E, ALERT_F]
 
 
 @pytest.fixture
@@ -19,6 +30,41 @@ def mock_alert_rules_service(mocker):
 @pytest.fixture
 def mock_alert_query(mocker):
     return mocker.MagicMock(spec=AlertQuery)
+
+
+@pytest.fixture
+def mock_alerts_service_with_pages(mocker, mock_alerts_service):
+    def _func(ascending=True):
+        alerts = TEST_ALERTS if ascending else TEST_ALERTS[::-1]
+        alert_page_1 = create_mock_response(mocker, json.dumps({"alerts": alerts[:3]}))
+        alert_page_2 = create_mock_response(mocker, json.dumps({"alerts": alerts[3:]}))
+
+        def page_gen():
+            yield alert_page_1
+            yield alert_page_2
+
+        mock_alerts_service.search_all_pages.return_value = page_gen()
+        return mock_alerts_service
+
+    return _func
+
+
+@pytest.fixture
+def mock_details(mocker):
+    detail_page_1 = create_mock_response(
+        mocker, json.dumps({"alerts": [ALERT_B, ALERT_C, ALERT_A]})
+    )
+    detail_page_2 = create_mock_response(
+        mocker, json.dumps({"alerts": [ALERT_F, ALERT_E, ALERT_D]})
+    )
+
+    def mock_get_details(alert_ids):
+        if set(alert_ids) == {"A", "B", "C"}:
+            return detail_page_1
+        if set(alert_ids) == {"D", "E", "F"}:
+            return detail_page_2
+
+    return mock_get_details
 
 
 class TestAlertsClient(object):
@@ -82,7 +128,7 @@ class TestAlertsClient(object):
         self, mock_alerts_service, mock_alert_rules_service,
     ):
         alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
-        query = '{"test": "data"}}'
+        query = AlertQuery()
         alert_client.search_all_pages(query)
         mock_alerts_service.search_all_pages.assert_called_once_with(query)
 
@@ -92,3 +138,57 @@ class TestAlertsClient(object):
         alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
         alert_client.get_aggregate_data("alert-id")
         mock_alerts_service.get_aggregate_data.assert_called_once_with("alert-id")
+
+    def test_alerts_client_get_all_alert_details_calls_get_details_for_each_page(
+        self, mock_alerts_service_with_pages, mock_alert_rules_service
+    ):
+        mock_alerts_service = mock_alerts_service_with_pages(ascending=True)
+        alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
+        query = AlertQuery()
+        list(alert_client.get_all_alert_details(query))
+        assert mock_alerts_service.get_details.call_args_list[0][0][0] == [
+            "A",
+            "B",
+            "C",
+        ]
+        assert mock_alerts_service.get_details.call_args_list[1][0][0] == [
+            "D",
+            "E",
+            "F",
+        ]
+
+    def test_alerts_client_get_all_alert_details_sorts_results_ascending_by_default(
+        self, mock_alerts_service_with_pages, mock_alert_rules_service, mock_details
+    ):
+        mock_alerts_service = mock_alerts_service_with_pages(ascending=True)
+        mock_alerts_service.get_details = mock_details
+        alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
+        query = AlertQuery()
+        results = list(alert_client.get_all_alert_details(query))
+        assert results == [ALERT_A, ALERT_B, ALERT_C, ALERT_D, ALERT_E, ALERT_F]
+
+    def test_alerts_client_get_all_alert_details_sorts_results_descending_when_specified(
+        self, mock_alerts_service_with_pages, mock_alert_rules_service, mock_details
+    ):
+        mock_alerts_service = mock_alerts_service_with_pages(ascending=False)
+        mock_alerts_service.get_details = mock_details
+        alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
+        query = AlertQuery()
+        results = list(alert_client.get_all_alert_details(query, ascending=False))
+        assert results == [ALERT_F, ALERT_E, ALERT_D, ALERT_C, ALERT_B, ALERT_A]
+
+    def test_alerts_client_get_all_alert_details_overrides_query_page_size_to_100_and_sets_sort_direction_properly(
+        self, mock_alerts_service_with_pages, mock_alert_rules_service, mock_details
+    ):
+        mock_alerts_service = mock_alerts_service_with_pages(ascending=True)
+        mock_alerts_service.get_details = mock_details
+        alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
+        query = AlertQuery()
+        query.page_size = 1000
+
+        list(alert_client.get_all_alert_details(query, ascending=False))
+        assert query.page_size == 100
+        assert query.sort_direction == "desc"
+
+        list(alert_client.get_all_alert_details(query, ascending=True))
+        assert query.sort_direction == "asc"

--- a/tests/clients/test_alerts.py
+++ b/tests/clients/test_alerts.py
@@ -177,7 +177,7 @@ class TestAlertsClient(object):
         results = list(alert_client.get_all_alert_details(query, ascending=False))
         assert results == [ALERT_F, ALERT_E, ALERT_D, ALERT_C, ALERT_B, ALERT_A]
 
-    def test_alerts_client_get_all_alert_details_overrides_query_page_size_to_100_and_sets_sort_direction_properly(
+    def test_alerts_client_get_all_alert_details_overrides_query_page_size_and_sorting_properties(
         self, mock_alerts_service_with_pages, mock_alert_rules_service, mock_details
     ):
         mock_alerts_service = mock_alerts_service_with_pages(ascending=True)
@@ -189,6 +189,7 @@ class TestAlertsClient(object):
         list(alert_client.get_all_alert_details(query, ascending=False))
         assert query.page_size == 100
         assert query.sort_direction == "desc"
+        assert query.sort_key == "CreatedAt"
 
         list(alert_client.get_all_alert_details(query, ascending=True))
         assert query.sort_direction == "asc"


### PR DESCRIPTION
### Description of Change ###

Adds method `sdk.alerts.get_all_alert_details()` to combine `sdk.alerts.search_all_pages()` and `sdk.alerts.get_details()`, making it painless to get all alert details in chronological order. 


### Testing Procedure ###

- Create an `AlertQuery`
- Pass query to `sdk.alerts.get_all_alert_details(query)`
- Will return a generator of individual alerts with detail included, in ascending chronological order.

- Pass query to `sdk.alerts.get_all_alert_details(query, ascending=False)`
- Will return a generator of individual alerts with detail included, in descending chronological order.

### PR Checklist ###
Did you remember to do the below?

- [X] Add unit tests to verify this change
- [X] Add an entry to CHANGELOG.md describing this change
- [X] Add docstrings for any new public parameters / methods / classes
