### PR TITLE
fix typo in filter class name

### DIFF
--- a/src/py42/sdk/queries/fileevents/filters/risk_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/risk_filter.py
@@ -77,7 +77,7 @@ class RiskIndicator(FileEventFilterStringField):
             RiskIndicator.CloudDataExposures.choices()
             + RiskIndicator.CloudStorageUploads.choices()
             + RiskIndicator.CodeRepositoryUploads.choices()
-            + RiskIndicator.EmaiServiceUploads.choices()
+            + RiskIndicator.EmailServiceUploads.choices()
             + RiskIndicator.ExternalDevices.choices()
             + RiskIndicator.FileCategories.choices()
             + RiskIndicator.MessagingServiceUploads.choices()
@@ -124,7 +124,7 @@ class RiskIndicator(FileEventFilterStringField):
         def choices():
             return get_attribute_keys_from_class(RiskIndicator.CodeRepositoryUploads)
 
-    class EmaiServiceUploads:
+    class EmailServiceUploads:
         ONESIXTHREE_DOT_COM = "163.com upload"
         ONETWOSIX_DOT_COM = "126.com upload"
         AOL = "AOL upload"
@@ -142,7 +142,7 @@ class RiskIndicator(FileEventFilterStringField):
 
         @staticmethod
         def choices():
-            return get_attribute_keys_from_class(RiskIndicator.EmaiServiceUploads)
+            return get_attribute_keys_from_class(RiskIndicator.EmailServiceUploads)
 
     class ExternalDevices:
         AIRDROP = "AirDrop"


### PR DESCRIPTION
### Description of Change ###

Nothing _broken_, but `EmailServiceUploads` was misspelled as `EmaiServiceUploads` in all places.