### PR TITLE
update min requests version to 2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Changed
+
+- Updated minimum version of `requests` library to 2.4.2
+
 ## 1.17.0 - 2021-08-10
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     python_requires=">=3.6, <4",
-    install_requires=["requests>=2.3"],
+    install_requires=["requests>=2.5"],
     extras_require={
         "dev": [
             "flake8==3.9.2",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     python_requires=">=3.6, <4",
-    install_requires=["requests>=2.5"],
+    install_requires=["requests>=2.4.2"],
     extras_require={
         "dev": [
             "flake8==3.9.2",


### PR DESCRIPTION
### Description of Change ###

Since we're now using the json param in the `requests.models.Request` object, we should update the minimum to the version this was introduced: 

https://docs.python-requests.org/en/latest/community/updates/#id56

### PR Checklist ###
Did you remember to do the below?

- [ ] Add unit tests to verify this change
- [X] Add an entry to CHANGELOG.md describing this change
- [ ] Add docstrings for any new public parameters / methods / classes
