### PR TITLE
rm all core rest documentation links

### DIFF
--- a/src/py42/clients/archive.py
+++ b/src/py42/clients/archive.py
@@ -54,6 +54,8 @@ class ArchiveClient:
         """Streams a file from a backup archive to memory. This method uses the same endpoint
         as restoring from Console and therefore has all the same considerations.
 
+        `Support Documentation <https://support.code42.com/Administrator/6/Monitoring_and_managing/Restore_files_from_the_Code42_console#Troubleshooting>`__
+
         Args:
             file_paths (str or list of str): The path or list of paths to the files or directories in
                 the archive.

--- a/src/py42/clients/archive.py
+++ b/src/py42/clients/archive.py
@@ -54,7 +54,7 @@ class ArchiveClient:
         """Streams a file from a backup archive to memory. This method uses the same endpoint
         as restoring from Console and therefore has all the same considerations.
 
-        `Support Documentation <https://support.code42.com/Administrator/6/Monitoring_and_managing/Restore_files_from_the_Code42_console#Troubleshooting>`__
+        `Support Documentation <https://support.code42.com/Administrator/Cloud/Monitoring_and_managing/Restore_files_from_the_Code42_console#Troubleshooting>`__
 
         Args:
             file_paths (str or list of str): The path or list of paths to the files or directories in

--- a/src/py42/clients/archive.py
+++ b/src/py42/clients/archive.py
@@ -17,7 +17,6 @@ class ArchiveClient:
 
     def get_by_archive_guid(self, archive_guid):
         """Gets single archive information by GUID.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#Archive-get>`__
 
         Args:
             archive_guid (str): The GUID for the archive.
@@ -30,7 +29,6 @@ class ArchiveClient:
 
     def get_all_by_device_guid(self, device_guid):
         """Gets archive information for a device.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#Archive-get>`__
 
         Args:
             device_guid (str): The GUID for the device.
@@ -55,8 +53,6 @@ class ArchiveClient:
     ):
         """Streams a file from a backup archive to memory. This method uses the same endpoint
         as restoring from Console and therefore has all the same considerations.
-
-        `Support Documentation <https://support.code42.com/Administrator/6/Monitoring_and_managing/Restore_files_from_the_Code42_console#Troubleshooting>`__
 
         Args:
             file_paths (str or list of str): The path or list of paths to the files or directories in
@@ -214,7 +210,6 @@ class ArchiveClient:
 
     def get_all_org_restore_history(self, days, org_id):
         """Gets all restore jobs from the past given days for the organization with the given ID.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#RestoreHistory-get>`__
 
         Args:
             days (int): Number of days of restore history to retrieve.
@@ -228,7 +223,6 @@ class ArchiveClient:
 
     def get_all_user_restore_history(self, days, user_id):
         """Gets all restore jobs from the past given days for the user with the given ID.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#RestoreHistory-get>`__
 
         Args:
             days (int): Number of days of restore history to retrieve.
@@ -242,7 +236,6 @@ class ArchiveClient:
 
     def get_all_device_restore_history(self, days, device_id):
         """Gets all restore jobs from the past given days for the device with the given ID.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#RestoreHistory-get>`__
 
         Args:
             days (int): Number of days of restore history to retrieve.
@@ -258,7 +251,6 @@ class ArchiveClient:
 
     def update_cold_storage_purge_date(self, archive_guid, purge_date):
         """Updates the cold storage purge date for a specified archive.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#ColdStorage-put>`__
 
         Args:
             archive_guid (str): The identification number of the archive that should be updated

--- a/src/py42/clients/loginconfig.py
+++ b/src/py42/clients/loginconfig.py
@@ -10,8 +10,6 @@ class LoginConfigurationClient:
         `LOCAL`, `LOCAL_2FA`, and `CLOUD_SSO`. If username does not exist the default
         return value is `LOCAL_2FA`.
 
-        `REST Documentation: <https://console.us.code42.com/swagger/index.html?urls.primaryName=v3#/Feature/get>`__
-
         Args:
             username (str): Username to retrieve login configuration for.
 

--- a/src/py42/services/archive.py
+++ b/src/py42/services/archive.py
@@ -11,7 +11,6 @@ class ArchiveService(BaseService):
 
     def get_single_archive(self, archive_guid):
         """Gets single archive information by GUID.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#Archive-get>`__
 
         Args:
             archive_guid (str): The GUID for the archive.
@@ -24,7 +23,6 @@ class ArchiveService(BaseService):
 
     def get_page(self, page_num, page_size=None, **kwargs):
         """Gets an individual page of archives.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#Archive-get>`__
 
         Args:
             page_num (int): The page number to request.
@@ -40,7 +38,6 @@ class ArchiveService(BaseService):
 
     def get_all_archives_from_value(self, id_value, id_type):
         """Gets archive information from an ID, such as a User UID, Device GUID, or Destination GUID.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#Archive-get>`__
 
         Args:
             id_value (str): Query value for archive.

--- a/src/py42/services/devices.py
+++ b/src/py42/services/devices.py
@@ -30,7 +30,6 @@ class DeviceService(BaseService):
         q=None,
     ):
         """Gets a page of devices.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#Computer-get>`__
 
         Args:
             page_num (int): The page number to request.
@@ -90,7 +89,6 @@ class DeviceService(BaseService):
         When no arguments are passed, all records are returned. To filter results, specify
         respective arguments. For example, to retrieve all active and blocked devices, pass
         active=true and blocked=true.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#Computer-get>`__
 
         Args:
             active (bool, optional): Filters results by device state. When set to True, gets all
@@ -133,7 +131,6 @@ class DeviceService(BaseService):
 
     def get_by_id(self, device_id, include_backup_usage=None, **kwargs):
         """Gets device information by ID.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#Computer-get>`__
 
         Args:
             device_id (int): The identification number of the device.
@@ -149,7 +146,6 @@ class DeviceService(BaseService):
 
     def get_by_guid(self, guid, include_backup_usage=None, **kwargs):
         """Gets device information by GUID.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#Computer-get>`__
 
         Args:
             guid (str): The globally unique identifier of the device.
@@ -166,7 +162,6 @@ class DeviceService(BaseService):
     def block(self, device_id):
         """Blocks a device causing the user not to be able to log in to or restore from Code42 on
         that device.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#ComputerBlock>`__
 
         Args:
             device_id (int): The identification number of the device.
@@ -179,7 +174,6 @@ class DeviceService(BaseService):
 
     def unblock(self, device_id):
         """Unblocks a device, permitting a user to be able to login and restore again.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#ComputerBlock>`__
 
         Args:
             device_id (int): The identification number of the device.
@@ -192,7 +186,6 @@ class DeviceService(BaseService):
 
     def deactivate(self, device_id):
         """Deactivates a device, causing backups to stop and archives to go to cold storage.
-        `REST Documentation <https://console.us.code42.com/swagger/index.html?urls.primaryName=v4#/computer-deactivation/ComputerDeactivation_Update>`__
 
         Args:
             device_id (int): The identification number of the device.
@@ -210,7 +203,6 @@ class DeviceService(BaseService):
 
     def reactivate(self, device_id):
         """Activates a previously deactivated device.
-        `REST Documentation <https://console.us.code42.com/swagger/?urls.primaryName=v4#/computer-deactivation/ComputerDeactivation_Remove>`__
 
         Args:
             device_id (int): The identification number of the device.
@@ -225,7 +217,6 @@ class DeviceService(BaseService):
     def deauthorize(self, device_id):
         """Deauthorizes the device with the given ID. If used on a cloud connector device, it will
         remove the authorization token for that account.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#ComputerDeauthorization>`__
 
         Args:
             device_id (int): The identification number of the device.
@@ -238,7 +229,6 @@ class DeviceService(BaseService):
 
     def get_agent_state(self, guid, property_name):
         """Gets the agent state of the device.
-            `REST Documentation <https://console.us.code42.com/swagger/index.html?urls.primaryName=v14#/agent-state/AgentState_ViewByDeviceGuid>`__
 
             Args:
                 guid (str): The globally unique identifier of the device.
@@ -253,7 +243,6 @@ class DeviceService(BaseService):
 
     def get_agent_full_disk_access_state(self, guid):
         """Gets the full disk access status of a device.
-            `REST Documentation <https://console.us.code42.com/swagger/index.html?urls.primaryName=v14#/agent-state/AgentState_ViewByDeviceGuid>`__
 
             Args:
                 guid (str): The globally unique identifier of the device.

--- a/src/py42/services/fileevent.py
+++ b/src/py42/services/fileevent.py
@@ -14,7 +14,7 @@ class FileEventService(BaseService):
 
     def search(self, query):
         """Searches for file events matching the query criteria.
-        `REST Documentation <https://forensicsearch-east.us.code42.com/forensic-search/queryservice/swagger-ui.html#/file-event-controller/searchEventsUsingPOST>`__
+        `REST Documentation <https://developer.code42.com/api/#operation/searchEventsUsingPOST>`__
 
         Args:
             query (:class:`~py42.sdk.queries.fileevents.file_event_query.FileEventQuery` or str or unicode):

--- a/src/py42/services/legalhold.py
+++ b/src/py42/services/legalhold.py
@@ -32,7 +32,6 @@ class LegalHoldService(BaseService):
 
     def create_policy(self, name, policy=None):
         """Creates a new Legal Hold Preservation Policy.
-        `REST Documentation <https://console.us.code42.com/swagger/?urls.primaryName=v4#/legal-hold-policy/LegalHoldPolicy_Create>`__
 
         Args:
             name (str): The name of the new Policy.
@@ -50,7 +49,6 @@ class LegalHoldService(BaseService):
         self, name, hold_policy_uid, description=None, notes=None, hold_ext_ref=None
     ):
         """Creates a new, active Legal Hold Matter.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#LegalHold-post>`__
 
         Args:
             name (str): The name of the new Legal Hold Matter.
@@ -75,7 +73,6 @@ class LegalHoldService(BaseService):
 
     def get_policy_by_uid(self, legal_hold_policy_uid):
         """Gets a single Preservation Policy.
-        `V4 REST Documentation <https://console.us.code42.com/swagger/#/legal-hold-policy/LegalHoldPolicy_View>`__
 
         Args:
             legal_hold_policy_uid (str): The identifier of the Preservation Policy.
@@ -89,7 +86,6 @@ class LegalHoldService(BaseService):
 
     def get_policy_list(self):
         """Gets a list of existing Preservation Policies.
-        `V4 REST Documentation <https://console.us.code42.com/swagger/#/legal-hold-policy/LegalHoldPolicy_List>`__
 
         Returns:
             :class:`py42.response.Py42Response`: A response containing the list of Policies.
@@ -99,7 +95,6 @@ class LegalHoldService(BaseService):
 
     def get_matter_by_uid(self, legal_hold_uid):
         """Gets a single Legal Hold Matter.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#LegalHold-get>`__
 
         Args:
             legal_hold_uid (str): The identifier of the Legal Hold Matter.
@@ -123,7 +118,6 @@ class LegalHoldService(BaseService):
         page_size=None,
     ):
         """Gets a page of existing Legal Hold Matters.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#LegalHold-get>`__
 
         Args:
             page_num (int): The page number to request.
@@ -160,7 +154,6 @@ class LegalHoldService(BaseService):
         self, creator_user_uid=None, active=True, name=None, hold_ext_ref=None
     ):
         """Gets all existing Legal Hold Matters.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#LegalHold-get>`__
 
         Args:
             creator_user_uid (str, optional): Find Matters by the identifier of the user who created
@@ -201,7 +194,6 @@ class LegalHoldService(BaseService):
 
         `legal_hold_membership_uid`, `legal_hold_uid`, `user_uid`, `user`
 
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#LegalHoldMembership-get>`__
 
         Args:
             page_num (int): The page number to request.
@@ -250,7 +242,6 @@ class LegalHoldService(BaseService):
         "INACTIVE", they have been removed from the Matter and are no longer subject to the Legal
         Hold retention rules. Users can be Custodians of multiple Legal Holds at once (and thus
         would be part of multiple LegalHoldMembership objects).
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#LegalHoldMembership-get>`__
 
         Args:
             legal_hold_uid (str, optional): Find LegalHoldMemberships for the Legal Hold Matter
@@ -286,7 +277,6 @@ class LegalHoldService(BaseService):
     ):
         """Gets an individual page of Legal Hold events.
 
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#LegalHoldEventReport-get>`__
 
         Args:
             legal_hold_uid (str, optional): Find LegalHoldEvents for the Legal Hold
@@ -324,7 +314,6 @@ class LegalHoldService(BaseService):
         self, legal_hold_uid=None, min_event_date=None, max_event_date=None
     ):
         """Gets an individual page of Legal Hold events.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#LegalHoldEventReport-get>`__
 
         Args:
             legal_hold_uid (str, optional): Find LegalHoldEvents for the Legal Hold Matter
@@ -350,7 +339,6 @@ class LegalHoldService(BaseService):
 
     def add_to_matter(self, user_uid, legal_hold_uid):
         """Add a user (Custodian) to a Legal Hold Matter.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#LegalHoldMembership-post>`__
 
         Args:
             user_uid (str): The identifier of the user.
@@ -374,7 +362,6 @@ class LegalHoldService(BaseService):
 
     def remove_from_matter(self, legal_hold_membership_uid):
         """Remove a user (Custodian) from a Legal Hold Matter.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#LegalHoldMembershipDeactivation-post>`__
 
         Args:
             legal_hold_membership_uid (str): The identifier of the LegalHoldMembership
@@ -389,7 +376,6 @@ class LegalHoldService(BaseService):
 
     def deactivate_matter(self, legal_hold_uid):
         """Deactivates and closes a Legal Hold Matter.
-        `V4 REST Documentation <https://console.us.code42.com/swagger/#/legal-hold-deactivation/LegalHoldDeactivation_Update>`__
 
         Args:
             legal_hold_uid (str): The identifier of the Legal Hold Matter.
@@ -403,7 +389,6 @@ class LegalHoldService(BaseService):
 
     def reactivate_matter(self, legal_hold_uid):
         """Reactivates and re-opens a closed Matter.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#LegalHoldReactivation-put>`__
 
         Args:
             legal_hold_uid (str): The identifier of the Legal Hold Matter.

--- a/src/py42/services/orgs.py
+++ b/src/py42/services/orgs.py
@@ -20,7 +20,6 @@ class OrgService(BaseService):
 
     def create_org(self, org_name, org_ext_ref=None, notes=None, parent_org_uid=None):
         """Creates a new organization.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#Org-post>`__
 
         Args:
             org_name (str): The name of the new organization.
@@ -45,7 +44,6 @@ class OrgService(BaseService):
 
     def get_by_id(self, org_id, **kwargs):
         """Gets the organization with the given ID.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#Org-get>`__
 
         Args:
             org_id (int): An ID for an organization.
@@ -58,7 +56,6 @@ class OrgService(BaseService):
 
     def get_by_uid(self, org_uid, **kwargs):
         """Gets the organization with the given UID.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#Org-get>`__
 
         Args:
             org_uid (str): A UID for an organization.
@@ -72,7 +69,6 @@ class OrgService(BaseService):
 
     def get_page(self, page_num, page_size=None, **kwargs):
         """Gets an individual page of organizations.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#Org-get>`__
 
         Args:
             page_num (int): The page number to request.
@@ -90,7 +86,6 @@ class OrgService(BaseService):
 
     def get_all(self, **kwargs):
         """Gets all organizations.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#Org-get>`__
 
         Returns:
             generator: An object that iterates over :class:`py42.response.Py42Response` objects
@@ -103,7 +98,6 @@ class OrgService(BaseService):
         blocked organization will not allow any of its users or devices to log in. New
         registrations will be rejected and all currently logged in clients will be logged out.
         Backups continue for any devices that are still active.
-        `Rest Documentation <https://console.us.code42.com/apidocviewer/#OrgBlock-put>`__
 
         Args:
             org_id (int): An ID for an organization.
@@ -117,7 +111,6 @@ class OrgService(BaseService):
     def unblock(self, org_id):
         """Removes a block, if one exists, on an organization and its descendants with the given
         ID. All users in the organization remain blocked until they are unblocked individually.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#OrgBlock-delete>`__
 
         Args:
             org_id (int): An ID for an organization.
@@ -131,7 +124,6 @@ class OrgService(BaseService):
     def deactivate(self, org_id):
         """Deactivates the organization with the given ID, including all users, plans, and
         devices. Backups stop and archives move to cold storage.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#OrgDeactivation-put>`__
 
         Args:
             org_id (int): An ID for an organization.
@@ -145,7 +137,6 @@ class OrgService(BaseService):
     def reactivate(self, org_id):
         """Reactivates the organization with the given ID. Backups are *not* restarted
         automatically.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#OrgDeactivation-delete>`__
 
         Args:
             org_id (int): An ID for an organization.
@@ -158,7 +149,6 @@ class OrgService(BaseService):
 
     def get_current(self, **kwargs):
         """Gets the organization for the currently signed-in user.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#Org-get>`__
 
         Returns:
             :class:`py42.response.Py42Response`: A response containing the organization for the
@@ -169,7 +159,6 @@ class OrgService(BaseService):
 
     def get_agent_state(self, org_id, property_name):
         """Gets the agent state of the devices in the org.
-            `REST Documentation <https://console.us.code42.com/swagger/index.html?urls.primaryName=v14#/agent-state/AgentState_ViewByDeviceGuid>`__
 
             Args:
                 org_id (str): The org's identifier.
@@ -184,7 +173,6 @@ class OrgService(BaseService):
 
     def get_agent_full_disk_access_states(self, org_id):
         """Gets the full disk access status for devices in an org.
-            `REST Documentation <https://console.us.code42.com/swagger/index.html?urls.primaryName=v14#/agent-state/AgentState_ViewByDeviceGuid>`__
 
             Args:
                 org_id (str): The org's identifier.

--- a/src/py42/services/storage/restore.py
+++ b/src/py42/services/storage/restore.py
@@ -24,9 +24,7 @@ class RestoreService(BaseService):
         private_password=None,
         encryption_key=None,
     ):
-        """Creates a web restore connection.
-        See https://console.us.code42.com/apidocviewer/#WebRestoreSession
-        """
+        """Creates a web restore connection."""
         uri = "/api/WebRestoreSession"
         json_dict = {
             "computerGuid": device_guid,

--- a/src/py42/services/users.py
+++ b/src/py42/services/users.py
@@ -32,7 +32,6 @@ class UserService(BaseService):
         """Creates a new user.
         WARNING: If the provided username already exists for a user, it will be updated in the
         database instead.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#User-post>`__
 
         Args:
             org_uid (str): The org UID for the organization the new user belongs to.
@@ -195,7 +194,6 @@ class UserService(BaseService):
 
     def get_scim_data_by_uid(self, user_uid):
         """Returns SCIM data such as division, department, and title for a given user.
-        `REST Documentation <https://console.us.code42.com/swagger/?urls.primaryName=v7#/scim-user-data>`__
 
         Args:
             user_uid (str): A Code42 user uid.
@@ -210,7 +208,6 @@ class UserService(BaseService):
     def block(self, user_id):
         """Blocks the user with the given ID. A blocked user is not allowed to log in or restore
         files. Backups will continue if the user is still active.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#UserBlock-put>`__
 
         Args:
             user_id (int): An ID for a user.
@@ -224,7 +221,6 @@ class UserService(BaseService):
     def unblock(self, user_id):
         """Removes a block, if one exists, on the user with the given user ID. Unblocked users are
         allowed to log in and restore.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#UserBlock-delete>`__
 
         Args:
             user_id (int): An ID for a user.
@@ -238,7 +234,6 @@ class UserService(BaseService):
     def deactivate(self, user_id, block_user=None):
         """Deactivates the user with the given user ID.
         Backups discontinue for a deactivated user, and their archives go to cold storage.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#UserDeactivation-put>`__
 
         Args:
             user_id (int): An ID for a user.
@@ -257,7 +252,6 @@ class UserService(BaseService):
 
     def reactivate(self, user_id, unblock_user=None):
         """Reactivates the user with the given ID.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#UserDeactivation-delete>`__
 
         Args:
             user_id (int): An ID for a user.
@@ -272,7 +266,6 @@ class UserService(BaseService):
 
     def change_org_assignment(self, user_id, org_id):
         """Assigns a user to a different organization.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#UserMoveProcess-post>`__
 
         Args:
             user_id (int): An ID for a user.
@@ -288,7 +281,6 @@ class UserService(BaseService):
     def get_available_roles(self):
         """Report the list of roles that are available for the authenticated user to
         assign to other users.
-        `REST Documentation <https://console.us.code42.com/swagger/?urls.primaryName=v4#/role/Role_View>`__
 
         Returns:
             :class:`py42.response.Py42Response`
@@ -298,7 +290,6 @@ class UserService(BaseService):
 
     def get_roles(self, user_id):
         """Return the list of roles that are currently assigned to the given user.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#UserRole-get>`__
 
         Args:
             user_id (int): An ID for a user.
@@ -311,7 +302,6 @@ class UserService(BaseService):
 
     def add_role(self, user_id, role_name):
         """Adds a role to a user.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#UserRole-post>`__
 
         Args:
             user_id (int): An ID for a user.
@@ -326,7 +316,6 @@ class UserService(BaseService):
 
     def remove_role(self, user_id, role_name):
         """Removes a role from a user.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#UserRole-delete>`__
 
         Args:
             user_id (int): An ID for a user.
@@ -353,7 +342,6 @@ class UserService(BaseService):
         archive_size_quota_bytes=None,
     ):
         """Updates an existing user.
-        `REST Documentation <https://console.us.code42.com/apidocviewer/#User-put>`__
 
         Args:
             user_uid (str or int): A Code42 user UID.


### PR DESCRIPTION
### Description of Change ###

Removes dead API doc links from method docstrings. 

### Testing Procedure ###
None. This is a documentation-only change.
