### PR TITLE
Raise more informative error when fetching devices with invalid org UID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 ### Fixed
 
 - Issue where `sdk.users.get_roles()` was using a deprecated API.
+- Issue where `sdk.devices.get_page()` raises a vague error message when provided with invalid org UID.
 
 ## 1.14.1 - 2021-04-29
 

--- a/src/py42/services/devices.py
+++ b/src/py42/services/devices.py
@@ -4,6 +4,7 @@ from time import time
 from py42 import settings
 from py42.clients.settings.device_settings import DeviceSettings
 from py42.exceptions import Py42BadRequestError
+from py42.exceptions import Py42OrgNotFoundError
 from py42.services import BaseService
 from py42.services import handle_active_legal_hold_error
 from py42.services.util import get_all_pages
@@ -69,8 +70,12 @@ class DeviceService(BaseService):
             "pgSize": page_size,
             "q": q,
         }
-
-        return self._connection.get(uri, params=params)
+        try:
+            return self._connection.get(uri, params=params)
+        except Py42BadRequestError as err:
+            if "Unable to find org" in str(err.response.text):
+                raise Py42OrgNotFoundError(err, org_uid)
+            raise
 
     def get_all(
         self,


### PR DESCRIPTION
### Description of Change ###

Raise more informative error when fetching devices with invalid org UID. This is needed to align the error handling behavior with that of the users service. 

### Testing Procedure ###
Run `sdk.devices.get_all(org_uid="invalid_org_uid")`, and verify that you see this error message:
`py42.exceptions.Py42OrgNotFoundError: The organization with UID 'invalid_org_uid' was not found.`


### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [N/A] Add docstrings for any new public parameters / methods / classes
