### PR TITLE
enable tests that use exfiltration data service

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,7 @@ jobs:
           127.0.0.1 file-events
           127.0.0.1 storage
           127.0.0.1 preservation-data-service
+          127.0.0.1 exfiltration-data-service
           127.0.0.1 connected-server
           127.0.0.1 cases
           EOF

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,8 @@ ignore =
     E722
     # binary operation line break, different opinion from black
     W503
+    # exception chaining
+    B904
 # up to 88 allowed by bugbear B950
 max-line-length = 80
 per-file-ignores =

--- a/src/py42/services/storage/exfiltrateddata.py
+++ b/src/py42/services/storage/exfiltrateddata.py
@@ -26,8 +26,9 @@ class ExfiltratedDataService(BaseService):
         params = "deviceUid={}&eventId={}&filePath={}&versionTimestamp={}"
         params = params.format(device_id, event_id, quote(file_path), timestamp)
         resource = "file-download-token"
+        headers = {"Accept": "*/*"}
         uri = f"{self._base_uri}{resource}?{params}"
-        return self._connection.get(uri)
+        return self._connection.get(uri, headers=headers)
 
     def get_file(self, token):
         """Streams a file.

--- a/tests/integration/test_securitydata.py
+++ b/tests/integration/test_securitydata.py
@@ -42,11 +42,9 @@ class TestSecurityData:
         assert_successful_response(response)
 
     def test_stream_file_by_md5(self, connection, md5_hash, file_data):
-        pass
-        # response = connection.securitydata.stream_file_by_md5(md5_hash)
-        # assert str(response) == file_data
+        response = connection.securitydata.stream_file_by_md5(md5_hash)
+        assert str(response) == file_data
 
     def test_stream_file_by_sha256(self, connection, sha256_hash, file_data):
-        pass
-        # response = connection.securitydata.stream_file_by_sha256(sha256_hash)
-        # assert str(response) == file_data
+        response = connection.securitydata.stream_file_by_sha256(sha256_hash)
+        assert str(response) == file_data

--- a/tests/services/storage/test_exfiltrateddata.py
+++ b/tests/services/storage/test_exfiltrateddata.py
@@ -20,7 +20,7 @@ class TestExfiltratedDataService:
         service.get_download_token("testeventid", "testdeviceid", "testfilepath", 1223)
         qry = "deviceUid=testdeviceid&eventId=testeventid&filePath=testfilepath&versionTimestamp=1223"
         expected = f"api/v1/file-download-token?{qry}"
-        mock_successful_connection.get.assert_called_once_with(expected)
+        mock_successful_connection.get.assert_called_once_with(expected, headers={"Accept": "*/*"})
 
     def test_get_file_calls_get_with_valid_params(
         self, mock_successful_connection, mock_request

--- a/tests/services/storage/test_exfiltrateddata.py
+++ b/tests/services/storage/test_exfiltrateddata.py
@@ -20,7 +20,9 @@ class TestExfiltratedDataService:
         service.get_download_token("testeventid", "testdeviceid", "testfilepath", 1223)
         qry = "deviceUid=testdeviceid&eventId=testeventid&filePath=testfilepath&versionTimestamp=1223"
         expected = f"api/v1/file-download-token?{qry}"
-        mock_successful_connection.get.assert_called_once_with(expected, headers={"Accept": "*/*"})
+        mock_successful_connection.get.assert_called_once_with(
+            expected, headers={"Accept": "*/*"}
+        )
 
     def test_get_file_calls_get_with_valid_params(
         self, mock_successful_connection, mock_request


### PR DESCRIPTION
### Description of Change ###

Re-enables some tests that were temporarily disabled after the introduction of functionality from the exfiltration data service.

https://github.com/code42/code42-mock-servers/pull/15 is a dependency of this PR so it needs to be merged first before the newly-enabled tests will pass.
