### PR TITLE
Feature/add trusted domain methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ## Unreleased
 
+### Added
+
+- New `trustedactivities` client with the following new methods:
+    - `sdk.trustedactivities.get_all()` to get all trusted activities.
+    - `sdk.trustedactivities.create()` to create a new trusted activity.
+    - `sdk.trustedactivities.get()` to get details about a single trusted activity.
+    - `sdk.trustedactivities.update()` to update a trusted activity.
+    - `sdk.trustedactivities.delete()` to delete a trusted activity
+
+- New custom exceptions
+    - `Py42TrustedActivityInvalidChangeError`
+    - `Py42TrustedActivityConflictError`
+    - `Py42TrustedActivityInvalidCharacterError`
+
 ### Fixed
 
 - Bug where `sdk.securitydata.search_all_file_events()` errored when `page_token` param was `None`.

--- a/docs/methoddocs/trustedactivities.md
+++ b/docs/methoddocs/trustedactivities.md
@@ -1,0 +1,7 @@
+# Trusted Activities
+
+```eval_rst
+.. autoclass:: py42.clients.trustedactivities.TrustedActivitiesClient
+    :members:
+    :show-inheritance:
+```

--- a/docs/methods.md
+++ b/docs/methods.md
@@ -37,6 +37,7 @@ Explore the complete public documentation for `py42` below.
 * [Exceptions](methoddocs/exceptions.md)
 * [Util](methoddocs/util.md)
 * [Constants](methoddocs/constants.md)
+* [Trusted Activities](methoddocs/trustedactivities.md)
 
 ```eval_rst
 .. automodule:: py42.sdk

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,8 @@ ignore =
     E722
     # binary operation line break, different opinion from black
     W503
+    # exception chaining
+    B904
 # up to 88 allowed by bugbear B950
 max-line-length = 80
 per-file-ignores =

--- a/src/py42/clients/__init__.py
+++ b/src/py42/clients/__init__.py
@@ -11,5 +11,6 @@ Clients = namedtuple(
         "auditlogs",
         "cases",
         "loginconfig",
+        "trustedactivities",
     ],
 )

--- a/src/py42/clients/trustedactivities.py
+++ b/src/py42/clients/trustedactivities.py
@@ -15,7 +15,7 @@ class TrustedActivitiesClient:
     def __init__(self, trusted_activities_service):
         self._trusted_activities_service = trusted_activities_service
 
-    def get_all(self, type=None):
+    def get_all(self, type=None, page_size=None):
         """Gets all trusted activities.
         `Rest documentation <https://developer.code42.com/>`
 
@@ -25,7 +25,7 @@ class TrustedActivitiesClient:
         Returns:
             :class:'py42.response.Py42Response'
         """
-        return self._trusted_activities_service.get_all(type)
+        return self._trusted_activities_service.get_all(type, page_size)
 
     def create(self, type, value, description=None):
         """Gets all trusted activities with the given type.

--- a/src/py42/clients/trustedactivities.py
+++ b/src/py42/clients/trustedactivities.py
@@ -1,0 +1,69 @@
+from py42.choices import Choices
+
+
+class TrustedActivityType(Choices):
+    DOMAIN = "DOMAIN"
+    SLACK = "SLACK"
+
+
+class TrustedActivitiesClient:
+    """A client to expose the trusted activities/data preferences API
+
+    `Rest documentation <https://developer.code42.com/api/#tag/Trusted-Activities>`__
+    """
+
+    def __init__(self, trusted_activities_service):
+        self._trusted_activities_service = trusted_activities_service
+
+    def get_all(self, type):
+        """Gets all trusted activities with the given type.
+        `Rest documentation <https://developer.code42.com/api/TODO>`
+
+        Args:
+            type (str): Type of the trusted activity. `TrustedActivityType.DOMAIN` or `TrustedActivityType.SLACK`
+
+        Returns:
+            :class:'py42.response.Py42Response'
+        """
+        return self._trusted_activities_service.get_all(type)
+
+    def get(self, id):
+        """Retrieve trusted activity details by given resource number.
+        `Rest documentation <https://developer.code42.com/api/TODO>`
+
+        Args:
+            id (int): Resource number of the trusted activity or domain.
+
+        Returns:
+            :class:'py42.response.Py42Response'
+        """
+        return self._trusted_activities_service.get(id)
+
+    def update(self, id, type, value, description):
+        """Updates trusted activity details by given resource number.
+        `Rest documentation <https://developer.code42.com/api/TODO>`
+
+        Args:
+            id (int): Resource number of the trusted activity.
+            type (str): Type of the trusted activity. `TrustedActivityType.DOMAIN` or `TrustedActivityType.SLACK`
+            value (str): The URL of the domain or name of the Slack workspace.
+            description (str): Description of the trusted activity.
+
+        Returns:
+            :class:'py42.response.Py42Response'
+        """
+        return self._trusted_activities_service.update(
+            id=id, type=type, value=value, description=description
+        )
+
+    def delete(self, id):
+        """Deletes a trusted activity by given resource number.
+        `Rest documentation <https://developer.code42.com/api/TODO>`
+
+        Args:
+            id (int): Resource number of the trusted activity or domain.
+
+        Returns:
+            :class:'py42.response.Py42Response'
+        """
+        return self._trusted_activities_service.delete(id)

--- a/src/py42/clients/trustedactivities.py
+++ b/src/py42/clients/trustedactivities.py
@@ -53,13 +53,12 @@ class TrustedActivitiesClient:
         """
         return self._trusted_activities_service.get(id)
 
-    def update(self, id, type=None, value=None, description=None):
+    def update(self, id, value=None, description=None):
         """Updates trusted activity details by given resource number.
         `Rest documentation <https://developer.code42.com/>`
 
         Args:
             id (int): Resource number of the trusted activity.
-            type (str, optional): Type of the trusted activity. `TrustedActivityType.DOMAIN` or `TrustedActivityType.SLACK`
             value (str, optional): The URL of the domain or name of the Slack workspace.
             description (str, optional): Description of the trusted activity.
 
@@ -67,7 +66,7 @@ class TrustedActivitiesClient:
             :class:'py42.response.Py42Response'
         """
         return self._trusted_activities_service.update(
-            id=id, type=type, value=value, description=description
+            id=id, value=value, description=description
         )
 
     def delete(self, id):

--- a/src/py42/clients/trustedactivities.py
+++ b/src/py42/clients/trustedactivities.py
@@ -23,7 +23,8 @@ class TrustedActivitiesClient:
             type (str, optional): Type of the trusted activity. `TrustedActivityType.DOMAIN` or `TrustedActivityType.SLACK`
 
         Returns:
-            :class:'py42.response.Py42Response'
+            generator: An object that iterates over :class:`py42.response.Py42Response` objects
+            that each contain a page of cases.
         """
         return self._trusted_activities_service.get_all(type, page_size)
 
@@ -37,7 +38,7 @@ class TrustedActivitiesClient:
             description (str, optional): Description of the trusted activity.
 
         Returns:
-            :class:'py42.response.Py42Response'
+            :class:`py42.response.Py42Response`
         """
         return self._trusted_activities_service.create(type, value, description)
 
@@ -49,7 +50,7 @@ class TrustedActivitiesClient:
             id (int): Resource number of the trusted activity or domain.
 
         Returns:
-            :class:'py42.response.Py42Response'
+            :class:`py42.response.Py42Response`
         """
         return self._trusted_activities_service.get(id)
 
@@ -63,7 +64,7 @@ class TrustedActivitiesClient:
             description (str, optional): Description of the trusted activity.
 
         Returns:
-            :class:'py42.response.Py42Response'
+            :class:`py42.response.Py42Response`
         """
         return self._trusted_activities_service.update(
             id=id, value=value, description=description
@@ -77,6 +78,6 @@ class TrustedActivitiesClient:
             id (int): Resource number of the trusted activity or domain.
 
         Returns:
-            :class:'py42.response.Py42Response'
+            :class:`py42.response.Py42Response`
         """
         return self._trusted_activities_service.delete(id)

--- a/src/py42/clients/trustedactivities.py
+++ b/src/py42/clients/trustedactivities.py
@@ -17,10 +17,11 @@ class TrustedActivitiesClient:
 
     def get_all(self, type=None, page_size=None):
         """Gets all trusted activities.
-        `Rest documentation <https://developer.code42.com/>`
+        `Rest documentation <https://developer.code42.com/api>`
 
         Args:
             type (str, optional): Type of the trusted activity. `TrustedActivityType.DOMAIN` or `TrustedActivityType.SLACK`
+            page_size (int, optional): Number of results to return per page. Defaults to 100.
 
         Returns:
             generator: An object that iterates over :class:`py42.response.Py42Response` objects
@@ -30,7 +31,7 @@ class TrustedActivitiesClient:
 
     def create(self, type, value, description=None):
         """Gets all trusted activities with the given type.
-        `Rest documentation <https://developer.code42.com/>`
+        `Rest documentation <https://developer.code42.com/api>`
 
         Args:
             type (str): Type of the trusted activity. `TrustedActivityType.DOMAIN` or `TrustedActivityType.SLACK`
@@ -44,7 +45,7 @@ class TrustedActivitiesClient:
 
     def get(self, id):
         """Retrieve trusted activity details by given resource number.
-        `Rest documentation <https://developer.code42.com/>`
+        `Rest documentation <https://developer.code42.com/api>`
 
         Args:
             id (int): Resource number of the trusted activity or domain.
@@ -56,7 +57,7 @@ class TrustedActivitiesClient:
 
     def update(self, id, value=None, description=None):
         """Updates trusted activity details by given resource number.
-        `Rest documentation <https://developer.code42.com/>`
+        `Rest documentation <https://developer.code42.com/api>`
 
         Args:
             id (int): Resource number of the trusted activity.
@@ -72,7 +73,7 @@ class TrustedActivitiesClient:
 
     def delete(self, id):
         """Deletes a trusted activity by given resource number.
-        `Rest documentation <https://developer.code42.com/>`
+        `Rest documentation <https://developer.code42.com/api>`
 
         Args:
             id (int): Resource number of the trusted activity or domain.

--- a/src/py42/clients/trustedactivities.py
+++ b/src/py42/clients/trustedactivities.py
@@ -27,6 +27,20 @@ class TrustedActivitiesClient:
         """
         return self._trusted_activities_service.get_all(type)
 
+    def create(self, type, value, description):
+        """Gets all trusted activities with the given type.
+        `Rest documentation <https://developer.code42.com/api/TODO>`
+
+        Args:
+            type (str): Type of the trusted activity. `TrustedActivityType.DOMAIN` or `TrustedActivityType.SLACK`
+            value (str): The URL of the domain or name of the Slack workspace.
+            description (str): Description of the trusted activity.
+
+        Returns:
+            :class:'py42.response.Py42Response'
+        """
+        return self._trusted_activities_service.create(type, value, description)
+
     def get(self, id):
         """Retrieve trusted activity details by given resource number.
         `Rest documentation <https://developer.code42.com/api/TODO>`

--- a/src/py42/clients/trustedactivities.py
+++ b/src/py42/clients/trustedactivities.py
@@ -15,26 +15,26 @@ class TrustedActivitiesClient:
     def __init__(self, trusted_activities_service):
         self._trusted_activities_service = trusted_activities_service
 
-    def get_all(self, type):
-        """Gets all trusted activities with the given type.
-        `Rest documentation <https://developer.code42.com/api/TODO>`
+    def get_all(self, type=None):
+        """Gets all trusted activities.
+        `Rest documentation <https://developer.code42.com/>`
 
         Args:
-            type (str): Type of the trusted activity. `TrustedActivityType.DOMAIN` or `TrustedActivityType.SLACK`
+            type (str, optional): Type of the trusted activity. `TrustedActivityType.DOMAIN` or `TrustedActivityType.SLACK`
 
         Returns:
             :class:'py42.response.Py42Response'
         """
         return self._trusted_activities_service.get_all(type)
 
-    def create(self, type, value, description):
+    def create(self, type, value, description=None):
         """Gets all trusted activities with the given type.
-        `Rest documentation <https://developer.code42.com/api/TODO>`
+        `Rest documentation <https://developer.code42.com/>`
 
         Args:
             type (str): Type of the trusted activity. `TrustedActivityType.DOMAIN` or `TrustedActivityType.SLACK`
             value (str): The URL of the domain or name of the Slack workspace.
-            description (str): Description of the trusted activity.
+            description (str, optional): Description of the trusted activity.
 
         Returns:
             :class:'py42.response.Py42Response'
@@ -43,7 +43,7 @@ class TrustedActivitiesClient:
 
     def get(self, id):
         """Retrieve trusted activity details by given resource number.
-        `Rest documentation <https://developer.code42.com/api/TODO>`
+        `Rest documentation <https://developer.code42.com/>`
 
         Args:
             id (int): Resource number of the trusted activity or domain.
@@ -53,15 +53,15 @@ class TrustedActivitiesClient:
         """
         return self._trusted_activities_service.get(id)
 
-    def update(self, id, type, value, description):
+    def update(self, id, type=None, value=None, description=None):
         """Updates trusted activity details by given resource number.
-        `Rest documentation <https://developer.code42.com/api/TODO>`
+        `Rest documentation <https://developer.code42.com/>`
 
         Args:
             id (int): Resource number of the trusted activity.
-            type (str): Type of the trusted activity. `TrustedActivityType.DOMAIN` or `TrustedActivityType.SLACK`
-            value (str): The URL of the domain or name of the Slack workspace.
-            description (str): Description of the trusted activity.
+            type (str, optional): Type of the trusted activity. `TrustedActivityType.DOMAIN` or `TrustedActivityType.SLACK`
+            value (str, optional): The URL of the domain or name of the Slack workspace.
+            description (str, optional): Description of the trusted activity.
 
         Returns:
             :class:'py42.response.Py42Response'
@@ -72,7 +72,7 @@ class TrustedActivitiesClient:
 
     def delete(self, id):
         """Deletes a trusted activity by given resource number.
-        `Rest documentation <https://developer.code42.com/api/TODO>`
+        `Rest documentation <https://developer.code42.com/>`
 
         Args:
             id (int): Resource number of the trusted activity or domain.

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -360,7 +360,7 @@ class Py42TrustedActivityInvalidCharacterError(Py42BadRequestError):
     """An error raised when an invalid change is being made to a trusted activity."""
 
     def __init__(self, exception):
-        msg = "Domain name cannot include @"
+        msg = "Invalid character in domain or slack workspace name"
         super().__init__(exception, msg)
 
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -339,6 +339,7 @@ class Py42CaseAlreadyHasEventError(Py42BadRequestError):
 
 class Py42TrustedActivityInvalidChangeError(Py42BadRequestError):
     """An error raised when an invalid change is being made to a trusted activity."""
+
     def __init__(self, exception):
         msg = "Invalid change to trusted activity. Trusted activity type cannot be changed."
         super().__init__(exception, msg)
@@ -346,6 +347,7 @@ class Py42TrustedActivityInvalidChangeError(Py42BadRequestError):
 
 class Py42TrustedActivityConflictError(Py42HTTPError):
     """An error raised when theres a conflict with a trusted activity domain URL."""
+
     def __init__(self, exception, value):
         msg = (
             f"Duplicate URL or workspace name, '{value}' already exists on your trusted list.  "
@@ -356,6 +358,7 @@ class Py42TrustedActivityConflictError(Py42HTTPError):
 
 class Py42TrustedActivityInvalidCharacterError(Py42BadRequestError):
     """An error raised when an invalid change is being made to a trusted activity."""
+
     def __init__(self, exception):
         msg = "Domain name cannot include @"
         super().__init__(exception, msg)

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -344,7 +344,7 @@ class Py42TrustedActivityInvalidChangeError(Py42BadRequestError):
         super().__init__(exception, msg)
 
 
-class Py42TrustedActivityConflictError(Py42BadRequestError):
+class Py42TrustedActivityConflictError(Py42HTTPError):
     """An error raised when theres a conflict with a trusted activity domain URL."""
     def __init__(self, exception, value):
         msg = (

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -337,6 +337,30 @@ class Py42CaseAlreadyHasEventError(Py42BadRequestError):
         super().__init__(exception, msg)
 
 
+class Py42TrustedActivityInvalidChangeError(Py42BadRequestError):
+    """An error raised when an invalid change is being made to a trusted activity."""
+    def __init__(self, exception):
+        msg = "Invalid change to trusted activity. Trusted activity type cannot be changed."
+        super().__init__(exception, msg)
+
+
+class Py42TrustedActivityConflictError(Py42BadRequestError):
+    """An error raised when theres a conflict with a trusted activity domain URL."""
+    def __init__(self, exception, value):
+        msg = (
+            f"Duplicate URL or workspace name, '{value}' already exists on your trusted list.  "
+            "Please enter a unique value"
+        )
+        super().__init__(exception, msg)
+
+
+class Py42TrustedActivityInvalidCharacterError(Py42BadRequestError):
+    """An error raised when an invalid change is being made to a trusted activity."""
+    def __init__(self, exception):
+        msg = "Domain name cannot include @"
+        super().__init__(exception, msg)
+
+
 def raise_py42_error(raised_error):
     """Raises the appropriate :class:`py42.exceptions.Py42HttpError` based on the given
     HTTPError's response status code.

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -351,7 +351,7 @@ class Py42TrustedActivityConflictError(Py42HTTPError):
     def __init__(self, exception, value):
         msg = (
             f"Duplicate URL or workspace name, '{value}' already exists on your trusted list.  "
-            "Please enter a unique value"
+            "Please provide a unique value"
         )
         super().__init__(exception, msg)
 

--- a/src/py42/sdk/__init__.py
+++ b/src/py42/sdk/__init__.py
@@ -293,6 +293,7 @@ def _init_services(main_connection, main_auth):
     kv_prefix = "simple-key-value-store"
     audit_logs_key = "AUDIT-LOG_API-URL"
     cases_key = "CASES_API-URL"
+    trusted_activities_key = "TRUSTED-DOMAINS_API-URL"
 
     kv_connection = Connection.from_microservice_prefix(main_connection, kv_prefix)
     kv_service = KeyValueStoreService(kv_connection)
@@ -321,6 +322,9 @@ def _init_services(main_connection, main_auth):
     user_ctx = UserContext(administration_svc)
     user_profile_svc = DetectionListUserService(ecm_conn, user_ctx, user_svc)
     cases_conn = Connection.from_microservice_key(kv_service, cases_key, auth=main_auth)
+    trusted_activities_conn = Connection.from_microservice_key(
+        kv_service, trusted_activities_key, auth=main_auth
+    )
 
     services = Services(
         administration=administration_svc,
@@ -342,7 +346,7 @@ def _init_services(main_connection, main_auth):
         auditlogs=AuditLogsService(audit_logs_conn),
         cases=CasesService(cases_conn),
         casesfileevents=CasesFileEventsService(cases_conn),
-        trustedactivities=TrustedActivitiesService(main_connection),
+        trustedactivities=TrustedActivitiesService(trusted_activities_conn),
     )
 
     return services, user_ctx

--- a/src/py42/sdk/__init__.py
+++ b/src/py42/sdk/__init__.py
@@ -11,6 +11,7 @@ from py42.clients.cases import CasesClient
 from py42.clients.detectionlists import DetectionListsClient
 from py42.clients.loginconfig import LoginConfigurationClient
 from py42.clients.securitydata import SecurityDataClient
+from py42.clients.trustedactivities import TrustedActivitiesClient
 from py42.exceptions import Py42Error
 from py42.exceptions import Py42UnauthorizedError
 from py42.services import Services
@@ -36,6 +37,7 @@ from py42.services.preservationdata import PreservationDataService
 from py42.services.savedsearch import SavedSearchService
 from py42.services.storage._service_factory import ConnectionManager
 from py42.services.storage._service_factory import StorageServiceFactory
+from py42.services.trustedactivities import TrustedActivitiesService
 from py42.services.users import UserService
 from py42.usercontext import UserContext
 
@@ -258,7 +260,7 @@ class SDKClient:
         """A collection of methods for retrieving audit logs.
 
         Returns:
-            :class:`py42.clients.auditlogs.AuditLogsService`
+            :class:`py42.clients.auditlogs.AuditLogsClient`
         """
         return self._clients.auditlogs
 
@@ -271,6 +273,15 @@ class SDKClient:
             :class:`py42.clients.cases.CaseClient`
         """
         return self._clients.cases
+
+    @property
+    def trustedactivities(self):
+        """A collection of methods and properties for managing trusted domains.
+
+        Returns:
+            :class:`py42.clients.trustedactivities.TrustedActivitiesClient`
+        """
+        return self._clients.trustedactivities
 
 
 def _init_services(main_connection, main_auth):
@@ -331,6 +342,7 @@ def _init_services(main_connection, main_auth):
         auditlogs=AuditLogsService(audit_logs_conn),
         cases=CasesService(cases_conn),
         casesfileevents=CasesFileEventsService(cases_conn),
+        trustedactivities=TrustedActivitiesService(main_connection),
     )
 
     return services, user_ctx
@@ -365,6 +377,7 @@ def _init_clients(services, connection):
     archive = ArchiveClient(archive_accessor_factory, services.archive)
     auditlogs = AuditLogsClient(services.auditlogs)
     loginconfig = LoginConfigurationClient(connection)
+    trustedactivities = TrustedActivitiesClient(services.trustedactivities)
     clients = Clients(
         authority=authority,
         detectionlists=detectionlists,
@@ -374,5 +387,6 @@ def _init_clients(services, connection):
         auditlogs=auditlogs,
         cases=CasesClient(services.cases, services.casesfileevents),
         loginconfig=loginconfig,
+        trustedactivities=trustedactivities,
     )
     return clients

--- a/src/py42/services/__init__.py
+++ b/src/py42/services/__init__.py
@@ -36,5 +36,6 @@ Services = namedtuple(
         "auditlogs",
         "cases",
         "casesfileevents",
+        "trustedactivities",
     ],
 )

--- a/src/py42/services/cases.py
+++ b/src/py42/services/cases.py
@@ -137,4 +137,3 @@ def _handle_common_invalid_case_parameters_errors(base_err, name):
             raise Py42InvalidCaseUserError(base_err, "subject")
         elif "assignee" in base_err.response.text:
             raise Py42InvalidCaseUserError(base_err, "assignee")
-    raise

--- a/src/py42/services/cases.py
+++ b/src/py42/services/cases.py
@@ -137,3 +137,4 @@ def _handle_common_invalid_case_parameters_errors(base_err, name):
             raise Py42InvalidCaseUserError(base_err, "subject")
         elif "assignee" in base_err.response.text:
             raise Py42InvalidCaseUserError(base_err, "assignee")
+    raise

--- a/src/py42/services/trustedactivities.py
+++ b/src/py42/services/trustedactivities.py
@@ -27,7 +27,7 @@ class TrustedActivitiesService(BaseService):
         try:
             return self._connection.post(self._uri_prefix, json=data)
         except Py42BadRequestError as err:
-            _handle_common_invalid_case_parameters_errors(err, value)
+            _handle_common_invalid_case_parameters_errors(err)
         except Py42HTTPError as err:
             _handle_common_client_errors(err, value)
 
@@ -48,7 +48,7 @@ class TrustedActivitiesService(BaseService):
         except Py42BadRequestError as err:
             if "INVALID_CHANGE" in err.response.text:
                 raise Py42TrustedActivityInvalidChangeError(err)
-            _handle_common_invalid_case_parameters_errors(err, value)
+            _handle_common_invalid_case_parameters_errors(err)
         except Py42HTTPError as err:
             _handle_common_client_errors(err, value)
 
@@ -57,13 +57,15 @@ class TrustedActivitiesService(BaseService):
         return self._connection.delete(uri)
 
 
-def _handle_common_invalid_case_parameters_errors(base_err, value):
+def _handle_common_invalid_case_parameters_errors(base_err):
     if "DESCRIPTION_TOO_LONG" in base_err.response.text:
         raise Py42DescriptionLimitExceededError(base_err)
     elif "INVALID_CHARACTERS_IN_VALUE" in base_err.response.text:
         raise Py42TrustedActivityInvalidCharacterError(base_err)
+    raise
 
 
 def _handle_common_client_errors(base_err, value):
     if "CONFLICT" in base_err.response.text:
         raise Py42TrustedActivityConflictError(base_err, value)
+    raise

--- a/src/py42/services/trustedactivities.py
+++ b/src/py42/services/trustedactivities.py
@@ -1,9 +1,11 @@
+from py42 import settings
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42DescriptionLimitExceededError
 from py42.exceptions import Py42HTTPError
 from py42.exceptions import Py42TrustedActivityConflictError
 from py42.exceptions import Py42TrustedActivityInvalidCharacterError
 from py42.services import BaseService
+from py42.services.util import get_all_pages
 
 
 class TrustedActivitiesService(BaseService):
@@ -13,8 +15,18 @@ class TrustedActivitiesService(BaseService):
     def __init__(self, connection):
         super().__init__(connection)
 
-    def get_all(self, type=None):
-        params = {"type": type}
+    def get_all(self, type=None, page_size=None, **kwargs):
+        return get_all_pages(self.get_page, "trustedactivities", type=type, page_size=page_size, **kwargs)
+
+    def get_page(self, page_num, page_size, type, **kwargs):
+        page_size = page_size or settings.items_per_page
+        params = {
+            "type": type,
+            "pgNum": page_num,
+            "pgSize": page_size,
+        }
+        params.update(**kwargs)
+
         return self._connection.get(self._uri_prefix, params=params)
 
     def create(self, type, value, description=None):

--- a/src/py42/services/trustedactivities.py
+++ b/src/py42/services/trustedactivities.py
@@ -51,10 +51,14 @@ class TrustedActivitiesService(BaseService):
     def update(self, id, value=None, description=None):
         uri = f"{self._uri_prefix}/{id}"
         current_activity_data = self.get(id).data
+
+        if description is None:
+            description = current_activity_data.get("description")
+
         data = {
             "type": current_activity_data.get("type"),
             "value": value or current_activity_data.get("value"),
-            "description": description or current_activity_data.get("description"),
+            "description": description
         }
         try:
             return self._connection.put(uri, json=data)

--- a/src/py42/services/trustedactivities.py
+++ b/src/py42/services/trustedactivities.py
@@ -58,7 +58,7 @@ class TrustedActivitiesService(BaseService):
         data = {
             "type": current_activity_data.get("type"),
             "value": value or current_activity_data.get("value"),
-            "description": description
+            "description": description,
         }
         try:
             return self._connection.put(uri, json=data)

--- a/src/py42/services/trustedactivities.py
+++ b/src/py42/services/trustedactivities.py
@@ -16,7 +16,9 @@ class TrustedActivitiesService(BaseService):
         super().__init__(connection)
 
     def get_all(self, type=None, page_size=None, **kwargs):
-        return get_all_pages(self.get_page, "trustResources", type=type, page_size=page_size, **kwargs)
+        return get_all_pages(
+            self.get_page, "trustResources", type=type, page_size=page_size, **kwargs
+        )
 
     def get_page(self, page_num, page_size, type, **kwargs):
         page_size = page_size or settings.items_per_page

--- a/src/py42/services/trustedactivities.py
+++ b/src/py42/services/trustedactivities.py
@@ -1,7 +1,9 @@
-from py42.exceptions import Py42BadRequestError, Py42TrustedActivityInvalidChangeError, \
-    Py42CaseNameExistsError, Py42DescriptionLimitExceededError, \
-    Py42TrustedActivityConflictError, Py42TrustedActivityInvalidCharacterError, \
-    Py42HTTPError
+from py42.exceptions import Py42BadRequestError
+from py42.exceptions import Py42DescriptionLimitExceededError
+from py42.exceptions import Py42HTTPError
+from py42.exceptions import Py42TrustedActivityConflictError
+from py42.exceptions import Py42TrustedActivityInvalidChangeError
+from py42.exceptions import Py42TrustedActivityInvalidCharacterError
 from py42.services import BaseService
 
 
@@ -16,9 +18,7 @@ class TrustedActivitiesService(BaseService):
         params = {"type": type}
         return self._connection.get(self._uri_prefix, params=params)
 
-    def create(
-        self, type, value, description=None
-    ):
+    def create(self, type, value, description=None):
         data = {
             "type": type,
             "value": value,

--- a/src/py42/services/trustedactivities.py
+++ b/src/py42/services/trustedactivities.py
@@ -16,7 +16,7 @@ class TrustedActivitiesService(BaseService):
         super().__init__(connection)
 
     def get_all(self, type=None, page_size=None, **kwargs):
-        return get_all_pages(self.get_page, "trustedactivities", type=type, page_size=page_size, **kwargs)
+        return get_all_pages(self.get_page, "trustResources", type=type, page_size=page_size, **kwargs)
 
     def get_page(self, page_num, page_size, type, **kwargs):
         page_size = page_size or settings.items_per_page

--- a/src/py42/services/trustedactivities.py
+++ b/src/py42/services/trustedactivities.py
@@ -1,0 +1,40 @@
+from py42.services import BaseService
+
+
+class TrustedActivitiesService(BaseService):
+
+    _uri_prefix = "/api/v1/trusted-activities"
+
+    def __init__(self, connection):
+        super().__init__(connection)
+
+    def get_all(self, type):
+        params = {"type": type}
+        return self._connection.get(self._uri_prefix, params=params)
+
+    def create(
+        self, type, value, description
+    ):  # change this name probably, these should all be strings
+        data = {
+            "type": type,
+            "value": value,
+            "description": description,
+        }
+        return self._connection.post(self._uri_prefix, json=data)
+
+    def get(self, id):  # id should be int
+        uri = f"{self._uri_prefix}/{id}"
+        return self._connection.get(uri)
+
+    def update(self, id, type, value, description):
+        uri = f"{self._uri_prefix}/{id}"
+        data = {
+            "type": type,
+            "value": value,
+            "description": description,
+        }
+        return self._connection.post(uri, json=data)
+
+    def delete(self, id):
+        uri = f"{self._uri_prefix}/{id}"
+        return self._connection.delete(uri)

--- a/src/py42/services/trustedactivities.py
+++ b/src/py42/services/trustedactivities.py
@@ -2,7 +2,6 @@ from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42DescriptionLimitExceededError
 from py42.exceptions import Py42HTTPError
 from py42.exceptions import Py42TrustedActivityConflictError
-from py42.exceptions import Py42TrustedActivityInvalidChangeError
 from py42.exceptions import Py42TrustedActivityInvalidCharacterError
 from py42.services import BaseService
 
@@ -35,19 +34,17 @@ class TrustedActivitiesService(BaseService):
         uri = f"{self._uri_prefix}/{id}"
         return self._connection.get(uri)
 
-    def update(self, id, type=None, value=None, description=None):
+    def update(self, id, value=None, description=None):
         uri = f"{self._uri_prefix}/{id}"
         current_activity_data = self.get(id).data
         data = {
-            "type": type or current_activity_data.get("type"),
+            "type": current_activity_data.get("type"),
             "value": value or current_activity_data.get("value"),
             "description": description or current_activity_data.get("description"),
         }
         try:
             return self._connection.put(uri, json=data)
         except Py42BadRequestError as err:
-            if "INVALID_CHANGE" in err.response.text:
-                raise Py42TrustedActivityInvalidChangeError(err)
             _handle_common_invalid_case_parameters_errors(err)
         except Py42HTTPError as err:
             _handle_common_client_errors(err, value)

--- a/tests/clients/test_trustedactivities.py
+++ b/tests/clients/test_trustedactivities.py
@@ -22,6 +22,17 @@ class TestTrustedActivitiesClient:
         trusted_activities_client.get_all()
         assert mock_trusted_activities_service.get_all.call_count == 1
 
+    def test_get_all_calls_service_with_expected_optional_params(
+        self, mock_trusted_activities_service
+    ):
+        trusted_activities_client = TrustedActivitiesClient(
+            mock_trusted_activities_service
+        )
+        trusted_activities_client.get_all("DOMAIN", 1)
+        mock_trusted_activities_service.get_all.assert_called_once_with(
+            "DOMAIN", 1
+        )
+
     def test_create_calls_service_with_expected_params(
         self, mock_trusted_activities_service
     ):

--- a/tests/clients/test_trustedactivities.py
+++ b/tests/clients/test_trustedactivities.py
@@ -13,34 +13,48 @@ def mock_trusted_activities_service(mocker):
 
 
 class TestTrustedActivitiesClient:
-    def test_get_all_calls_service_with_expected_params(self, mock_trusted_activities_service):
-        trusted_activities_client = TrustedActivitiesClient(mock_trusted_activities_service)
+    def test_get_all_calls_service_with_expected_params(
+        self, mock_trusted_activities_service
+    ):
+        trusted_activities_client = TrustedActivitiesClient(
+            mock_trusted_activities_service
+        )
         trusted_activities_client.get_all()
         assert mock_trusted_activities_service.get_all.call_count == 1
 
-    def test_create_calls_service_with_expected_params(self, mock_trusted_activities_service):
-        trusted_activities_client = TrustedActivitiesClient(mock_trusted_activities_service)
+    def test_create_calls_service_with_expected_params(
+        self, mock_trusted_activities_service
+    ):
+        trusted_activities_client = TrustedActivitiesClient(
+            mock_trusted_activities_service
+        )
         trusted_activities_client.create(
-            "DOMAIN",
-            "test.com",
-            description="description"
+            "DOMAIN", "test.com", description="description"
         )
         mock_trusted_activities_service.create.assert_called_once_with(
-            "DOMAIN",
-            "test.com",
-            "description"
+            "DOMAIN", "test.com", "description"
         )
 
-    def test_get_calls_service_with_expected_params(self, mock_trusted_activities_service):
-        trusted_activities_client = TrustedActivitiesClient(mock_trusted_activities_service)
+    def test_get_calls_service_with_expected_params(
+        self, mock_trusted_activities_service
+    ):
+        trusted_activities_client = TrustedActivitiesClient(
+            mock_trusted_activities_service
+        )
         trusted_activities_client.get(_TEST_TRUSTED_ACTIVITY_RESOURCE_ID)
-        mock_trusted_activities_service.get.assert_called_once_with(_TEST_TRUSTED_ACTIVITY_RESOURCE_ID)
+        mock_trusted_activities_service.get.assert_called_once_with(
+            _TEST_TRUSTED_ACTIVITY_RESOURCE_ID
+        )
 
-    def test_update_calls_service_with_expected_params(self, mock_trusted_activities_service):
-        trusted_activities_client = TrustedActivitiesClient(mock_trusted_activities_service)
+    def test_update_calls_service_with_expected_params(
+        self, mock_trusted_activities_service
+    ):
+        trusted_activities_client = TrustedActivitiesClient(
+            mock_trusted_activities_service
+        )
         trusted_activities_client.update(
-            _TEST_TRUSTED_ACTIVITY_RESOURCE_ID,
-            value="new-domain.com")
+            _TEST_TRUSTED_ACTIVITY_RESOURCE_ID, value="new-domain.com"
+        )
         mock_trusted_activities_service.update.assert_called_once_with(
             id=_TEST_TRUSTED_ACTIVITY_RESOURCE_ID,
             type=None,
@@ -48,7 +62,13 @@ class TestTrustedActivitiesClient:
             description=None,
         )
 
-    def test_delete_calls_service_with_expected_params(self, mock_trusted_activities_service):
-        trusted_activities_client = TrustedActivitiesClient(mock_trusted_activities_service)
+    def test_delete_calls_service_with_expected_params(
+        self, mock_trusted_activities_service
+    ):
+        trusted_activities_client = TrustedActivitiesClient(
+            mock_trusted_activities_service
+        )
         trusted_activities_client.delete(_TEST_TRUSTED_ACTIVITY_RESOURCE_ID)
-        mock_trusted_activities_service.delete.assert_called_once_with(_TEST_TRUSTED_ACTIVITY_RESOURCE_ID)
+        mock_trusted_activities_service.delete.assert_called_once_with(
+            _TEST_TRUSTED_ACTIVITY_RESOURCE_ID
+        )

--- a/tests/clients/test_trustedactivities.py
+++ b/tests/clients/test_trustedactivities.py
@@ -1,0 +1,54 @@
+import pytest
+
+from py42.clients.trustedactivities import TrustedActivitiesClient
+from py42.services.trustedactivities import TrustedActivitiesService
+
+
+_TEST_TRUSTED_ACTIVITY_RESOURCE_ID = 123
+
+
+@pytest.fixture
+def mock_trusted_activities_service(mocker):
+    return mocker.MagicMock(spec=TrustedActivitiesService)
+
+
+class TestTrustedActivitiesClient:
+    def test_get_all_calls_service_with_expected_params(self, mock_trusted_activities_service):
+        trusted_activities_client = TrustedActivitiesClient(mock_trusted_activities_service)
+        trusted_activities_client.get_all()
+        assert mock_trusted_activities_service.get_all.call_count == 1
+
+    def test_create_calls_service_with_expected_params(self, mock_trusted_activities_service):
+        trusted_activities_client = TrustedActivitiesClient(mock_trusted_activities_service)
+        trusted_activities_client.create(
+            "DOMAIN",
+            "test.com",
+            description="description"
+        )
+        mock_trusted_activities_service.create.assert_called_once_with(
+            "DOMAIN",
+            "test.com",
+            "description"
+        )
+
+    def test_get_calls_service_with_expected_params(self, mock_trusted_activities_service):
+        trusted_activities_client = TrustedActivitiesClient(mock_trusted_activities_service)
+        trusted_activities_client.get(_TEST_TRUSTED_ACTIVITY_RESOURCE_ID)
+        mock_trusted_activities_service.get.assert_called_once_with(_TEST_TRUSTED_ACTIVITY_RESOURCE_ID)
+
+    def test_update_calls_service_with_expected_params(self, mock_trusted_activities_service):
+        trusted_activities_client = TrustedActivitiesClient(mock_trusted_activities_service)
+        trusted_activities_client.update(
+            _TEST_TRUSTED_ACTIVITY_RESOURCE_ID,
+            value="new-domain.com")
+        mock_trusted_activities_service.update.assert_called_once_with(
+            id=_TEST_TRUSTED_ACTIVITY_RESOURCE_ID,
+            type=None,
+            value="new-domain.com",
+            description=None,
+        )
+
+    def test_delete_calls_service_with_expected_params(self, mock_trusted_activities_service):
+        trusted_activities_client = TrustedActivitiesClient(mock_trusted_activities_service)
+        trusted_activities_client.delete(_TEST_TRUSTED_ACTIVITY_RESOURCE_ID)
+        mock_trusted_activities_service.delete.assert_called_once_with(_TEST_TRUSTED_ACTIVITY_RESOURCE_ID)

--- a/tests/clients/test_trustedactivities.py
+++ b/tests/clients/test_trustedactivities.py
@@ -57,7 +57,6 @@ class TestTrustedActivitiesClient:
         )
         mock_trusted_activities_service.update.assert_called_once_with(
             id=_TEST_TRUSTED_ACTIVITY_RESOURCE_ID,
-            type=None,
             value="new-domain.com",
             description=None,
         )

--- a/tests/clients/test_trustedactivities.py
+++ b/tests/clients/test_trustedactivities.py
@@ -29,9 +29,7 @@ class TestTrustedActivitiesClient:
             mock_trusted_activities_service
         )
         trusted_activities_client.get_all("DOMAIN", 1)
-        mock_trusted_activities_service.get_all.assert_called_once_with(
-            "DOMAIN", 1
-        )
+        mock_trusted_activities_service.get_all.assert_called_once_with("DOMAIN", 1)
 
     def test_create_calls_service_with_expected_params(
         self, mock_trusted_activities_service

--- a/tests/services/test_trustedactivities.py
+++ b/tests/services/test_trustedactivities.py
@@ -1,0 +1,233 @@
+import json
+
+import pytest
+
+from py42.exceptions import Py42BadRequestError, Py42DescriptionLimitExceededError, \
+    Py42HTTPError, Py42TrustedActivityConflictError, \
+    Py42TrustedActivityInvalidCharacterError, Py42TrustedActivityInvalidChangeError
+from py42.services.trustedactivities import TrustedActivitiesService
+from tests.conftest import create_mock_response, create_mock_error
+
+GET_TRUSTED_ACTIVITY_RESPONSE = {
+  "description": "test description",
+  "resourceId": "456",
+  "type": "DOMAIN",
+  "updatedAt": "2021-09-13T15:36:59.743Z",
+  "updatedByUserUid": "user uid",
+  "updatedByUsername": "username",
+  "value": "domain.com"
+}
+
+_TEST_TRUSTED_ACTIVITY_RESOURCE_ID = 123
+_BASE_URI = "/api/v1/trusted-activities"
+_DESCRIPTION_TOO_LONG_ERROR_MSG = '{"problem":"DESCRIPTION_TOO_LONG","description":null}'
+_CONFLICT_ERROR_MSG = '{"problem":"CONFLICT","description":null}'
+_INVALID_CHANGE_ERROR_MSG = '{"problem":"INVALID_CHANGE","description":null}'
+_INVALID_CHARACTER_ERROR_MSG = '{"problem":"INVALID_CHARACTERS_IN_VALUE","description":null}'
+
+
+@pytest.fixture
+def mock_get_response(mocker):
+    data = json.dumps(GET_TRUSTED_ACTIVITY_RESPONSE)
+    response = create_mock_response(mocker, data)
+    return response
+
+
+@pytest.fixture
+def mock_long_description_error(mocker):
+    return create_mock_error(Py42BadRequestError, mocker, _DESCRIPTION_TOO_LONG_ERROR_MSG)
+
+
+@pytest.fixture
+def mock_conflict_error(mocker):
+    return create_mock_error(Py42HTTPError, mocker, _CONFLICT_ERROR_MSG)
+
+
+@pytest.fixture
+def mock_invalid_change_error(mocker):
+    return create_mock_error(Py42BadRequestError, mocker, _INVALID_CHANGE_ERROR_MSG)
+
+
+@pytest.fixture
+def mock_invalid_character_error(mocker):
+    return create_mock_error(Py42BadRequestError, mocker, _INVALID_CHARACTER_ERROR_MSG)
+
+
+class TestTrustedActivitiesService:
+
+    def test_create_called_with_expected_url_and_params(self, mock_connection):
+        trusted_activities_service = TrustedActivitiesService(mock_connection)
+        trusted_activities_service.create(
+            "DOMAIN",
+            "test.com",
+        )
+        assert mock_connection.post.call_args[0][0] == _BASE_URI
+        data = {
+            "type": "DOMAIN",
+            "value": "test.com",
+            "description": None,
+        }
+        mock_connection.post.assert_called_once_with(_BASE_URI, json=data)
+
+    def test_create_called_with_expected_url_and_optional_params(self, mock_connection):
+        trusted_activities_service = TrustedActivitiesService(mock_connection)
+        trusted_activities_service.create(
+            "DOMAIN",
+            "test.com",
+            "description"
+        )
+        assert mock_connection.post.call_args[0][0] == _BASE_URI
+        data = {
+            "type": "DOMAIN",
+            "value": "test.com",
+            "description": "description",
+        }
+        mock_connection.post.assert_called_once_with(_BASE_URI, json=data)
+
+    def test_create_when_fails_with_name_conflict_error_raises_custom_exception(self, mock_connection, mock_conflict_error):
+        trusted_activities_service = TrustedActivitiesService(mock_connection)
+        mock_connection.post.side_effect = mock_conflict_error
+        with pytest.raises(Py42TrustedActivityConflictError) as err:
+            trusted_activities_service.create("DOMAIN", "duplicate-name")
+
+        assert (
+            err.value.args[0]
+            == (
+                "Duplicate URL or workspace name, 'duplicate-name' already exists on your trusted list.  "
+                "Please enter a unique value"
+            )
+        )
+
+    def test_create_when_fails_with_description_too_long_error_raises_custom_exception(self, mock_connection, mock_long_description_error):
+        trusted_activities_service = TrustedActivitiesService(mock_connection)
+        mock_connection.post.side_effect = mock_long_description_error
+        with pytest.raises(Py42DescriptionLimitExceededError) as err:
+            trusted_activities_service.create("DOMAIN", "name",
+                                              description="supposedly too long")
+
+        assert (
+            err.value.args[0]
+            == "Description limit exceeded, max 250 characters allowed."
+        )
+
+    def test_create_when_fails_with_invalid_character_error_raises_custom_exception(self, mock_connection, mock_invalid_character_error):
+        trusted_activities_service = TrustedActivitiesService(mock_connection)
+        mock_connection.post.side_effect = mock_invalid_character_error
+        with pytest.raises(Py42TrustedActivityInvalidCharacterError) as err:
+            trusted_activities_service.create("DOMAIN", "bad@name")
+
+        assert (
+            err.value.args[0]
+            == "Domain name cannot include @"
+        )
+
+    def test_get_all_called_with_expected_url_and_params(self, mock_connection):
+        trusted_activities_service = TrustedActivitiesService(mock_connection)
+        trusted_activities_service.get_all()
+        assert mock_connection.get.call_args[0][0] == _BASE_URI
+        data = {"type": None}
+        mock_connection.get.assert_called_once_with(_BASE_URI, params=data)
+
+    def test_get_all_called_with_expected_url_and_all_optional_params(self, mock_connection):
+        trusted_activities_service = TrustedActivitiesService(mock_connection)
+        trusted_activities_service.get_all("DOMAIN")
+        assert mock_connection.get.call_args[0][0] == _BASE_URI
+        data = {"type": "DOMAIN"}
+        mock_connection.get.assert_called_once_with(_BASE_URI, params=data)
+
+    def test_get_called_with_expected_url_and_params(self, mock_connection):
+        trusted_activities_service = TrustedActivitiesService(mock_connection)
+        trusted_activities_service.get(_TEST_TRUSTED_ACTIVITY_RESOURCE_ID)
+        expected_url = f"{_BASE_URI}/{_TEST_TRUSTED_ACTIVITY_RESOURCE_ID}"
+        assert mock_connection.get.call_args[0][0] == expected_url
+        mock_connection.get.assert_called_once_with(expected_url)
+
+    def test_update_called_with_expected_url_and_params(self, mock_connection, mock_get_response):
+        trusted_activities_service = TrustedActivitiesService(mock_connection)
+        mock_connection.get.return_value = mock_get_response
+        trusted_activities_service.update(
+            _TEST_TRUSTED_ACTIVITY_RESOURCE_ID,
+        )
+        expected_url = f"{_BASE_URI}/{_TEST_TRUSTED_ACTIVITY_RESOURCE_ID}"
+        assert mock_connection.put.call_args[0][0] == expected_url
+        data = {
+            "type": "DOMAIN",
+            "value": "domain.com",
+            "description": "test description",
+        }
+        mock_connection.put.assert_called_once_with(expected_url, json=data)
+
+    def test_update_called_with_expected_url_and_optional_params(self, mock_connection):
+        trusted_activities_service = TrustedActivitiesService(mock_connection)
+        trusted_activities_service.update(
+            _TEST_TRUSTED_ACTIVITY_RESOURCE_ID,
+            "DOMAIN",
+            "test.com",
+            "description"
+        )
+        expected_url = f"{_BASE_URI}/{_TEST_TRUSTED_ACTIVITY_RESOURCE_ID}"
+        assert mock_connection.put.call_args[0][0] == expected_url
+        data = {
+            "type": "DOMAIN",
+            "value": "test.com",
+            "description": "description",
+        }
+        mock_connection.put.assert_called_once_with(expected_url, json=data)
+
+    def test_update_when_fails_with_name_conflict_error_raises_custom_exception(self, mock_connection, mock_conflict_error, mock_get_response):
+        trusted_activities_service = TrustedActivitiesService(mock_connection)
+        mock_connection.get.return_value = mock_get_response
+        mock_connection.put.side_effect = mock_conflict_error
+        with pytest.raises(Py42TrustedActivityConflictError) as err:
+            trusted_activities_service.update(_TEST_TRUSTED_ACTIVITY_RESOURCE_ID, value="duplicate-name")
+
+        assert (
+            err.value.args[0]
+            == (
+                "Duplicate URL or workspace name, 'duplicate-name' already exists on your trusted list.  "
+                "Please enter a unique value"
+            )
+        )
+
+    def test_update_when_fails_with_description_too_long_error_raises_custom_exception(self, mock_connection, mock_get_response, mock_long_description_error):
+        trusted_activities_service = TrustedActivitiesService(mock_connection)
+        mock_connection.get.return_value = mock_get_response
+        mock_connection.put.side_effect = mock_long_description_error
+        with pytest.raises(Py42DescriptionLimitExceededError) as err:
+            trusted_activities_service.update(_TEST_TRUSTED_ACTIVITY_RESOURCE_ID, description="supposedly too long")
+
+        assert (
+            err.value.args[0]
+            == "Description limit exceeded, max 250 characters allowed."
+        )
+
+    def test_update_when_fails_with_invalid_character_error_raises_custom_exception(self, mock_connection, mock_get_response, mock_invalid_character_error):
+        trusted_activities_service = TrustedActivitiesService(mock_connection)
+        mock_connection.get.return_value = mock_get_response
+        mock_connection.put.side_effect = mock_invalid_character_error
+        with pytest.raises(Py42TrustedActivityInvalidCharacterError) as err:
+            trusted_activities_service.update(_TEST_TRUSTED_ACTIVITY_RESOURCE_ID, value="bad@name")
+
+        assert (
+            err.value.args[0]
+            == "Domain name cannot include @"
+        )
+
+    def test_update_when_fails_with_invalid_change_error_raises_custom_exception(self, mock_connection, mock_get_response, mock_invalid_change_error):
+        trusted_activities_service = TrustedActivitiesService(mock_connection)
+        mock_connection.get.return_value = mock_get_response
+        mock_connection.put.side_effect = mock_invalid_change_error
+        with pytest.raises(Py42TrustedActivityInvalidChangeError) as err:
+            trusted_activities_service.update(_TEST_TRUSTED_ACTIVITY_RESOURCE_ID, type="SLACK")
+
+        assert (
+            err.value.args[0]
+            == "Invalid change to trusted activity. Trusted activity type cannot be changed."
+        )
+
+    def test_delete_called_with_expected_url_and_params(self, mock_connection):
+        trusted_activities_service = TrustedActivitiesService(mock_connection)
+        trusted_activities_service.delete(_TEST_TRUSTED_ACTIVITY_RESOURCE_ID)
+        expected_url = f"{_BASE_URI}/{_TEST_TRUSTED_ACTIVITY_RESOURCE_ID}"
+        assert mock_connection.delete.call_args[0][0] == expected_url
+        mock_connection.delete.assert_called_once_with(expected_url)

--- a/tests/services/test_trustedactivities.py
+++ b/tests/services/test_trustedactivities.py
@@ -1,11 +1,10 @@
 import json
 
 import pytest
-
-import py42.settings
 from tests.conftest import create_mock_error
 from tests.conftest import create_mock_response
 
+import py42.settings
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42DescriptionLimitExceededError
 from py42.exceptions import Py42HTTPError
@@ -155,11 +154,11 @@ class TestTrustedActivitiesService:
         assert mock_connection.get.call_count == 2
         py42.settings.items_per_page = 500
 
-    def test_get_all_called_with_expected_url_and_params(self, mock_connection, mock_get_all_response):
+    def test_get_all_called_with_expected_url_and_params(
+        self, mock_connection, mock_get_all_response
+    ):
         trusted_activities_service = TrustedActivitiesService(mock_connection)
-        mock_connection.get.side_effect = [
-            mock_get_all_response
-        ]
+        mock_connection.get.side_effect = [mock_get_all_response]
 
         for _ in trusted_activities_service.get_all():
             pass

--- a/tests/services/test_trustedactivities.py
+++ b/tests/services/test_trustedactivities.py
@@ -98,7 +98,7 @@ class TestTrustedActivitiesService:
 
         assert err.value.args[0] == (
             "Duplicate URL or workspace name, 'duplicate-name' already exists on your trusted list.  "
-            "Please enter a unique value"
+            "Please provide a unique value"
         )
 
     def test_create_when_fails_with_description_too_long_error_raises_custom_exception(
@@ -124,7 +124,7 @@ class TestTrustedActivitiesService:
         with pytest.raises(Py42TrustedActivityInvalidCharacterError) as err:
             trusted_activities_service.create("DOMAIN", "bad@name")
 
-        assert err.value.args[0] == "Domain name cannot include @"
+        assert err.value.args[0] == "Invalid character in domain or slack workspace name"
 
     def test_get_all_called_with_expected_url_and_params(self, mock_connection):
         trusted_activities_service = TrustedActivitiesService(mock_connection)
@@ -191,7 +191,7 @@ class TestTrustedActivitiesService:
 
         assert err.value.args[0] == (
             "Duplicate URL or workspace name, 'duplicate-name' already exists on your trusted list.  "
-            "Please enter a unique value"
+            "Please provide a unique value"
         )
 
     def test_update_when_fails_with_description_too_long_error_raises_custom_exception(
@@ -221,7 +221,7 @@ class TestTrustedActivitiesService:
                 _TEST_TRUSTED_ACTIVITY_RESOURCE_ID, value="bad@name"
             )
 
-        assert err.value.args[0] == "Domain name cannot include @"
+        assert err.value.args[0] == "Invalid character in domain or slack workspace name"
 
     def test_update_when_fails_with_invalid_change_error_raises_custom_exception(
         self, mock_connection, mock_get_response, mock_invalid_change_error

--- a/tests/services/test_trustedactivities.py
+++ b/tests/services/test_trustedactivities.py
@@ -8,7 +8,6 @@ from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42DescriptionLimitExceededError
 from py42.exceptions import Py42HTTPError
 from py42.exceptions import Py42TrustedActivityConflictError
-from py42.exceptions import Py42TrustedActivityInvalidChangeError
 from py42.exceptions import Py42TrustedActivityInvalidCharacterError
 from py42.services.trustedactivities import TrustedActivitiesService
 
@@ -124,7 +123,9 @@ class TestTrustedActivitiesService:
         with pytest.raises(Py42TrustedActivityInvalidCharacterError) as err:
             trusted_activities_service.create("DOMAIN", "bad@name")
 
-        assert err.value.args[0] == "Invalid character in domain or slack workspace name"
+        assert (
+            err.value.args[0] == "Invalid character in domain or slack workspace name"
+        )
 
     def test_get_all_called_with_expected_url_and_params(self, mock_connection):
         trusted_activities_service = TrustedActivitiesService(mock_connection)
@@ -154,7 +155,7 @@ class TestTrustedActivitiesService:
     ):
         trusted_activities_service = TrustedActivitiesService(mock_connection)
         mock_connection.get.return_value = mock_get_response
-        trusted_activities_service.update(_TEST_TRUSTED_ACTIVITY_RESOURCE_ID,)
+        trusted_activities_service.update(_TEST_TRUSTED_ACTIVITY_RESOURCE_ID)
         expected_url = f"{_BASE_URI}/{_TEST_TRUSTED_ACTIVITY_RESOURCE_ID}"
         assert mock_connection.put.call_args[0][0] == expected_url
         data = {
@@ -164,10 +165,11 @@ class TestTrustedActivitiesService:
         }
         mock_connection.put.assert_called_once_with(expected_url, json=data)
 
-    def test_update_called_with_expected_url_and_optional_params(self, mock_connection):
+    def test_update_called_with_expected_url_and_optional_params(self, mock_connection, mock_get_response):
         trusted_activities_service = TrustedActivitiesService(mock_connection)
+        mock_connection.get.return_value = mock_get_response
         trusted_activities_service.update(
-            _TEST_TRUSTED_ACTIVITY_RESOURCE_ID, "DOMAIN", "test.com", "description"
+            _TEST_TRUSTED_ACTIVITY_RESOURCE_ID, "test.com", "description"
         )
         expected_url = f"{_BASE_URI}/{_TEST_TRUSTED_ACTIVITY_RESOURCE_ID}"
         assert mock_connection.put.call_args[0][0] == expected_url
@@ -221,22 +223,8 @@ class TestTrustedActivitiesService:
                 _TEST_TRUSTED_ACTIVITY_RESOURCE_ID, value="bad@name"
             )
 
-        assert err.value.args[0] == "Invalid character in domain or slack workspace name"
-
-    def test_update_when_fails_with_invalid_change_error_raises_custom_exception(
-        self, mock_connection, mock_get_response, mock_invalid_change_error
-    ):
-        trusted_activities_service = TrustedActivitiesService(mock_connection)
-        mock_connection.get.return_value = mock_get_response
-        mock_connection.put.side_effect = mock_invalid_change_error
-        with pytest.raises(Py42TrustedActivityInvalidChangeError) as err:
-            trusted_activities_service.update(
-                _TEST_TRUSTED_ACTIVITY_RESOURCE_ID, type="SLACK"
-            )
-
         assert (
-            err.value.args[0]
-            == "Invalid change to trusted activity. Trusted activity type cannot be changed."
+            err.value.args[0] == "Invalid character in domain or slack workspace name"
         )
 
     def test_delete_called_with_expected_url_and_params(self, mock_connection):

--- a/tests/services/test_trustedactivities.py
+++ b/tests/services/test_trustedactivities.py
@@ -1,29 +1,37 @@
 import json
 
 import pytest
+from tests.conftest import create_mock_error
+from tests.conftest import create_mock_response
 
-from py42.exceptions import Py42BadRequestError, Py42DescriptionLimitExceededError, \
-    Py42HTTPError, Py42TrustedActivityConflictError, \
-    Py42TrustedActivityInvalidCharacterError, Py42TrustedActivityInvalidChangeError
+from py42.exceptions import Py42BadRequestError
+from py42.exceptions import Py42DescriptionLimitExceededError
+from py42.exceptions import Py42HTTPError
+from py42.exceptions import Py42TrustedActivityConflictError
+from py42.exceptions import Py42TrustedActivityInvalidChangeError
+from py42.exceptions import Py42TrustedActivityInvalidCharacterError
 from py42.services.trustedactivities import TrustedActivitiesService
-from tests.conftest import create_mock_response, create_mock_error
 
 GET_TRUSTED_ACTIVITY_RESPONSE = {
-  "description": "test description",
-  "resourceId": "456",
-  "type": "DOMAIN",
-  "updatedAt": "2021-09-13T15:36:59.743Z",
-  "updatedByUserUid": "user uid",
-  "updatedByUsername": "username",
-  "value": "domain.com"
+    "description": "test description",
+    "resourceId": "456",
+    "type": "DOMAIN",
+    "updatedAt": "2021-09-13T15:36:59.743Z",
+    "updatedByUserUid": "user uid",
+    "updatedByUsername": "username",
+    "value": "domain.com",
 }
 
 _TEST_TRUSTED_ACTIVITY_RESOURCE_ID = 123
 _BASE_URI = "/api/v1/trusted-activities"
-_DESCRIPTION_TOO_LONG_ERROR_MSG = '{"problem":"DESCRIPTION_TOO_LONG","description":null}'
+_DESCRIPTION_TOO_LONG_ERROR_MSG = (
+    '{"problem":"DESCRIPTION_TOO_LONG","description":null}'
+)
 _CONFLICT_ERROR_MSG = '{"problem":"CONFLICT","description":null}'
 _INVALID_CHANGE_ERROR_MSG = '{"problem":"INVALID_CHANGE","description":null}'
-_INVALID_CHARACTER_ERROR_MSG = '{"problem":"INVALID_CHARACTERS_IN_VALUE","description":null}'
+_INVALID_CHARACTER_ERROR_MSG = (
+    '{"problem":"INVALID_CHARACTERS_IN_VALUE","description":null}'
+)
 
 
 @pytest.fixture
@@ -35,7 +43,9 @@ def mock_get_response(mocker):
 
 @pytest.fixture
 def mock_long_description_error(mocker):
-    return create_mock_error(Py42BadRequestError, mocker, _DESCRIPTION_TOO_LONG_ERROR_MSG)
+    return create_mock_error(
+        Py42BadRequestError, mocker, _DESCRIPTION_TOO_LONG_ERROR_MSG
+    )
 
 
 @pytest.fixture
@@ -54,12 +64,10 @@ def mock_invalid_character_error(mocker):
 
 
 class TestTrustedActivitiesService:
-
     def test_create_called_with_expected_url_and_params(self, mock_connection):
         trusted_activities_service = TrustedActivitiesService(mock_connection)
         trusted_activities_service.create(
-            "DOMAIN",
-            "test.com",
+            "DOMAIN", "test.com",
         )
         assert mock_connection.post.call_args[0][0] == _BASE_URI
         data = {
@@ -71,11 +79,7 @@ class TestTrustedActivitiesService:
 
     def test_create_called_with_expected_url_and_optional_params(self, mock_connection):
         trusted_activities_service = TrustedActivitiesService(mock_connection)
-        trusted_activities_service.create(
-            "DOMAIN",
-            "test.com",
-            "description"
-        )
+        trusted_activities_service.create("DOMAIN", "test.com", "description")
         assert mock_connection.post.call_args[0][0] == _BASE_URI
         data = {
             "type": "DOMAIN",
@@ -84,42 +88,43 @@ class TestTrustedActivitiesService:
         }
         mock_connection.post.assert_called_once_with(_BASE_URI, json=data)
 
-    def test_create_when_fails_with_name_conflict_error_raises_custom_exception(self, mock_connection, mock_conflict_error):
+    def test_create_when_fails_with_name_conflict_error_raises_custom_exception(
+        self, mock_connection, mock_conflict_error
+    ):
         trusted_activities_service = TrustedActivitiesService(mock_connection)
         mock_connection.post.side_effect = mock_conflict_error
         with pytest.raises(Py42TrustedActivityConflictError) as err:
             trusted_activities_service.create("DOMAIN", "duplicate-name")
 
-        assert (
-            err.value.args[0]
-            == (
-                "Duplicate URL or workspace name, 'duplicate-name' already exists on your trusted list.  "
-                "Please enter a unique value"
-            )
+        assert err.value.args[0] == (
+            "Duplicate URL or workspace name, 'duplicate-name' already exists on your trusted list.  "
+            "Please enter a unique value"
         )
 
-    def test_create_when_fails_with_description_too_long_error_raises_custom_exception(self, mock_connection, mock_long_description_error):
+    def test_create_when_fails_with_description_too_long_error_raises_custom_exception(
+        self, mock_connection, mock_long_description_error
+    ):
         trusted_activities_service = TrustedActivitiesService(mock_connection)
         mock_connection.post.side_effect = mock_long_description_error
         with pytest.raises(Py42DescriptionLimitExceededError) as err:
-            trusted_activities_service.create("DOMAIN", "name",
-                                              description="supposedly too long")
+            trusted_activities_service.create(
+                "DOMAIN", "name", description="supposedly too long"
+            )
 
         assert (
             err.value.args[0]
             == "Description limit exceeded, max 250 characters allowed."
         )
 
-    def test_create_when_fails_with_invalid_character_error_raises_custom_exception(self, mock_connection, mock_invalid_character_error):
+    def test_create_when_fails_with_invalid_character_error_raises_custom_exception(
+        self, mock_connection, mock_invalid_character_error
+    ):
         trusted_activities_service = TrustedActivitiesService(mock_connection)
         mock_connection.post.side_effect = mock_invalid_character_error
         with pytest.raises(Py42TrustedActivityInvalidCharacterError) as err:
             trusted_activities_service.create("DOMAIN", "bad@name")
 
-        assert (
-            err.value.args[0]
-            == "Domain name cannot include @"
-        )
+        assert err.value.args[0] == "Domain name cannot include @"
 
     def test_get_all_called_with_expected_url_and_params(self, mock_connection):
         trusted_activities_service = TrustedActivitiesService(mock_connection)
@@ -128,7 +133,9 @@ class TestTrustedActivitiesService:
         data = {"type": None}
         mock_connection.get.assert_called_once_with(_BASE_URI, params=data)
 
-    def test_get_all_called_with_expected_url_and_all_optional_params(self, mock_connection):
+    def test_get_all_called_with_expected_url_and_all_optional_params(
+        self, mock_connection
+    ):
         trusted_activities_service = TrustedActivitiesService(mock_connection)
         trusted_activities_service.get_all("DOMAIN")
         assert mock_connection.get.call_args[0][0] == _BASE_URI
@@ -142,12 +149,12 @@ class TestTrustedActivitiesService:
         assert mock_connection.get.call_args[0][0] == expected_url
         mock_connection.get.assert_called_once_with(expected_url)
 
-    def test_update_called_with_expected_url_and_params(self, mock_connection, mock_get_response):
+    def test_update_called_with_expected_url_and_params(
+        self, mock_connection, mock_get_response
+    ):
         trusted_activities_service = TrustedActivitiesService(mock_connection)
         mock_connection.get.return_value = mock_get_response
-        trusted_activities_service.update(
-            _TEST_TRUSTED_ACTIVITY_RESOURCE_ID,
-        )
+        trusted_activities_service.update(_TEST_TRUSTED_ACTIVITY_RESOURCE_ID,)
         expected_url = f"{_BASE_URI}/{_TEST_TRUSTED_ACTIVITY_RESOURCE_ID}"
         assert mock_connection.put.call_args[0][0] == expected_url
         data = {
@@ -160,10 +167,7 @@ class TestTrustedActivitiesService:
     def test_update_called_with_expected_url_and_optional_params(self, mock_connection):
         trusted_activities_service = TrustedActivitiesService(mock_connection)
         trusted_activities_service.update(
-            _TEST_TRUSTED_ACTIVITY_RESOURCE_ID,
-            "DOMAIN",
-            "test.com",
-            "description"
+            _TEST_TRUSTED_ACTIVITY_RESOURCE_ID, "DOMAIN", "test.com", "description"
         )
         expected_url = f"{_BASE_URI}/{_TEST_TRUSTED_ACTIVITY_RESOURCE_ID}"
         assert mock_connection.put.call_args[0][0] == expected_url
@@ -174,51 +178,61 @@ class TestTrustedActivitiesService:
         }
         mock_connection.put.assert_called_once_with(expected_url, json=data)
 
-    def test_update_when_fails_with_name_conflict_error_raises_custom_exception(self, mock_connection, mock_conflict_error, mock_get_response):
+    def test_update_when_fails_with_name_conflict_error_raises_custom_exception(
+        self, mock_connection, mock_conflict_error, mock_get_response
+    ):
         trusted_activities_service = TrustedActivitiesService(mock_connection)
         mock_connection.get.return_value = mock_get_response
         mock_connection.put.side_effect = mock_conflict_error
         with pytest.raises(Py42TrustedActivityConflictError) as err:
-            trusted_activities_service.update(_TEST_TRUSTED_ACTIVITY_RESOURCE_ID, value="duplicate-name")
-
-        assert (
-            err.value.args[0]
-            == (
-                "Duplicate URL or workspace name, 'duplicate-name' already exists on your trusted list.  "
-                "Please enter a unique value"
+            trusted_activities_service.update(
+                _TEST_TRUSTED_ACTIVITY_RESOURCE_ID, value="duplicate-name"
             )
+
+        assert err.value.args[0] == (
+            "Duplicate URL or workspace name, 'duplicate-name' already exists on your trusted list.  "
+            "Please enter a unique value"
         )
 
-    def test_update_when_fails_with_description_too_long_error_raises_custom_exception(self, mock_connection, mock_get_response, mock_long_description_error):
+    def test_update_when_fails_with_description_too_long_error_raises_custom_exception(
+        self, mock_connection, mock_get_response, mock_long_description_error
+    ):
         trusted_activities_service = TrustedActivitiesService(mock_connection)
         mock_connection.get.return_value = mock_get_response
         mock_connection.put.side_effect = mock_long_description_error
         with pytest.raises(Py42DescriptionLimitExceededError) as err:
-            trusted_activities_service.update(_TEST_TRUSTED_ACTIVITY_RESOURCE_ID, description="supposedly too long")
+            trusted_activities_service.update(
+                _TEST_TRUSTED_ACTIVITY_RESOURCE_ID, description="supposedly too long"
+            )
 
         assert (
             err.value.args[0]
             == "Description limit exceeded, max 250 characters allowed."
         )
 
-    def test_update_when_fails_with_invalid_character_error_raises_custom_exception(self, mock_connection, mock_get_response, mock_invalid_character_error):
+    def test_update_when_fails_with_invalid_character_error_raises_custom_exception(
+        self, mock_connection, mock_get_response, mock_invalid_character_error
+    ):
         trusted_activities_service = TrustedActivitiesService(mock_connection)
         mock_connection.get.return_value = mock_get_response
         mock_connection.put.side_effect = mock_invalid_character_error
         with pytest.raises(Py42TrustedActivityInvalidCharacterError) as err:
-            trusted_activities_service.update(_TEST_TRUSTED_ACTIVITY_RESOURCE_ID, value="bad@name")
+            trusted_activities_service.update(
+                _TEST_TRUSTED_ACTIVITY_RESOURCE_ID, value="bad@name"
+            )
 
-        assert (
-            err.value.args[0]
-            == "Domain name cannot include @"
-        )
+        assert err.value.args[0] == "Domain name cannot include @"
 
-    def test_update_when_fails_with_invalid_change_error_raises_custom_exception(self, mock_connection, mock_get_response, mock_invalid_change_error):
+    def test_update_when_fails_with_invalid_change_error_raises_custom_exception(
+        self, mock_connection, mock_get_response, mock_invalid_change_error
+    ):
         trusted_activities_service = TrustedActivitiesService(mock_connection)
         mock_connection.get.return_value = mock_get_response
         mock_connection.put.side_effect = mock_invalid_change_error
         with pytest.raises(Py42TrustedActivityInvalidChangeError) as err:
-            trusted_activities_service.update(_TEST_TRUSTED_ACTIVITY_RESOURCE_ID, type="SLACK")
+            trusted_activities_service.update(
+                _TEST_TRUSTED_ACTIVITY_RESOURCE_ID, type="SLACK"
+            )
 
         assert (
             err.value.args[0]

--- a/tests/services/test_trustedactivities.py
+++ b/tests/services/test_trustedactivities.py
@@ -165,7 +165,9 @@ class TestTrustedActivitiesService:
         }
         mock_connection.put.assert_called_once_with(expected_url, json=data)
 
-    def test_update_called_with_expected_url_and_optional_params(self, mock_connection, mock_get_response):
+    def test_update_called_with_expected_url_and_optional_params(
+        self, mock_connection, mock_get_response
+    ):
         trusted_activities_service = TrustedActivitiesService(mock_connection)
         mock_connection.get.return_value = mock_get_response
         trusted_activities_service.update(


### PR DESCRIPTION
### Description of Change ###

- New `trustedactivities` client with the following new methods:
    - `sdk.trustedactivities.get_all()` to get all trusted activities.
    - `sdk.trustedactivities.create()` to create a new trusted activity.
    - `sdk.trustedactivities.get()` to get details about a single trusted activity.
    - `sdk.trustedactivities.update()` to update a trusted activity.
    - `sdk.trustedactivities.delete()` to delete a trusted activity

- New custom exceptions
    - `Py42TrustedActivityInvalidChangeError`
    - `Py42TrustedActivityConflictError`
    - `Py42TrustedActivityInvalidCharacterError`

### Testing Procedure ###
Users should be able to use the py42 sdk methods of the `trustedactivities` client to hit the corresponding API endpoints to add, update, delete, and retrieve trusted activity details.  Currently the two types of activity supported are `DOMAIN` (urls) and `SLACK` (slack workspaces).  

Unit tests for the client and services can be found in `tests/clients/test_trustedactivities.py` and `tests/clients/test_trustedactivities.py`, respectively.  A separate story specifies adding integration tests and adding the service to the mock-servers.

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
