### PR TITLE
Chore/trust integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
           127.0.0.1 exfiltration-data-service
           127.0.0.1 connected-server
           127.0.0.1 cases
+          127.0.0.1 trusted-activities-service
           EOF
       - name: Start up the mock servers
         run: cd code42-mock-servers; docker-compose up -d --build

--- a/tests/integration/test_trustedactivites.py
+++ b/tests/integration/test_trustedactivites.py
@@ -16,6 +16,14 @@ class TestTrustedActivities:
             assert_successful_response(response)
             break
 
+    def test_get_all_trusted_activities_with_optional_params(
+        self, connection,
+    ):
+        page_gen = connection.trustedactivities.get_all(type="DOMAIN", page_size=1)
+        for response in page_gen:
+            assert_successful_response(response)
+            break
+
     def test_get_trusted_activity(self, connection, trusted_activity):
         response = connection.trustedactivities.get(trusted_activity["resourceId"])
         assert_successful_response(response)

--- a/tests/integration/test_trustedactivites.py
+++ b/tests/integration/test_trustedactivites.py
@@ -1,0 +1,28 @@
+import pytest
+from tests.integration.conftest import assert_successful_response
+
+
+@pytest.mark.integration
+class TestTrustedActivities:
+    @pytest.fixture(scope="module")
+    # def trusted_activity(self, connection):
+    #     return connection.trustedactivities.create("DOMAIN", 'test.com')
+    #
+    # def test_get_all_trusted_activities(
+    #     self, connection,
+    # ):
+    #     page_gen = connection.trustedactivites.get_all()
+    #     for response in page_gen:
+    #         assert_successful_response(response)
+    #         break
+    def test_get_trusted_activity(self, connection, trusted_activity):
+        response = connection.cases.get(trusted_activity["resourceId"])
+        assert_successful_response(response)
+
+    # def test_update_trusted_activity(self, connection, trusted_activity):
+    #     response = connection.trustedactivities.update(trusted_activity["resourceId"], description="integration test case")
+    #     assert_successful_response(response)
+    #
+    # def test_delete_trusted_activity(self, connection, trusted_activity):
+    #     response = connection.trustedactivities.delete(trusted_activity["resourceId"])
+    #     assert_successful_response(response)

--- a/tests/integration/test_trustedactivites.py
+++ b/tests/integration/test_trustedactivites.py
@@ -5,24 +5,27 @@ from tests.integration.conftest import assert_successful_response
 @pytest.mark.integration
 class TestTrustedActivities:
     @pytest.fixture(scope="module")
-    # def trusted_activity(self, connection):
-    #     return connection.trustedactivities.create("DOMAIN", 'test.com')
-    #
-    # def test_get_all_trusted_activities(
-    #     self, connection,
-    # ):
-    #     page_gen = connection.trustedactivites.get_all()
-    #     for response in page_gen:
-    #         assert_successful_response(response)
-    #         break
+    def trusted_activity(self, connection):
+        return connection.trustedactivities.create("DOMAIN", "test.com")
+
+    def test_get_all_trusted_activities(
+        self, connection,
+    ):
+        page_gen = connection.trustedactivities.get_all()
+        for response in page_gen:
+            assert_successful_response(response)
+            break
+
     def test_get_trusted_activity(self, connection, trusted_activity):
-        response = connection.cases.get(trusted_activity["resourceId"])
+        response = connection.trustedactivities.get(trusted_activity["resourceId"])
         assert_successful_response(response)
 
-    # def test_update_trusted_activity(self, connection, trusted_activity):
-    #     response = connection.trustedactivities.update(trusted_activity["resourceId"], description="integration test case")
-    #     assert_successful_response(response)
-    #
-    # def test_delete_trusted_activity(self, connection, trusted_activity):
-    #     response = connection.trustedactivities.delete(trusted_activity["resourceId"])
-    #     assert_successful_response(response)
+    def test_update_trusted_activity(self, connection, trusted_activity):
+        response = connection.trustedactivities.update(
+            trusted_activity["resourceId"], description="integration test case"
+        )
+        assert_successful_response(response)
+
+    def test_delete_trusted_activity(self, connection, trusted_activity):
+        response = connection.trustedactivities.delete(trusted_activity["resourceId"])
+        assert_successful_response(response)


### PR DESCRIPTION
### Description of Change ###

Added integration tests for the `trusted-activities` service endpoints

### Testing Procedure ###
Tests will not pass until the mock-servers PR which adds the trusted-activities service is merged

### PR Checklist ###
Did you remember to do the below?

- [NA] Add unit tests to verify this change
- [NA] Add an entry to CHANGELOG.md describing this change
- [NA] Add docstrings for any new public parameters / methods / classes
