### PR TITLE
additional error handling for trusted activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
     - `Py42TrustedActivityInvalidChangeError`
     - `Py42TrustedActivityConflictError`
     - `Py42TrustedActivityInvalidCharacterError`
+    - `Py42TrustedActivityIdNotFound`
+
+- New custom `HTTP 409 error` wrapper class `Py42ConflictError`
 
 ### Fixed
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -124,6 +124,10 @@ class Py42NotFoundError(Py42HTTPError):
     """A wrapper to represent an HTTP 404 error."""
 
 
+class Py42ConflictError(Py42HTTPError):
+    """A wrapper to represent an HTTP 409 error."""
+
+
 class Py42InternalServerError(Py42HTTPError):
     """A wrapper to represent an HTTP 500 error."""
 
@@ -345,7 +349,7 @@ class Py42TrustedActivityInvalidChangeError(Py42BadRequestError):
         super().__init__(exception, msg)
 
 
-class Py42TrustedActivityConflictError(Py42HTTPError):
+class Py42TrustedActivityConflictError(Py42ConflictError):
     """An error raised when theres a conflict with a trusted activity domain URL."""
 
     def __init__(self, exception, value):
@@ -364,6 +368,14 @@ class Py42TrustedActivityInvalidCharacterError(Py42BadRequestError):
         super().__init__(exception, msg)
 
 
+class Py42TrustedActivityIdNotFound(Py42NotFoundError):
+    """An exception raised when the trusted activity ID does not exist."""
+
+    def __init__(self, exception, resource_id):
+        message = f"Resource ID '{resource_id}' not found."
+        super(Py42NotFoundError, self).__init__(exception, message)
+
+
 def raise_py42_error(raised_error):
     """Raises the appropriate :class:`py42.exceptions.Py42HttpError` based on the given
     HTTPError's response status code.
@@ -376,6 +388,8 @@ def raise_py42_error(raised_error):
         raise Py42ForbiddenError(raised_error)
     elif raised_error.response.status_code == 404:
         raise Py42NotFoundError(raised_error)
+    elif raised_error.response.status_code == 409:
+        raise Py42ConflictError(raised_error)
     elif raised_error.response.status_code == 429:
         raise Py42TooManyRequestsError(raised_error)
     elif 500 <= raised_error.response.status_code < 600:

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -361,7 +361,7 @@ class Py42TrustedActivityConflictError(Py42ConflictError):
 
 
 class Py42TrustedActivityInvalidCharacterError(Py42BadRequestError):
-    """An error raised when an invalid change is being made to a trusted activity."""
+    """An error raised when an invalid character is in a trusted activity value."""
 
     def __init__(self, exception):
         msg = "Invalid character in domain or slack workspace name"

--- a/tests/services/test_trustedactivities.py
+++ b/tests/services/test_trustedactivities.py
@@ -6,9 +6,11 @@ from tests.conftest import create_mock_response
 
 import py42.settings
 from py42.exceptions import Py42BadRequestError
+from py42.exceptions import Py42ConflictError
 from py42.exceptions import Py42DescriptionLimitExceededError
-from py42.exceptions import Py42HTTPError
+from py42.exceptions import Py42NotFoundError
 from py42.exceptions import Py42TrustedActivityConflictError
+from py42.exceptions import Py42TrustedActivityIdNotFound
 from py42.exceptions import Py42TrustedActivityInvalidCharacterError
 from py42.services.trustedactivities import TrustedActivitiesService
 
@@ -24,6 +26,7 @@ GET_TRUSTED_ACTIVITY_RESPONSE = {
     "value": "domain.com",
 }
 
+_INVALID_RESOURCE_ID = 0
 _TEST_TRUSTED_ACTIVITY_RESOURCE_ID = 123
 _BASE_URI = "/api/v1/trusted-activities"
 _DESCRIPTION_TOO_LONG_ERROR_MSG = (
@@ -34,6 +37,7 @@ _INVALID_CHANGE_ERROR_MSG = '{"problem":"INVALID_CHANGE","description":null}'
 _INVALID_CHARACTER_ERROR_MSG = (
     '{"problem":"INVALID_CHARACTERS_IN_VALUE","description":null}'
 )
+_RESOURCE_ID_NOT_FOUND_ERROR_MSG = ""
 
 
 @pytest.fixture
@@ -62,7 +66,7 @@ def mock_long_description_error(mocker):
 
 @pytest.fixture
 def mock_conflict_error(mocker):
-    return create_mock_error(Py42HTTPError, mocker, _CONFLICT_ERROR_MSG)
+    return create_mock_error(Py42ConflictError, mocker, _CONFLICT_ERROR_MSG)
 
 
 @pytest.fixture
@@ -73,6 +77,13 @@ def mock_invalid_change_error(mocker):
 @pytest.fixture
 def mock_invalid_character_error(mocker):
     return create_mock_error(Py42BadRequestError, mocker, _INVALID_CHARACTER_ERROR_MSG)
+
+
+@pytest.fixture
+def mock_resource_id_not_found_error(mocker):
+    return create_mock_error(
+        Py42NotFoundError, mocker, _RESOURCE_ID_NOT_FOUND_ERROR_MSG
+    )
 
 
 class TestTrustedActivitiesService:
@@ -197,6 +208,16 @@ class TestTrustedActivitiesService:
         assert mock_connection.get.call_args[0][0] == expected_url
         mock_connection.get.assert_called_once_with(expected_url)
 
+    def test_get_when_fails_with_resource_id_not_found_error_raises_custom_exception(
+        self, mock_connection, mock_resource_id_not_found_error
+    ):
+        trusted_activities_service = TrustedActivitiesService(mock_connection)
+        mock_connection.get.side_effect = mock_resource_id_not_found_error
+        with pytest.raises(Py42TrustedActivityIdNotFound) as err:
+            trusted_activities_service.get(_INVALID_RESOURCE_ID)
+
+        assert err.value.args[0] == f"Resource ID '{_INVALID_RESOURCE_ID}' not found."
+
     def test_update_called_with_expected_url_and_params(
         self, mock_connection, mock_get_response
     ):
@@ -276,9 +297,31 @@ class TestTrustedActivitiesService:
             err.value.args[0] == "Invalid character in domain or slack workspace name"
         )
 
+    def test_update_when_fails_with_resource_id_not_found_error_raises_custom_exception(
+        self, mock_connection, mock_resource_id_not_found_error
+    ):
+        trusted_activities_service = TrustedActivitiesService(mock_connection)
+        mock_connection.put.side_effect = mock_resource_id_not_found_error
+        with pytest.raises(Py42TrustedActivityIdNotFound) as err:
+            trusted_activities_service.update(
+                _INVALID_RESOURCE_ID, description="This id should not be found."
+            )
+
+        assert err.value.args[0] == f"Resource ID '{_INVALID_RESOURCE_ID}' not found."
+
     def test_delete_called_with_expected_url_and_params(self, mock_connection):
         trusted_activities_service = TrustedActivitiesService(mock_connection)
         trusted_activities_service.delete(_TEST_TRUSTED_ACTIVITY_RESOURCE_ID)
         expected_url = f"{_BASE_URI}/{_TEST_TRUSTED_ACTIVITY_RESOURCE_ID}"
         assert mock_connection.delete.call_args[0][0] == expected_url
         mock_connection.delete.assert_called_once_with(expected_url)
+
+    def test_delete_when_fails_with_resource_id_not_found_error_raises_custom_exception(
+        self, mock_connection, mock_resource_id_not_found_error
+    ):
+        trusted_activities_service = TrustedActivitiesService(mock_connection)
+        mock_connection.delete.side_effect = mock_resource_id_not_found_error
+        with pytest.raises(Py42TrustedActivityIdNotFound) as err:
+            trusted_activities_service.delete(_INVALID_RESOURCE_ID)
+
+        assert err.value.args[0] == f"Resource ID '{_INVALID_RESOURCE_ID}' not found."

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -2,6 +2,7 @@ import pytest
 from tests.conftest import REQUEST_EXCEPTION_MESSAGE
 
 from py42.exceptions import Py42BadRequestError
+from py42.exceptions import Py42ConflictError
 from py42.exceptions import Py42ForbiddenError
 from py42.exceptions import Py42HTTPError
 from py42.exceptions import Py42InternalServerError
@@ -33,6 +34,11 @@ class TestPy42Errors:
         with pytest.raises(Py42NotFoundError):
             raise_py42_error(error_response)
 
+    def test_raise_py42_error_raises_conflict_error(self, error_response):
+        error_response.response.status_code = 409
+        with pytest.raises(Py42ConflictError):
+            raise_py42_error(error_response)
+
     def test_raise_py42_error_raises_internal_server_error(self, error_response):
         error_response.response.status_code = 500
         with pytest.raises(Py42InternalServerError):
@@ -48,7 +54,7 @@ class TestPy42Errors:
         with pytest.raises(Py42TooManyRequestsError):
             raise_py42_error(error_response)
 
-    @pytest.mark.parametrize("status_code", [400, 401, 403, 404, 429, 500, 600])
+    @pytest.mark.parametrize("status_code", [400, 401, 403, 404, 409, 429, 500, 600])
     def test_raise_py42_http_error_has_correct_response_type(
         self, error_response, status_code
     ):


### PR DESCRIPTION
### Description of Change ###

Additional custom error handling for the trusted activities service.
- creation of `py42ConflictError` 409 wrapper class
- custom exception `Py42TrustedActivityIdNotFound`

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
