### PR TITLE
Bugfix: get all alert details empty results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
     - `DepartingEmployeeFilters`
     - `HighRiskEmployeeFilters`
 
+### Fixed
+
+- Bug where `sdk.alerts.get_all_alert_details()` was raising error when no alerts were found in query.
+
 ## 1.19.0 - 2021-09-21
 
 ### Added

--- a/src/py42/clients/alerts.py
+++ b/src/py42/clients/alerts.py
@@ -169,4 +169,4 @@ class AlertsClient:
                     reverse=reverse,
                 )
             else:
-                return []  # noqa B901
+                yield from []

--- a/src/py42/clients/alerts.py
+++ b/src/py42/clients/alerts.py
@@ -161,7 +161,10 @@ class AlertsClient:
         pages = self._alert_service.search_all_pages(query)
         for page in pages:
             alert_ids = [alert["id"] for alert in page["alerts"]]
-            alert_details = self._alert_service.get_details(alert_ids)
-            yield from sorted(
-                alert_details["alerts"], key=lambda x: x.get(sort_key), reverse=reverse,
-            )
+            if alert_ids:
+                alert_details = self._alert_service.get_details(alert_ids)
+                yield from sorted(
+                    alert_details["alerts"], key=lambda x: x.get(sort_key), reverse=reverse,
+                )
+            else:
+                return []

--- a/src/py42/clients/alerts.py
+++ b/src/py42/clients/alerts.py
@@ -164,7 +164,9 @@ class AlertsClient:
             if alert_ids:
                 alert_details = self._alert_service.get_details(alert_ids)
                 yield from sorted(
-                    alert_details["alerts"], key=lambda x: x.get(sort_key), reverse=reverse,
+                    alert_details["alerts"],
+                    key=lambda x: x.get(sort_key),
+                    reverse=reverse,
                 )
             else:
-                return []
+                return []  # noqa B901

--- a/tests/clients/test_alerts.py
+++ b/tests/clients/test_alerts.py
@@ -367,23 +367,23 @@ class TestAlertsClient:
         query.sort_key = sort_key
         results = list(alert_client.get_all_alert_details(query))
         assert results == [ALERT_F, ALERT_E, ALERT_D, ALERT_C, ALERT_B, ALERT_A]
-    
+
     def test_alerts_client_get_all_alert_details_returns_empty_generator_when_no_alerts_found(
-        self,
-        mock_alerts_service_with_no_alerts,
-        mock_alert_rules_service
+        self, mock_alerts_service_with_no_alerts, mock_alert_rules_service
     ):
-        alert_client = AlertsClient(mock_alerts_service_with_no_alerts, mock_alert_rules_service)
+        alert_client = AlertsClient(
+            mock_alerts_service_with_no_alerts, mock_alert_rules_service
+        )
         query = AlertQuery()
         results = list(alert_client.get_all_alert_details(query))
         assert results == []
 
     def test_alerts_client_get_all_alert_details_does_not_call_get_details_when_no_alerts_found(
-        self,
-        mock_alerts_service_with_no_alerts,
-        mock_alert_rules_service
+        self, mock_alerts_service_with_no_alerts, mock_alert_rules_service
     ):
-        alert_client = AlertsClient(mock_alerts_service_with_no_alerts, mock_alert_rules_service)
+        alert_client = AlertsClient(
+            mock_alerts_service_with_no_alerts, mock_alert_rules_service
+        )
         query = AlertQuery()
         list(alert_client.get_all_alert_details(query))
         assert mock_alerts_service_with_no_alerts.get_details.call_count == 0


### PR DESCRIPTION
### Description of Change ###

Resolves error raised when `sdk.alerts.get_all_alert_details(query)` resulted in no alerts found. If no alertIds are found in the query, the function makes no calls to `get_details()`.

### Testing Procedure ###
- Construct an AlertQuery which returns no results.
- Pass query to `result = sdk.alerts.get_all_alert_details(query)`
- Iterate over the resulting generator (e.g. `list(result)` `for item in result: print(item)`, `next(result)`)

Expected outcome: 
Iteration results in empty list or no action (depending on how the object was iterated over), no exceptions should be raised.

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [N/A] Add docstrings for any new public parameters / methods / classes
