### PR TITLE
Bugfix: Fixed incorrect API definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Fixed
 
+- Fixed typo in API resource `/api/v1/cases`, which was incorrectly specified as `/api/v1/case`"
 - Decreased `get_all_alert_details` batch size to 25 when retrieving alert queries due to performance concerns.
 
 ## 1.19.1 - 2021-10-12

--- a/src/py42/services/cases.py
+++ b/src/py42/services/cases.py
@@ -10,7 +10,7 @@ from py42.services.util import get_all_pages
 
 class CasesService(BaseService):
 
-    _uri_prefix = "/api/v1/case"
+    _uri_prefix = "/api/v1/cases"
 
     def __init__(self, connection):
         super().__init__(connection)

--- a/src/py42/services/casesfileevents.py
+++ b/src/py42/services/casesfileevents.py
@@ -6,7 +6,7 @@ from py42.services import BaseService
 
 class CasesFileEventsService(BaseService):
 
-    _uri_prefix = "/api/v1/case/{0}/fileevent"
+    _uri_prefix = "/api/v1/cases/{0}/fileevent"
 
     def __init__(self, connection):
         super().__init__(connection)

--- a/tests/services/test_cases.py
+++ b/tests/services/test_cases.py
@@ -41,7 +41,7 @@ NAME_EXISTS_ERROR_MSG = '{"problem":"NAME_EXISTS","description":null}'
 DESCRIPTION_TOO_LONG_ERROR_MSG = '{"problem":"DESCRIPTION_TOO_LONG","description":null}'
 UNKNOWN_ERROR_MSG = '{"problem":"SURPRISE!"}'
 _TEST_CASE_NUMBER = 123456
-_BASE_URI = "/api/v1/case"
+_BASE_URI = "/api/v1/cases"
 
 
 def _get_invalid_user_text(user_type):
@@ -64,7 +64,7 @@ class TestCasesService:
     def test_create_called_with_expected_url_and_params(self, mock_connection):
         cases_service = CasesService(mock_connection)
         cases_service.create("name", "subject", "user uid", "description", "findings")
-        assert mock_connection.post.call_args[0][0] == "/api/v1/case"
+        assert mock_connection.post.call_args[0][0] == "/api/v1/cases"
         data = {
             "name": "name",
             "subject": "subject",
@@ -240,14 +240,14 @@ class TestCasesService:
         cases_service.export_summary(_TEST_CASE_NUMBER)
         assert (
             mock_connection.get.call_args[0][0]
-            == f"/api/v1/case/{_TEST_CASE_NUMBER}/export"
+            == f"/api/v1/cases/{_TEST_CASE_NUMBER}/export"
         )
 
     def test_get_called_with_expected_url_and_params(self, mock_connection):
         cases_service = CasesService(mock_connection)
         cases_service.get(_TEST_CASE_NUMBER)
         assert (
-            mock_connection.get.call_args[0][0] == f"/api/v1/case/{_TEST_CASE_NUMBER}"
+            mock_connection.get.call_args[0][0] == f"/api/v1/cases/{_TEST_CASE_NUMBER}"
         )
 
     def test_update_called_with_expected_url_and_params(
@@ -265,7 +265,7 @@ class TestCasesService:
             "findings": "x",
         }
         mock_connection.put.assert_called_once_with(
-            f"/api/v1/case/{_TEST_CASE_NUMBER}", json=data
+            f"/api/v1/cases/{_TEST_CASE_NUMBER}", json=data
         )
 
     def test_update_when_fails_with_name_exists_error_raises_custom_exception(

--- a/tests/services/test_casesfileevents.py
+++ b/tests/services/test_casesfileevents.py
@@ -18,7 +18,7 @@ class TestCasesFileEventService:
         case_file_event_service.add(_TEST_CASE_NUMBER, "event-id")
         assert (
             mock_connection.post.call_args[0][0]
-            == f"/api/v1/case/{_TEST_CASE_NUMBER}/fileevent/event-id"
+            == f"/api/v1/cases/{_TEST_CASE_NUMBER}/fileevent/event-id"
         )
 
     def test_delete_called_with_expected_url_and_params(self, mock_connection):
@@ -26,7 +26,7 @@ class TestCasesFileEventService:
         case_file_event_service.delete(_TEST_CASE_NUMBER, "event-id")
         assert (
             mock_connection.delete.call_args[0][0]
-            == f"/api/v1/case/{_TEST_CASE_NUMBER}/fileevent/event-id"
+            == f"/api/v1/cases/{_TEST_CASE_NUMBER}/fileevent/event-id"
         )
 
     def test_get_called_with_expected_url_and_params(self, mock_connection):
@@ -34,7 +34,7 @@ class TestCasesFileEventService:
         case_file_event_service.get(_TEST_CASE_NUMBER, "event-id")
         assert (
             mock_connection.get.call_args[0][0]
-            == f"/api/v1/case/{_TEST_CASE_NUMBER}/fileevent/event-id"
+            == f"/api/v1/cases/{_TEST_CASE_NUMBER}/fileevent/event-id"
         )
 
     def test_get_all_called_with_expected_url_and_params(self, mock_connection):
@@ -42,7 +42,7 @@ class TestCasesFileEventService:
         case_file_event_service.get_all(_TEST_CASE_NUMBER)
         assert (
             mock_connection.get.call_args[0][0]
-            == f"/api/v1/case/{_TEST_CASE_NUMBER}/fileevent"
+            == f"/api/v1/cases/{_TEST_CASE_NUMBER}/fileevent"
         )
 
     def test_add_on_a_closed_case_raises_error(self, mocker, mock_connection):


### PR DESCRIPTION
### Description of Change ###

Corrected URIs for resource `api/v1/cases` which was incorrectly specified as `api/v1/case`.

### Issues Resolved ###
N/A

### Testing Procedure ###

Tests already existed for these functions, I simply updated their assertions.
