### PR TITLE
fix various CI issues

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.x'
+        python-version: '3.8'
     - name: Install tox
       run: pip install tox==3.24.1
     - name: Build docs

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.8'
+        python-version: '3.x'
     - name: Install tox
       run: pip install tox==3.24.1
     - name: Run style checks


### PR DESCRIPTION
Fixes a couple CI issues.

- Mock servers are no longer starting consistently, temporarily disabling integration tests for this reason. There have no been changes to these recently so this is likely due to a change on the GitHub side.

- Docs task is failing due to using python 3.10, which removed some things that we currently want to have in order to build the docs.
