### PR TITLE
Chore/integ 1920 update risk severity filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Changed
+
+- Updated `sdk.queries.alerts.filters.alerts_filter.Severity` enum to use updated `riskSeverity` search propert instead of deprecated `severity`.
+   - New values `CRITICAL` and `MODERATE`.
+   - Aliased previous `severity.MEDIUM` > `riskSeverity.MODERATE` for backwards compatibility.
+
 ## 1.19.3 - 2021-11-09
 
 ### Removed

--- a/src/py42/sdk/queries/alerts/filters/alert_filter.py
+++ b/src/py42/sdk/queries/alerts/filters/alert_filter.py
@@ -6,7 +6,6 @@ from py42.sdk.queries.query_filter import QueryFilterTimestampField
 from py42.util import MICROSECOND_FORMAT
 from py42.util import parse_timestamp_to_microseconds_precision
 
-
 def create_contains_filter_group(term, value):
     """Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering results
     where the value with key ``term`` contains the given value. Useful for creating ``CONTAINS``
@@ -155,8 +154,9 @@ class Severity(QueryFilterStringField, Choices):
     """Class that filters alerts based on severity.
 
     Available options are:
+        - :attr:`Severity.CRITICAL`
         - :attr:`Severity.HIGH`
-        - :attr:`Severity.MEDIUM`
+        - :attr:`Severity.MODERATE`
         - :attr:`Severity.LOW`
     """
 

--- a/src/py42/sdk/queries/alerts/filters/alert_filter.py
+++ b/src/py42/sdk/queries/alerts/filters/alert_filter.py
@@ -6,6 +6,7 @@ from py42.sdk.queries.query_filter import QueryFilterTimestampField
 from py42.util import MICROSECOND_FORMAT
 from py42.util import parse_timestamp_to_microseconds_precision
 
+
 def create_contains_filter_group(term, value):
     """Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering results
     where the value with key ``term`` contains the given value. Useful for creating ``CONTAINS``

--- a/src/py42/sdk/queries/alerts/filters/alert_filter.py
+++ b/src/py42/sdk/queries/alerts/filters/alert_filter.py
@@ -160,10 +160,12 @@ class Severity(QueryFilterStringField, Choices):
         - :attr:`Severity.LOW`
     """
 
-    _term = "severity"
+    _term = "riskSeverity"
 
+    CRITICAL = "CRITICAL"
     HIGH = "HIGH"
-    MEDIUM = "MEDIUM"
+    MEDIUM = "MODERATE"
+    MODERATE = "MODERATE"
     LOW = "LOW"
 
 

--- a/tests/sdk/queries/alerts/filters/test_alert_filter.py
+++ b/tests/sdk/queries/alerts/filters/test_alert_filter.py
@@ -141,27 +141,27 @@ def test_actor_not_contains_str_gives_correct_json_representation():
 
 def test_severity_eq_str_gives_correct_json_representation():
     _filter = Severity.eq("HIGH")
-    expected = IS.format("severity", "HIGH")
+    expected = IS.format("riskSeverity", "HIGH")
     assert str(_filter) == expected
 
 
 def test_severity_not_eq_str_gives_correct_json_representation():
     _filter = Severity.not_eq("HIGH")
-    expected = IS_NOT.format("severity", "HIGH")
+    expected = IS_NOT.format("riskSeverity", "HIGH")
     assert str(_filter) == expected
 
 
 def test_severity_is_in_str_gives_correct_json_representation():
-    items = ["HIGH", "MEDIUM", "LOW"]
+    items = ["HIGH", "MODERATE", "LOW"]
     _filter = Severity.is_in(items)
-    expected = IS_IN.format("severity", *sorted(items))
+    expected = IS_IN.format("riskSeverity", *sorted(items))
     assert str(_filter) == expected
 
 
 def test_severity_not_in_str_gives_correct_json_representation():
-    items = ["HIGH", "MEDIUM", "LOW"]
+    items = ["HIGH", "MODERATE", "LOW"]
     _filter = Severity.not_in(items)
-    expected = NOT_IN.format("severity", *sorted(items))
+    expected = NOT_IN.format("riskSeverity", *sorted(items))
     assert str(_filter) == expected
 
 
@@ -363,7 +363,7 @@ def test_rule_type_choices_returns_set():
 
 def test_severity_choices_returns_set():
     choices = Severity.choices()
-    valid_set = {"HIGH", "MEDIUM", "LOW"}
+    valid_set = {"CRITICAL", "HIGH", "MODERATE", "LOW"}
     assert set(choices) == valid_set
 
 


### PR DESCRIPTION
### Description of Change ###

- Updated `sdk.queries.alerts.filters.alert_filter.Severity` to use `riskSeverity` search key. 
- Added new `CRITICAL` and `MODERATE` values to the filter class.
- Aliased `MEDIUM` to `MODERATE`.

### Testing Procedure ###
Validate that alert queries return expected results for `riskSeverity` properties.

- `AlertQuery(Severity.eq(Severity.LOW))` returns `riskSeverity: LOW` events
- `AlertQuery(Severity.eq(Severity.MODERATE))` returns `riskSeverity: MODERATE` events
- `AlertQuery(Severity.eq(Severity.MEDIUM))` returns `riskSeverity: MODERATE` events
- `AlertQuery(Severity.eq(Severity.CRITICAL))` returns `riskSeverity: CRITICAL` events

### PR Checklist ###
Did you remember to do the below?

- [x] Update unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Update docstrings for any new public parameters / methods / classes
