### PR TITLE
bugfix

### DIFF
--- a/src/py42/services/legalholdapiclient.py
+++ b/src/py42/services/legalholdapiclient.py
@@ -193,7 +193,7 @@ class LegalHoldApiClientService(BaseService):
         """
         return get_all_pages(
             self.get_matters_page,
-            "legalHolds",
+            None,
             creator_user_uid=creator_user_uid,
             active=active,
             name=name,
@@ -277,7 +277,7 @@ class LegalHoldApiClientService(BaseService):
         """
         return get_all_pages(
             self.get_custodians_page,
-            "legalHoldMemberships",
+            None,
             legal_hold_matter_uid=legal_hold_matter_uid,
             user_uid=user_uid,
             user=user,

--- a/src/py42/services/util.py
+++ b/src/py42/services/util.py
@@ -13,7 +13,7 @@ def get_all_pages(func, key, *args, **kwargs):
         page_num += 1
         response = func(*args, page_num=page_num, **kwargs)
         yield response
-        page_items = response[key]
+        page_items = response[key] if key else response.data
         item_count = len(page_items)
 
 

--- a/tests/services/test_legalholdapiclient.py
+++ b/tests/services/test_legalholdapiclient.py
@@ -31,13 +31,13 @@ DEFAULT_GET_LEGAL_HOLDS_PARAMS = {
     "q": None,
 }
 
-MOCK_GET_ALL_MATTERS_RESPONSE = """{"legalHolds":["foo"]}"""
+MOCK_GET_ALL_MATTERS_RESPONSE = """["foo"]"""
 
-MOCK_EMPTY_GET_ALL_MATTERS_RESPONSE = """{"legalHolds": []}"""
+MOCK_EMPTY_GET_ALL_MATTERS_RESPONSE = """[]"""
 
-MOCK_GET_ALL_MATTER_CUSTODIANS_RESPONSE = """{"legalHoldMemberships": ["foo"]}"""
+MOCK_GET_ALL_MATTER_CUSTODIANS_RESPONSE = """["foo"]"""
 
-MOCK_EMPTY_GET_ALL_MATTER_CUSTODIANS_RESPONSE = """{"legalHoldMemberships": []}"""
+MOCK_EMPTY_GET_ALL_MATTER_CUSTODIANS_RESPONSE = """[]"""
 
 
 class TestLegalHoldApiClientService:


### PR DESCRIPTION
The legal hold API endpoints for listing memberships and matters were formatted a little differently such that they returned a list of items without additional data.  This was throwing an error in the `get_all_pages()` method.  Adjusting this method so that it will return the response data if a key is not provided fixes this. 
