### PR TITLE
Chore/update py42 exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 - Updated `sdk.queries.alerts.filters.alerts_filter.Severity` enum to use updated `riskSeverity` search propert instead of deprecated `severity`.
    - New values `CRITICAL` and `MODERATE`.
    - Aliased previous `severity.MEDIUM` > `riskSeverity.MODERATE` for backwards compatibility.
+- Updated custom exception behavior such that the parameters relating to the exception are:
+  - Printed in addition to the error message.
+  - Accessible as properties of the custom exception class.
 
 ## 1.19.3 - 2021-11-09
 

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -210,17 +210,11 @@ class Py42UserAlreadyAddedError(Py42BadRequestError):
         msg = f"User with ID {user_id} is already on the {list_name}."
         super().__init__(exception, msg, user_id, list_name)
         self._user_id = user_id
-        self._list_name = list_name
 
     @property
     def user_id(self):
         """ The user ID. """
         return self._user_id
-
-    @property
-    def list_name(self):
-        """ The list name. """
-        return self._list_name
 
 
 class Py42LegalHoldNotFoundOrPermissionDeniedError(Py42ForbiddenError):
@@ -230,7 +224,6 @@ class Py42LegalHoldNotFoundOrPermissionDeniedError(Py42ForbiddenError):
     def __init__(self, exception, resource_uid, legal_hold_resource="matter"):
         message = f"{legal_hold_resource.capitalize()} with UID '{resource_uid}' can not be found. Your account may not have permission to view the {legal_hold_resource.lower()}."
         super().__init__(exception, message, resource_uid)
-        self._legal_hold_object = legal_hold_resource
         self._resource_uid = resource_uid
 
     @property

--- a/src/py42/services/trustedactivities.py
+++ b/src/py42/services/trustedactivities.py
@@ -42,7 +42,7 @@ class TrustedActivitiesService(BaseService):
         try:
             return self._connection.post(self._uri_prefix, json=data)
         except Py42BadRequestError as err:
-            _handle_common_invalid_case_parameters_errors(err)
+            _handle_common_invalid_trust_parameters_errors(err)
         except Py42ConflictError as err:
             raise Py42TrustedActivityConflictError(err, value)
 
@@ -68,7 +68,7 @@ class TrustedActivitiesService(BaseService):
         try:
             return self._connection.put(uri, json=data)
         except Py42BadRequestError as err:
-            _handle_common_invalid_case_parameters_errors(err)
+            _handle_common_invalid_trust_parameters_errors(err)
         except Py42NotFoundError as err:
             raise Py42TrustedActivityIdNotFound(err, id)
         except Py42ConflictError as err:
@@ -82,7 +82,7 @@ class TrustedActivitiesService(BaseService):
             raise Py42TrustedActivityIdNotFound(err, id)
 
 
-def _handle_common_invalid_case_parameters_errors(base_err):
+def _handle_common_invalid_trust_parameters_errors(base_err):
     if "DESCRIPTION_TOO_LONG" in base_err.response.text:
         raise Py42DescriptionLimitExceededError(base_err)
     elif "INVALID_CHARACTERS_IN_VALUE" in base_err.response.text:

--- a/tests/clients/test_detectionlists.py
+++ b/tests/clients/test_detectionlists.py
@@ -118,6 +118,7 @@ class TestDetectionListClient:
             "possibly still being created if you just recently created the Code42 "
             "user." in str(err.value)
         )
+        assert err.value.username == "testusername"
 
     def test_create_user_when_service_returns_bad_request_raises(
         self,

--- a/tests/clients/test_detectionlists.py
+++ b/tests/clients/test_detectionlists.py
@@ -113,11 +113,10 @@ class TestDetectionListClient:
             client.create_user("testusername")
 
         assert (
-            str(err.value)
-            == "Detection-list profiles are now created automatically on the server. "
+            "Detection-list profiles are now created automatically on the server. "
             "Unable to find a detection-list profile for 'testusername'. It is "
             "possibly still being created if you just recently created the Code42 "
-            "user."
+            "user." in str(err.value)
         )
 
     def test_create_user_when_service_returns_bad_request_raises(

--- a/tests/services/detectionlists/test_departing_employee.py
+++ b/tests/services/detectionlists/test_departing_employee.py
@@ -138,6 +138,7 @@ class TestDepartingEmployeeClient:
 
         expected = "User with ID user_id is already on the departing-employee list."
         assert expected in str(err.value)
+        assert err.value.user_id == "user_id"
 
     def test_remove_posts_expected_data_and_to_expected_url(
         self,

--- a/tests/services/detectionlists/test_departing_employee.py
+++ b/tests/services/detectionlists/test_departing_employee.py
@@ -137,7 +137,7 @@ class TestDepartingEmployeeClient:
             client.add("user_id")
 
         expected = "User with ID user_id is already on the departing-employee list."
-        assert str(err.value) == expected
+        assert expected in str(err.value)
 
     def test_remove_posts_expected_data_and_to_expected_url(
         self,

--- a/tests/services/detectionlists/test_high_risk_employee.py
+++ b/tests/services/detectionlists/test_high_risk_employee.py
@@ -88,7 +88,7 @@ class TestHighRiskEmployeeClient:
             client.add("user_id")
 
         expected = "User with ID user_id is already on the high-risk-employee list."
-        assert str(err.value) == expected
+        assert expected in str(err.value)
 
     def test_set_alerts_enabled_posts_expected_data_with_default_value(
         self, user_context, mock_connection, mock_detection_list_user_client

--- a/tests/services/detectionlists/test_high_risk_employee.py
+++ b/tests/services/detectionlists/test_high_risk_employee.py
@@ -89,6 +89,7 @@ class TestHighRiskEmployeeClient:
 
         expected = "User with ID user_id is already on the high-risk-employee list."
         assert expected in str(err.value)
+        assert err.value.user_id == "user_id"
 
     def test_set_alerts_enabled_posts_expected_data_with_default_value(
         self, user_context, mock_connection, mock_detection_list_user_client

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -171,7 +171,7 @@ class TestConnectedServerHostResolver:
             "Device with GUID 'device-guid' is not currently connected "
             "to the Authority server."
         )
-        assert str(err.value) == expected_message
+        assert expected_message in str(err.value)
 
 
 class TestConnection:

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -172,6 +172,7 @@ class TestConnectedServerHostResolver:
             "to the Authority server."
         )
         assert expected_message in str(err.value)
+        assert err.value.device_guid == TEST_DEVICE_GUID
 
 
 class TestConnection:

--- a/tests/services/test_devices.py
+++ b/tests/services/test_devices.py
@@ -146,6 +146,8 @@ class TestDeviceService:
 
         expected = "Cannot deactivate the device with ID 1234 as the device is involved in a legal hold matter."
         assert expected in str(err.value)
+        assert err.value.resource == "device"
+        assert err.value.resource_id == 1234
 
     def test_get_page_when_org_not_found_raises_expected_error(
         self, mocker, mock_connection
@@ -160,3 +162,4 @@ class TestDeviceService:
             service.get_page(1, org_uid="TestOrgUid")
 
         assert "The organization with UID 'TestOrgUid' was not found." in str(err.value)
+        assert err.value.org_uid == "TestOrgUid"

--- a/tests/services/test_devices.py
+++ b/tests/services/test_devices.py
@@ -145,7 +145,7 @@ class TestDeviceService:
             client.deactivate(1234)
 
         expected = "Cannot deactivate the device with ID 1234 as the device is involved in a legal hold matter."
-        assert str(err.value) == expected
+        assert expected in str(err.value)
 
     def test_get_page_when_org_not_found_raises_expected_error(
         self, mocker, mock_connection
@@ -159,4 +159,4 @@ class TestDeviceService:
         with pytest.raises(Py42OrgNotFoundError) as err:
             service.get_page(1, org_uid="TestOrgUid")
 
-        assert str(err.value) == "The organization with UID 'TestOrgUid' was not found."
+        assert "The organization with UID 'TestOrgUid' was not found." in str(err.value)

--- a/tests/services/test_fileevent.py
+++ b/tests/services/test_fileevent.py
@@ -58,7 +58,7 @@ class TestFileEventService:
         with pytest.raises(Py42InvalidPageTokenError) as err:
             service.search(query)
 
-        assert str(err.value) == f'Invalid page token: "{query.page_token}".'
+        assert f'Invalid page token: "{query.page_token}".' in str(err.value)
 
     def test_search_when_bad_request_raised_and_token_not_in_query_raises_bad_request(
         self, mock_invalid_page_token_connection

--- a/tests/services/test_fileevent.py
+++ b/tests/services/test_fileevent.py
@@ -59,6 +59,7 @@ class TestFileEventService:
             service.search(query)
 
         assert f'Invalid page token: "{query.page_token}".' in str(err.value)
+        assert err.value.page_token == "test_page_token"
 
     def test_search_when_bad_request_raised_and_token_not_in_query_raises_bad_request(
         self, mock_invalid_page_token_connection

--- a/tests/services/test_legalhold.py
+++ b/tests/services/test_legalhold.py
@@ -86,6 +86,7 @@ class TestLegalHoldService:
 
         expected = "Matter with UID 'matter' can not be found. Your account may not have permission to view the matter."
         assert expected in str(err.value)
+        assert err.value.uid == "matter"
 
     def test_get_all_matters_calls_get_expected_number_of_times(
         self,
@@ -238,3 +239,4 @@ class TestLegalHoldService:
             "User with ID user is already on the legal hold matter id=legal, name=NAME."
         )
         assert expected in str(err.value)
+        assert err.value.user_id == "user"

--- a/tests/services/test_legalhold.py
+++ b/tests/services/test_legalhold.py
@@ -84,11 +84,8 @@ class TestLegalHoldService:
         with pytest.raises(Py42LegalHoldNotFoundOrPermissionDeniedError) as err:
             service.get_matter_by_uid("matter")
 
-        expected = (
-            "Matter with ID=matter can not be found. Your account may not have "
-            "permission to view the matter."
-        )
-        assert str(err.value) == expected
+        expected = "Matter with UID 'matter' can not be found. Your account may not have permission to view the matter."
+        assert expected in str(err.value)
 
     def test_get_all_matters_calls_get_expected_number_of_times(
         self,
@@ -212,8 +209,8 @@ class TestLegalHoldService:
             service.get_custodians_page(1)
 
         assert (
-            str(err.value) == "At least one criteria must be specified; "
-            "legal_hold_membership_uid, legal_hold_uid, user_uid, or user."
+            str(err.value) == "At least one criteria must be specified: "
+            "legal_hold_membership_uid, legal_hold_matter_uid, user_uid, or user."
         )
 
     def test_add_to_matter_calls_post_with_expected_url_and_params(
@@ -240,4 +237,4 @@ class TestLegalHoldService:
         expected = (
             "User with ID user is already on the legal hold matter id=legal, name=NAME."
         )
-        assert str(err.value) == expected
+        assert expected in str(err.value)

--- a/tests/services/test_users.py
+++ b/tests/services/test_users.py
@@ -243,6 +243,7 @@ class TestUserService:
             service.get_page(1, org_uid="TestOrgUid")
 
         assert "The organization with UID 'TestOrgUid' was not found." in str(err.value)
+        assert err.value.org_uid == "TestOrgUid"
 
     def test_get_page_when_bad_request_raises(self, mocker, mock_connection):
         mock_connection.get.side_effect = create_mock_error(
@@ -268,6 +269,8 @@ class TestUserService:
             "a legal hold matter."
         )
         assert expected in str(err.value)
+        assert err.value.resource == "user"
+        assert err.value.resource_id == 1234
 
     def test_update_user_calls_put_with_expected_url_and_params(
         self, mock_connection, put_api_mock_response
@@ -343,6 +346,7 @@ class TestUserService:
             user_service.update_user("123", username="foo", email="test")
 
         assert "'test' is not a valid email." in str(err.value)
+        assert err.value.email == "test"
 
     def test_update_user_when_get_internal_server_error_containing_password_invalid_raises_expected_error(
         self, mock_connection, invalid_password_error_response

--- a/tests/services/test_users.py
+++ b/tests/services/test_users.py
@@ -242,7 +242,7 @@ class TestUserService:
         with pytest.raises(Py42OrgNotFoundError) as err:
             service.get_page(1, org_uid="TestOrgUid")
 
-        assert str(err.value) == "The organization with UID 'TestOrgUid' was not found."
+        assert "The organization with UID 'TestOrgUid' was not found." in str(err.value)
 
     def test_get_page_when_bad_request_raises(self, mocker, mock_connection):
         mock_connection.get.side_effect = create_mock_error(
@@ -267,7 +267,7 @@ class TestUserService:
             "Cannot deactivate the user with ID 1234 as the user is involved in "
             "a legal hold matter."
         )
-        assert str(err.value) == expected
+        assert expected in str(err.value)
 
     def test_update_user_calls_put_with_expected_url_and_params(
         self, mock_connection, put_api_mock_response
@@ -342,7 +342,7 @@ class TestUserService:
         with pytest.raises(Py42InvalidEmailError) as err:
             user_service.update_user("123", username="foo", email="test")
 
-        assert str(err.value) == "'test' is not a valid email."
+        assert "'test' is not a valid email." in str(err.value)
 
     def test_update_user_when_get_internal_server_error_containing_password_invalid_raises_expected_error(
         self, mock_connection, invalid_password_error_response


### PR DESCRIPTION
### Description of Change ###

Updating py42 custom exceptions to expose the args by
- Add and expose properties to each custom exception 
- Pass the raw args to the base class `__init__` method in while keeping the main string arg remains in the same position

The args are now printed in addition to the error message:
`py42.exceptions.Py42LegalHoldNotFoundOrPermissionDeniedError: ("Matter with UID '123' can not be found. Your account may not have permission to view the matter.", '123')`

Current behavior: 
`py42.exceptions.Py42LegalHoldNotFoundOrPermissionDeniedError: Matter with ID=123 can not be found. Your account may not have permission to view the matter.`

### Testing Procedure ###

Args should be visible in error message as well as accessible as properties of the exception.

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
