### PR TITLE
riskScore file event filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ### Added
 
-- New fileevent filter query `sdk.queries.fileevents.filers.risk_filter.RiskScore` to search for file events based on riskScore values.
+- New file event filter query `sdk.queries.fileevents.filers.risk_filter.RiskScore` to search for file events based on riskScore values.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 
 ## Unreleased
 
+### Added
+
+- New fileevent filter query `sdk.queries.fileevents.filers.risk_filter.RiskScore` to search for file events based on riskScore values.
+
 ### Changed
 
 - Updated `sdk.queries.alerts.filters.alerts_filter.Severity` enum to use updated `riskSeverity` search propert instead of deprecated `severity`.

--- a/docs/methoddocs/filleeventqueries.md
+++ b/docs/methoddocs/filleeventqueries.md
@@ -394,3 +394,10 @@ See [Executing Searches](../userguides/searches.md) for more on building search 
     :inherited-members:
     :show-inheritance:
 ```
+
+```eval_rst
+.. autoclass:: py42.sdk.queries.fileevents.filters.risk_filter.RiskScore
+    :members:
+    :inherited-members:
+    :show-inheritance:
+```

--- a/src/py42/sdk/queries/fileevents/filters/risk_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/risk_filter.py
@@ -1,6 +1,7 @@
 from py42.choices import Choices
 from py42.sdk.queries.fileevents.file_event_query import FileEventFilterStringField
-
+from py42.sdk.queries.fileevents.file_event_query import FileEventFilterComparableField
+from py42.sdk.queries.query_filter import QueryFilterStringField
 
 class RiskIndicator(FileEventFilterStringField):
     """Class that filters events by risk indicator.
@@ -190,3 +191,12 @@ class RiskSeverity(FileEventFilterStringField, Choices):
     MODERATE = "MODERATE"
     LOW = "LOW"
     NO_RISK_INDICATED = "NO_RISK_INDICATED"
+
+
+class RiskScore(QueryFilterStringField, FileEventFilterComparableField):
+    """Class that filters events by risk score."""
+
+    _term = "riskScore"
+
+    
+

--- a/src/py42/sdk/queries/fileevents/filters/risk_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/risk_filter.py
@@ -1,7 +1,8 @@
 from py42.choices import Choices
-from py42.sdk.queries.fileevents.file_event_query import FileEventFilterStringField
 from py42.sdk.queries.fileevents.file_event_query import FileEventFilterComparableField
+from py42.sdk.queries.fileevents.file_event_query import FileEventFilterStringField
 from py42.sdk.queries.query_filter import QueryFilterStringField
+
 
 class RiskIndicator(FileEventFilterStringField):
     """Class that filters events by risk indicator.
@@ -197,6 +198,3 @@ class RiskScore(QueryFilterStringField, FileEventFilterComparableField):
     """Class that filters events by risk score."""
 
     _term = "riskScore"
-
-    
-

--- a/tests/sdk/queries/fileevents/filters/test_risk_filter.py
+++ b/tests/sdk/queries/fileevents/filters/test_risk_filter.py
@@ -1,13 +1,13 @@
+from tests.sdk.queries.conftest import GREATER_THAN
 from tests.sdk.queries.conftest import IS
 from tests.sdk.queries.conftest import IS_IN
 from tests.sdk.queries.conftest import IS_NOT
-from tests.sdk.queries.conftest import NOT_IN
-from tests.sdk.queries.conftest import GREATER_THAN
 from tests.sdk.queries.conftest import LESS_THAN
+from tests.sdk.queries.conftest import NOT_IN
 
 from py42.sdk.queries.fileevents.filters.risk_filter import RiskIndicator
-from py42.sdk.queries.fileevents.filters.risk_filter import RiskSeverity
 from py42.sdk.queries.fileevents.filters.risk_filter import RiskScore
+from py42.sdk.queries.fileevents.filters.risk_filter import RiskSeverity
 
 
 def test_risk_indicator_eq_str_gives_correct_json_representation():
@@ -83,14 +83,14 @@ def test_risk_score_not_eq_str_gives_correct_json_representation():
 
 
 def test_risk_score_is_in_str_gives_correct_json_representation():
-    items = [3,4,5]
+    items = [3, 4, 5]
     _filter = RiskScore.is_in(items)
     expected = IS_IN.format("riskScore", *items)
     assert str(_filter) == expected
 
 
 def test_risk_score_not_in_str_gives_correct_json_representation():
-    items = [3,4,5]
+    items = [3, 4, 5]
     _filter = RiskScore.not_in(items)
     expected = NOT_IN.format("riskScore", *items)
     assert str(_filter) == expected
@@ -100,6 +100,7 @@ def test_risk_score_greater_than_str_gives_correct_json_representation():
     _filter = RiskScore.greater_than(5)
     expected = GREATER_THAN.format("riskScore", "5")
     assert str(_filter) == expected
+
 
 def test_risk_score_less_than_str_gives_correct_json_representation():
     _filter = RiskScore.less_than(5)

--- a/tests/sdk/queries/fileevents/filters/test_risk_filter.py
+++ b/tests/sdk/queries/fileevents/filters/test_risk_filter.py
@@ -2,9 +2,12 @@ from tests.sdk.queries.conftest import IS
 from tests.sdk.queries.conftest import IS_IN
 from tests.sdk.queries.conftest import IS_NOT
 from tests.sdk.queries.conftest import NOT_IN
+from tests.sdk.queries.conftest import GREATER_THAN
+from tests.sdk.queries.conftest import LESS_THAN
 
 from py42.sdk.queries.fileevents.filters.risk_filter import RiskIndicator
 from py42.sdk.queries.fileevents.filters.risk_filter import RiskSeverity
+from py42.sdk.queries.fileevents.filters.risk_filter import RiskScore
 
 
 def test_risk_indicator_eq_str_gives_correct_json_representation():
@@ -64,4 +67,41 @@ def test_risk_severity_not_in_str_gives_correct_json_representation():
     items = [RiskSeverity.HIGH, RiskSeverity.LOW, RiskSeverity.MODERATE]
     _filter = RiskSeverity.not_in(items)
     expected = NOT_IN.format("riskSeverity", *items)
+    assert str(_filter) == expected
+
+
+def test_risk_score_eq_str_gives_correct_json_representation():
+    _filter = RiskScore.eq(5)
+    expected = IS.format("riskScore", "5")
+    assert str(_filter) == expected
+
+
+def test_risk_score_not_eq_str_gives_correct_json_representation():
+    _filter = RiskScore.not_eq(5)
+    expected = IS_NOT.format("riskScore", "5")
+    assert str(_filter) == expected
+
+
+def test_risk_score_is_in_str_gives_correct_json_representation():
+    items = [3,4,5]
+    _filter = RiskScore.is_in(items)
+    expected = IS_IN.format("riskScore", *items)
+    assert str(_filter) == expected
+
+
+def test_risk_score_not_in_str_gives_correct_json_representation():
+    items = [3,4,5]
+    _filter = RiskScore.not_in(items)
+    expected = NOT_IN.format("riskScore", *items)
+    assert str(_filter) == expected
+
+
+def test_risk_score_greater_than_str_gives_correct_json_representation():
+    _filter = RiskScore.greater_than(5)
+    expected = GREATER_THAN.format("riskScore", "5")
+    assert str(_filter) == expected
+
+def test_risk_score_less_than_str_gives_correct_json_representation():
+    _filter = RiskScore.less_than(5)
+    expected = LESS_THAN.format("riskScore", "5")
     assert str(_filter) == expected


### PR DESCRIPTION
### Description of Change ###

Enables searching for file events by `riskScore` value directly.

### Testing Procedure ###

- Query for file events with `RiskScore.eq(<score_val>)` , only events with `riskScore == score_val` should be returned
- Query for file events with `RiskScore.greater_than(<score_val>)`, only events with `riskScore > score_val` should be returned.
- Query for file events with `RiskScore.less_than(<score_val>)`, only events with `riskScore < score_val` should be returned.
- Query for file events with `RiskScore.is_in([<score_val_1>, <score_val_2>])`, only events with `riskScore in [score_val_1, score_val_2]` should be returned.
- Query for file events with `RiskScore.not_in([<score_val_1>, <score_val_2>])`, only events with `riskScore not in [score_val_1, score_val_2]` should be returned.

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
