### PR TITLE
docs: fix rest docs links in trusted activities client

### DIFF
--- a/src/py42/clients/trustedactivities.py
+++ b/src/py42/clients/trustedactivities.py
@@ -23,7 +23,7 @@ class TrustedActivitiesClient:
 
     def get_all(self, type=None, page_size=None):
         """Gets all trusted activities.
-        `Rest documentation <https://developer.code42.com/api>`
+        `Rest documentation <https://developer.code42.com/api>`__
 
         Args:
             type (str, optional): Type of the trusted activity. Defaults to None. Constants available at :class:`py42.constants.TrustedActivityType`.
@@ -37,7 +37,7 @@ class TrustedActivitiesClient:
 
     def create(self, type, value, description=None):
         """Gets all trusted activities with the given type.
-        `Rest documentation <https://developer.code42.com/api>`
+        `Rest documentation <https://developer.code42.com/api>`__
 
         Args:
             type (str): Type of the trusted activity. Defaults to None. Constants available at :class:`py42.constants.TrustedActivityType`.
@@ -51,7 +51,7 @@ class TrustedActivitiesClient:
 
     def get(self, id):
         """Retrieve trusted activity details by given resource number.
-        `Rest documentation <https://developer.code42.com/api>`
+        `Rest documentation <https://developer.code42.com/api>`__
 
         Args:
             id (int): Resource number of the trusted activity or domain.
@@ -63,7 +63,7 @@ class TrustedActivitiesClient:
 
     def update(self, id, value=None, description=None):
         """Updates trusted activity details by given resource number.
-        `Rest documentation <https://developer.code42.com/api>`
+        `Rest documentation <https://developer.code42.com/api>`__
 
         Args:
             id (int): Resource number of the trusted activity.
@@ -79,7 +79,7 @@ class TrustedActivitiesClient:
 
     def delete(self, id):
         """Deletes a trusted activity by given resource number.
-        `Rest documentation <https://developer.code42.com/api>`
+        `Rest documentation <https://developer.code42.com/api>`__
 
         Args:
             id (int): Resource number of the trusted activity or domain.


### PR DESCRIPTION
### Description of Change ###

Fixes links in docs site. They were showing kind of odd.

### Issues Resolved ###

The link has the `<>` and is not clickable, I think just adding the two `__` after each one fixes this.

<img width="356" alt="Screen Shot 2022-01-25 at 20 06 36" src="https://user-images.githubusercontent.com/19540978/151092029-662d9f45-ba64-469c-9956-339e29a5577a.png">

### Testing Procedure ###

Build and see docs for `TrustedActivitiesClient`

### PR Checklist ###
Did you remember to do the below?

- [ ] Add unit tests to verify this change
- [ ] Add an entry to CHANGELOG.md describing this change
- [ ] Add docstrings for any new public parameters / methods / classes
