### PR TITLE
adjust error handling when adding user cloud aliases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,4 +56,4 @@ jobs:
       - name: Start up the mock servers
         run: cd code42-mock-servers; docker-compose up -d --build
       - name: Run the integration testss
-        run: cd py42; tox -e integration
+        run: sleep 15; cd py42; tox -e integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
         - `DestinationCategory`
         - `DestinationName`
 
+### Fixed
+
+- Improved error handling for `sdk.detectionlists.add_user_cloud_alias()`
+
 ## 1.20.0 - 2022-01-10
 
 ### Added

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -354,8 +354,19 @@ class Py42CloudAliasLimitExceededError(Py42BadRequestError):
     already has the max amount of supported cloud aliases."""
 
     def __init__(self, exception, message=None):
-        message = message or "Cloud alias limit exceeded."
+        message = (
+            message
+            or "Cloud alias limit exceeded. A max of 2 cloud aliases are allowed."
+        )
         super(Py42BadRequestError, self).__init__(exception, message)
+
+
+class Py42CloudAliasCharacterLimitExceededError(Py42Error):
+    """An exception raised when trying to add a cloud alias to a user that exceeds the max character limit."""
+
+    def __init__(self):
+        message = "Cloud alias character limit exceeded. Max 50 characters."
+        super().__init__(message)
 
 
 class Py42BadRestoreRequestError(Py42BadRequestError):

--- a/src/py42/services/detectionlists/user_profile.py
+++ b/src/py42/services/detectionlists/user_profile.py
@@ -1,4 +1,5 @@
 from py42.exceptions import Py42BadRequestError
+from py42.exceptions import Py42CloudAliasCharacterLimitExceededError
 from py42.exceptions import Py42CloudAliasLimitExceededError
 from py42.services import BaseService
 
@@ -124,6 +125,12 @@ class DetectionListUserService(BaseService):
         Returns:
             :class:`py42.response.Py42Response`
         """
+
+        # check if alias > 50 characters
+        # this error checking is handled by the frontend of the console
+        if len(alias) > 50:
+            raise Py42CloudAliasCharacterLimitExceededError
+
         data = {
             "tenantId": self._user_context.get_current_tenant_id(),
             "userId": user_id,
@@ -133,7 +140,7 @@ class DetectionListUserService(BaseService):
         try:
             return self._connection.post(uri, json=data)
         except Py42BadRequestError as err:
-            if "Cloud usernames must be less than or equal to" in err.response.text:
+            if "A max of 2 cloud aliases are allowed" in err.response.text:
                 raise Py42CloudAliasLimitExceededError(err)
             raise err
 

--- a/tests/services/detectionlists/test_user_profile.py
+++ b/tests/services/detectionlists/test_user_profile.py
@@ -3,6 +3,7 @@ from tests.conftest import create_mock_error
 from tests.conftest import create_mock_response
 
 from py42.exceptions import Py42BadRequestError
+from py42.exceptions import Py42CloudAliasCharacterLimitExceededError
 from py42.exceptions import Py42CloudAliasLimitExceededError
 from py42.services.detectionlists.user_profile import DetectionListUserService
 from py42.services.users import UserService
@@ -40,16 +41,6 @@ class TestDetectionListUserClient:
         user_client = UserService(mock_connection)
         mock_connection.post.side_effect = create_mock_error(
             Py42BadRequestError, mocker, ""
-        )
-        return user_client
-
-    @pytest.fixture
-    def mock_user_client_error_on_adding_cloud_aliases(
-        self, mocker, mock_connection, user_context,
-    ):
-        user_client = UserService(mock_connection)
-        mock_connection.post.side_effect = create_mock_error(
-            Py42BadRequestError, mocker, CLOUD_ALIAS_LIMIT_EXCEEDED_ERROR_MESSAGE
         )
         return user_client
 
@@ -189,16 +180,28 @@ class TestDetectionListUserClient:
         )
 
     def test_add_cloud_alias_limit_raises_custom_error_on_limit(
-        self,
-        mock_connection,
-        user_context,
-        mock_user_client_error_on_adding_cloud_aliases,
+        self, mocker, mock_connection, user_context, mock_user_client
     ):
         detection_list_user_client = DetectionListUserService(
-            mock_connection,
-            user_context,
-            mock_user_client_error_on_adding_cloud_aliases,
+            mock_connection, user_context, mock_user_client
+        )
+        text = "AddCloudAliases: A max of 2 cloud aliases are allowed"
+        mock_connection.post.side_effect = create_mock_error(
+            Py42BadRequestError, mocker, text
         )
         with pytest.raises(Py42CloudAliasLimitExceededError) as err:
             detection_list_user_client.add_cloud_alias("942897397520289999", "Test")
         assert "Cloud alias limit exceeded." in str(err.value)
+
+    def test_add_cloud_alias_when_over_character_limit_raises_custom_error(
+        self, mock_connection, user_context, mock_user_client
+    ):
+        detection_list_user_client = DetectionListUserService(
+            mock_connection, user_context, mock_user_client
+        )
+        with pytest.raises(Py42CloudAliasCharacterLimitExceededError) as err:
+            detection_list_user_client.add_cloud_alias(
+                "942897397520289999",
+                "a-very-long-cloud-alias-which-exceeds-the-character-limit-of-fifty-characters-per-alias",
+            )
+        assert "Cloud alias character limit exceeded." in str(err.value)


### PR DESCRIPTION
### Description of Change ###

Adjusts the error handling on the method for adding cloud aliases to a user.

Previously `Py42CloudAliasLimitExceededError` was being raised in the case of an alias exceeding a character limit.

The character limit doesn't seem to be checked by the backend the same way it is in the UI, so changed this check to be done in the method.  Also adjusted that particular exception to be raised when in the correct context - when the user already has the max number of cloud aliases.  

### Testing Procedure ###
The add-cloud-alias method should throw the appropriate custom errors when 
- an alias with a length >50 characters is passed
- the user already has the max number of cloud aliases associated with their username

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [NA] Add an entry to CHANGELOG.md describing this change
- [NA] Add docstrings for any new public parameters / methods / classes
