### PR TITLE
Chore/update device settings

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -12,7 +12,7 @@ jobs:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheckcla' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         # Alpha Release
-        uses: cla-assistant/github-action@v2.0.1-alpha
+        uses: cla-assistant/github-action@v2.13.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret
@@ -22,7 +22,7 @@ jobs:
           path-to-cla-document: 'https://code42.github.io/code42-cla/Code42_Individual_Contributor_License_Agreement'
           # branch should not be protected
           branch: 'main'
-          allowlist: alang13,unparalleled-js,kiran-chaudhary,ceciliastevens,DiscoRiver,annie-payseur,amoravec,patelsagar192,peterbriggs42
+          allowlist: alang13,unparalleled-js,kiran-chaudhary,ceciliastevens,DiscoRiver,annie-payseur,amoravec,patelsagar192,peterbriggs42,tora-kozic,timabrmsn
 
           #below are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         - id: reorder-python-imports
           args: ["--application-directories", "src"]
     - repo: https://github.com/psf/black
-      rev: 19.10b0
+      rev: 22.3.0
       hooks:
         - id: black
     - repo: https://gitlab.com/pycqa/flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Added
+- `IncyderDeviceSettings` class to allow users to manage the settings on individual Incyder devices.
+
 ## 1.21.1 - 2022-02-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 ## Unreleased
 
 ### Added
-- `IncyderDeviceSettings` class to allow users to manage the settings on individual Incyder devices.
+- `IncydrDeviceSettings` class to allow users to manage the settings on individual Incydr devices.
 
 ## 1.21.1 - 2022-02-22
 

--- a/docs/methoddocs/devicesettings.md
+++ b/docs/methoddocs/devicesettings.md
@@ -1,6 +1,12 @@
 # Device Settings
 
 ```{eval-rst}
+.. autoclass:: py42.clients.settings.device_settings.IncydrDeviceSettings
+    :members:
+    :show-inheritance:
+```
+
+```{eval-rst}
 .. autoclass:: py42.clients.settings.device_settings.DeviceSettings
     :members:
     :show-inheritance:

--- a/docs/userguides/devicesettings.md
+++ b/docs/userguides/devicesettings.md
@@ -1,17 +1,18 @@
 # View or Modify device settings
 
-Use py42 to easily view and update the settings for devices with the `DeviceSettings` object.
+Use py42 to easily view and update the settings for devices with the `DeviceSettings` and `IncydrDeviceSettings` objects for Crashplan and Incydr customers, respectively.
 
-The `DeviceSettings` object is a wrapper around the complex nested dict that the Code42 `Computer` API endpoint expects,
+The [Device Settings](../methoddocs/devicesettings.md) objects are wrappers around the complex nested dict that the Code42 `Computer` API endpoint expects,
 providing helper properties that can be used to get/set values, without having to know the underlying nested structure.
 
-To get started, create a `DeviceSettings` object for a given device guid:
+To get started, create a `DeviceSettings` or `IncydrDeviceSettings` object for a given device guid.  The `get_settings()` method will create the appropriate object automatically based on the corresponding service running on the device:
 
 ```python
 device_settings = sdk.devices.get_settings(908765043021)
 ```
 
-Some common non-modifiable details about the device are accessible as read-only properties:
+Details on which settings can be updated and which are non-modifiable can be found in the method documentation [Device Settings](../methoddocs/devicesettings.md). These may differ between services.
+Some common non-modifiable settings fields are accessible as read-only properties on the object:
 
 ```python
 >>> device_settings.computer_id
@@ -24,28 +25,16 @@ Some common non-modifiable details about the device are accessible as read-only 
 494842
 >>> device_settings.version
 1525200006800
->>> device_settings.available_destinations
-{'632540230984925185': 'PROe Cloud, US - West', '43': 'PROe Cloud, US'}
 ```
 
 And to change settings, in most cases you can just assign new values to the corresponding attribute:
 
 ```python
->>> device_settings.name
-"Admin's Computer"
->>> device_settings.name = "Bob's Laptop"
+>>> device_settings.notes
+"A note on this device."
+>>> device_settings.notes = "A note on this device."
 ```
-
-Because device backup settings are tied to a given "Backup Set", of which there could be more than one, the `DeviceSettings.backup_sets`
-property returns a list of `BackupSet` wrapper classes that help manage backup configuration settings.
-
-```python
->>> device_settings.backup_sets
-[<BackupSet: id: 1, name: 'Primary - Backup Set'>, <BackupSet: id: 298010138, name: 'Secondary (large files) - Backup Set'>]
-```
-
-See the [Configuring Backup Sets](backupsets.md) guide for details on managing backup set settings.
-
+The below section provides more detail on managing backup settings for Crashplan customers.
 
 For convenience and logging purposes, all changes are tracked in the `.changes` property of the `DeviceSettings` objects.
 
@@ -62,7 +51,28 @@ with the server response:
 <Py42Response [status=200, data={'active': True, 'address': '192.168.74.144:4247', 'alertState': 0, 'alertStates': ['OK'], ...}]>
 ```
 
-## Advanced Usage
+
+## Crashplan
+
+### Backup settings
+
+The available backup destinations for a device can be found on the read-only `availableDestinations` property:
+```python
+>>> device_settings.available_destinations
+{'632540230984925185': 'PROe Cloud, US - West', '43': 'PROe Cloud, US'}
+```
+
+Because device backup settings are tied to a given "Backup Set", of which there could be more than one, the `DeviceSettings.backup_sets`
+property returns a list of `BackupSet` wrapper classes that help manage backup configuration settings.
+
+```python
+>>> device_settings.backup_sets
+[<BackupSet: id: 1, name: 'Primary - Backup Set'>, <BackupSet: id: 298010138, name: 'Secondary (large files) - Backup Set'>]
+```
+
+See the [Configuring Backup Sets](backupsets.md) guide for details on managing backup set settings.
+
+### Advanced usage
 
 Because `DeviceSettings` is a subclass of `UserDict` with added attributes/methods to help easily access/modify setting values,
 the underlying dict that ultimately gets posted to the server is stored on the `.data` attribute of `DeviceSettings` instances,

--- a/src/py42/clients/_archiveaccess/__init__.py
+++ b/src/py42/clients/_archiveaccess/__init__.py
@@ -108,7 +108,11 @@ class ArchiveContentStreamer(ArchiveExplorer):
     """A class with methods for restoring files from backup."""
 
     def stream_from_backup(
-        self, backup_set_id, file_paths, file_size_calc_timeout=None, show_deleted=None,
+        self,
+        backup_set_id,
+        file_paths,
+        file_size_calc_timeout=None,
+        show_deleted=None,
     ):
         file_selections = self.create_file_selections(
             backup_set_id, file_paths, file_size_calc_timeout
@@ -173,7 +177,10 @@ def _create_file_selections(file_paths, metadata_list, file_sizes=None):
             "selected": True,
         }
         selection = FileSelection(
-            file, size_info["numFiles"], size_info["numDirs"], size_info["size"],
+            file,
+            size_info["numFiles"],
+            size_info["numDirs"],
+            size_info["size"],
         )
         file_selections.append(selection)
     return file_selections

--- a/src/py42/clients/_archiveaccess/accessorfactory.py
+++ b/src/py42/clients/_archiveaccess/accessorfactory.py
@@ -36,7 +36,10 @@ class ArchiveAccessorFactory:
             restore_job_manager,
             file_size_poller,
         ) = self._create_archive_accessor_dependencies(
-            storage_archive_service, device_guid, private_password, encryption_key,
+            storage_archive_service,
+            device_guid,
+            private_password,
+            encryption_key,
         )
         return accessor_class(
             device_guid,
@@ -66,7 +69,10 @@ class ArchiveAccessorFactory:
             restore_job_manager,
             file_size_poller,
         ) = self._create_archive_accessor_dependencies(
-            push_service, device_guid, private_password, encryption_key,
+            push_service,
+            device_guid,
+            private_password,
+            encryption_key,
         )
         destination_guid = (
             destination_guid
@@ -87,13 +93,17 @@ class ArchiveAccessorFactory:
         self, storage_archive_service, device_guid, private_password, encryption_key
     ):
         decryption_keys = self._get_decryption_keys(
-            device_guid, private_password, encryption_key,
+            device_guid,
+            private_password,
+            encryption_key,
         )
         session_id = self._create_restore_session(
             storage_archive_service, device_guid, **decryption_keys
         )
         restore_job_manager = create_restore_job_manager(
-            storage_archive_service, device_guid, session_id,
+            storage_archive_service,
+            device_guid,
+            session_id,
         )
         file_size_poller = create_file_size_poller(storage_archive_service, device_guid)
         return decryption_keys, session_id, restore_job_manager, file_size_poller

--- a/src/py42/clients/_archiveaccess/restoremanager.py
+++ b/src/py42/clients/_archiveaccess/restoremanager.py
@@ -9,7 +9,11 @@ from py42.util import format_dict
 def create_restore_job_manager(
     storage_archive_service, device_guid, archive_session_id
 ):
-    return RestoreJobManager(storage_archive_service, device_guid, archive_session_id,)
+    return RestoreJobManager(
+        storage_archive_service,
+        device_guid,
+        archive_session_id,
+    )
 
 
 def create_file_size_poller(storage_archive_service, device_guid):

--- a/src/py42/clients/cases.py
+++ b/src/py42/clients/cases.py
@@ -7,8 +7,8 @@ from py42.util import parse_timestamp_to_milliseconds_precision
 class CaseStatus(Choices):
     """Constants available for setting the status of a case.
 
-        * ``OPEN``
-        * ``CLOSED``
+    * ``OPEN``
+    * ``CLOSED``
     """
 
     OPEN = "OPEN"

--- a/src/py42/clients/securitydata.py
+++ b/src/py42/clients/securitydata.py
@@ -176,7 +176,9 @@ class SecurityDataClient:
             version["storageNodeURL"]
         )
         token = pds.get_download_token(
-            version["archiveGuid"], version["fileId"], version["versionTimestamp"],
+            version["archiveGuid"],
+            version["fileId"],
+            version["versionTimestamp"],
         )
         return pds.get_file(str(token))
 

--- a/src/py42/clients/settings/_converters.py
+++ b/src/py42/clients/settings/_converters.py
@@ -48,7 +48,7 @@ def minutes_to_days(minutes):
 def bytes_to_gb(bytes):
     if bytes == -1:  # special "unlimited" value
         return bytes
-    gb = bytes / 1000 ** 3
+    gb = bytes / 1000**3
     if isinstance(gb, float) and gb.is_integer():
         return int(gb)
     return gb
@@ -58,6 +58,6 @@ def gb_to_bytes(gb):
     if gb == -1:  # special "unlimited" value
         return gb
     try:
-        return gb * 1000 ** 3
+        return gb * 1000**3
     except ValueError:
         raise AttributeError("value must be numeric.")

--- a/src/py42/clients/settings/device_settings.py
+++ b/src/py42/clients/settings/device_settings.py
@@ -18,6 +18,60 @@ destination_not_added_error = Py42Error(
 )
 
 
+class IncydrDeviceSettings(UserDict):
+    """Class used to manage individual Incydr devices.  These devices have no backup settings and are only the **notes** and **external reference** fields are modifiable."""
+
+    def __init__(self, settings_dict):
+        self.changes = {}
+        self.data = settings_dict
+
+    @property
+    def name(self):
+        """Name of this device. Read-only."""
+        return self.data["name"]
+
+    @property
+    def computer_id(self):
+        """Identifier of this device. Read-only."""
+        return self.data["computerId"]
+
+    @property
+    def device_id(self):
+        """Identifier of this device (alias of `.computer_id`). Read only."""
+        return self.computer_id
+
+    @property
+    def guid(self):
+        """Globally unique identifier of this device. Read-only."""
+        return self.data["guid"]
+
+    @property
+    def org_id(self):
+        """Identifier of the organization this device belongs to. Read-only."""
+        return self.data["orgId"]
+
+    @property
+    def user_id(self):
+        """Identifier of the user this device belongs to. Read-only."""
+        return self.data["userId"]
+
+    @property
+    def version(self):
+        """Latest reported Code42 client version number for this device. Read-only."""
+        return self.data["version"]
+
+    external_reference = SettingProperty(
+        name="external_reference", location=["computerExtRef"]
+    )
+    """External reference field for this device."""
+
+    notes = SettingProperty(name="notes", location=["notes"])
+    """Notes field for this device."""
+
+    def __repr__(self):
+        return f"<IncydrDeviceSettings: guid: {self.data['guid']}, name: {self.data['name']}>"
+
+
 class DeviceSettingsDefaults(UserDict):
     """Class used for managing an Organization's Device Default settings. Also acts as a
     base class for `DeviceSettings` to manage individual device settings."""

--- a/src/py42/clients/settings/device_settings.py
+++ b/src/py42/clients/settings/device_settings.py
@@ -19,7 +19,7 @@ destination_not_added_error = Py42Error(
 
 
 class IncydrDeviceSettings(UserDict):
-    """Class used to manage individual Incydr devices.  These devices have no backup settings and are only the **notes** and **external reference** fields are modifiable."""
+    """Class used to manage individual Incydr devices.  These devices have no backup settings and only the **notes** and **external reference** fields are modifiable."""
 
     def __init__(self, settings_dict):
         self.changes = {}

--- a/src/py42/clients/settings/org_settings.py
+++ b/src/py42/clients/settings/org_settings.py
@@ -51,7 +51,8 @@ class OrgSettings(UserDict):
     """Notes field for this Org."""
 
     quota_settings_inherited = SettingProperty(
-        "quota_settings_inherited", ["settings", "isUsingQuotaDefaults"],
+        "quota_settings_inherited",
+        ["settings", "isUsingQuotaDefaults"],
     )
     """Determines if Org Quota settings (`maximum_user_subscriptions`, `org_backup_quota`,
     `user_backup_quota`, `archive_hold_days`) are inherited from parent organization.
@@ -105,7 +106,8 @@ class OrgSettings(UserDict):
     """Limit (in MB) to amount of data restorable by non-admin users via web restore."""
 
     reporting_settings_inherited = SettingProperty(
-        "reporting_settings_inherited", ["settings", "isUsingReportingDefaults"],
+        "reporting_settings_inherited",
+        ["settings", "isUsingReportingDefaults"],
     )
     """Determines if Org Reporting settings (`backup_warning_email_days`,
     `backup_critical_email_days', `backup_alert_recipient_emails`) are inherited from

--- a/src/py42/clients/trustedactivities.py
+++ b/src/py42/clients/trustedactivities.py
@@ -4,8 +4,8 @@ from py42.choices import Choices
 class TrustedActivityType(Choices):
     """Constants available for setting the type of a trusted activity.
 
-        * ``DOMAIN``
-        * ``SLACK``
+    * ``DOMAIN``
+    * ``SLACK``
     """
 
     DOMAIN = "DOMAIN"

--- a/src/py42/constants/__init__.py
+++ b/src/py42/constants/__init__.py
@@ -9,8 +9,8 @@ from py42.services.detectionlists.high_risk_employee import HighRiskEmployeeFilt
 class SortDirection(Choices):
     """Constants available to set Code42 request `sort_direction` when sorting returned lists in responses.
 
-        * ``ASC``
-        * ``DESC``
+    * ``ASC``
+    * ``DESC``
     """
 
     DESC = "DESC"

--- a/src/py42/exceptions.py
+++ b/src/py42/exceptions.py
@@ -51,12 +51,12 @@ class Py42ChecksumNotFoundError(Py42ResponseError):
 
     @property
     def checksum_name(self):
-        """ The checksum name. """
+        """The checksum name."""
         return self._checksum_name
 
     @property
     def checksum_value(self):
-        """ The checksum value. """
+        """The checksum value."""
         return self.checksum_value
 
 
@@ -96,7 +96,7 @@ class Py42DeviceNotConnectedError(Py42ResponseError):
 
     @property
     def device_guid(self):
-        """ The device GUID. """
+        """The device GUID."""
         return self._device_guid
 
 
@@ -177,7 +177,7 @@ class Py42OrgNotFoundError(Py42BadRequestError):
 
     @property
     def org_uid(self):
-        """" The org UID. """
+        """ " The org UID."""
         return self._org_uid
 
 
@@ -193,12 +193,12 @@ class Py42ActiveLegalHoldError(Py42BadRequestError):
 
     @property
     def resource(self):
-        """ The user or device resource. """
+        """The user or device resource."""
         return self._resource
 
     @property
     def resource_id(self):
-        """ The resource ID. """
+        """The resource ID."""
         return self._resource_id
 
 
@@ -213,7 +213,7 @@ class Py42UserAlreadyAddedError(Py42BadRequestError):
 
     @property
     def user_id(self):
-        """ The user ID. """
+        """The user ID."""
         return self._user_id
 
 
@@ -228,7 +228,7 @@ class Py42LegalHoldNotFoundOrPermissionDeniedError(Py42ForbiddenError):
 
     @property
     def uid(self):
-        """ The UID of the legal hold resource. """
+        """The UID of the legal hold resource."""
         return self._resource_uid
 
 
@@ -253,7 +253,7 @@ class Py42LegalHoldAlreadyDeactivatedError(Py42BadRequestError):
 
     @property
     def legal_hold_matter_uid(self):
-        """ The legal hold matter UID. """
+        """The legal hold matter UID."""
         return self._legal_hold_matter_uid
 
 
@@ -269,7 +269,7 @@ class Py42LegalHoldAlreadyActiveError(Py42BadRequestError):
 
     @property
     def legal_hold_matter_uid(self):
-        """ The legal hold matter UID. """
+        """The legal hold matter UID."""
         return self._legal_hold_matter_uid
 
 
@@ -285,12 +285,12 @@ class Py42InvalidRuleOperationError(Py42HTTPError):
 
     @property
     def rule_id(self):
-        """ The rule ID. """
+        """The rule ID."""
         return self._rule_id
 
     @property
     def source(self):
-        """ The rule source. """
+        """The rule source."""
         return self._source
 
 
@@ -329,7 +329,7 @@ class Py42InvalidEmailError(Py42InternalServerError):
 
     @property
     def email(self):
-        """ The email being assigned to a user. """
+        """The email being assigned to a user."""
         return self._email
 
 
@@ -388,7 +388,7 @@ class Py42InvalidPageTokenError(Py42BadRequestError):
 
     @property
     def page_token(self):
-        """ The page token. """
+        """The page token."""
         return self._page_token
 
 
@@ -403,12 +403,12 @@ class Py42UserNotOnListError(Py42NotFoundError):
 
     @property
     def user_id(self):
-        """ The user ID. """
+        """The user ID."""
         return self._user_id
 
     @property
     def list_name(self):
-        """ The list name. """
+        """The list name."""
         return self._list_name
 
 
@@ -430,7 +430,7 @@ class Py42UnableToCreateProfileError(Py42BadRequestError):
 
     @property
     def username(self):
-        """ The username of the user. """
+        """The username of the user."""
         return self._username
 
 
@@ -444,7 +444,7 @@ class Py42InvalidRuleError(Py42NotFoundError):
 
     @property
     def rule_id(self):
-        """ The observer rule ID. """
+        """The observer rule ID."""
         return self._rule_id
 
 
@@ -466,7 +466,7 @@ class Py42CaseNameExistsError(Py42BadRequestError):
 
     @property
     def case_name(self):
-        """ The case name. """
+        """The case name."""
         return self._case_name
 
 
@@ -488,7 +488,7 @@ class Py42InvalidCaseUserError(Py42BadRequestError):
 
     @property
     def user(self):
-        """ The user UID. """
+        """The user UID."""
         return self._user_uid
 
 
@@ -521,7 +521,7 @@ class Py42TrustedActivityConflictError(Py42ConflictError):
 
     @property
     def value(self):
-        """ The domain, URL or workspace name. """
+        """The domain, URL or workspace name."""
         return self._value
 
 
@@ -543,7 +543,7 @@ class Py42TrustedActivityIdNotFound(Py42NotFoundError):
 
     @property
     def resource_id(self):
-        """ The resource ID. """
+        """The resource ID."""
         return self._resource_id
 
 

--- a/src/py42/sdk/queries/fileevents/filters/cloud_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/cloud_filter.py
@@ -13,7 +13,7 @@ class Actor(FileEventFilterStringField):
 
 class DirectoryID(FileEventFilterStringField):
     """Class that filters events by unique identifier of the cloud drive or folder where the event
-     occurred (applies to cloud data source events only).
+    occurred (applies to cloud data source events only).
     """
 
     _term = "directoryId"

--- a/src/py42/sdk/queries/fileevents/filters/source_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/source_filter.py
@@ -17,7 +17,7 @@ class SourceCategory(FileEventFilterStringField, Choices):
         - :attr:`SourceCategory.SOURCE_CODE_REPOSITORY`
         - :attr:`SourceCategory.UNCATEGORIZED`
         - :attr:`SourceCategory.UNKNOWN`
-        """
+    """
 
     _term = "sourceCategory"
 

--- a/src/py42/sdk/queries/query_filter.py
+++ b/src/py42/sdk/queries/query_filter.py
@@ -42,7 +42,7 @@ def create_filter_group(query_filter_list, filter_clause):
 
 
 def create_eq_filter_group(term, value):
-    """"Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering results
+    """ "Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering results
     where the value with key ``term`` equals the given value. Useful for creating ``IS``
     filters that are not yet supported in py42 or programmatically crafting filter groups.
 
@@ -59,7 +59,7 @@ def create_eq_filter_group(term, value):
 
 
 def create_not_eq_filter_group(term, value):
-    """"Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering results
+    """ "Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering results
     where the value with key ``term`` does not equal the given value. Useful for creating
     ``IS_NOT`` filters that are not yet supported in py42 or programmatically crafting filter
     groups.
@@ -77,7 +77,7 @@ def create_not_eq_filter_group(term, value):
 
 
 def create_is_in_filter_group(term, value_list):
-    """"Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering results
+    """ "Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering results
     where the value with key ``term`` is one of several values. Useful for creating ``IS_IN``
     filters that are not yet supported in py42 or programmatically crafting filter groups.
 
@@ -94,7 +94,7 @@ def create_is_in_filter_group(term, value_list):
 
 
 def create_not_in_filter_group(term, value_list):
-    """"Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering results
+    """ "Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering results
     where the value with key ``term`` is not one of several values. Useful for creating
     ``NOT_IN`` filters that are not yet supported in py42 or programmatically crafting
     filter groups.
@@ -112,7 +112,7 @@ def create_not_in_filter_group(term, value_list):
 
 
 def create_on_or_after_filter_group(term, value):
-    """"Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering results
+    """ "Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering results
     where the value with key ``term`` is on or after the given value. Examples include
     values describing dates. Useful for creating ``ON_OR_AFTER`` filters that are not yet
     supported in py42  or programmatically crafting filter groups.
@@ -130,7 +130,7 @@ def create_on_or_after_filter_group(term, value):
 
 
 def create_on_or_before_filter_group(term, value):
-    """"Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering results
+    """ "Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering results
     where the value with key ``term`` is on or before the given value. Examples include
     values describing dates. Useful for creating ``ON_OR_BEFORE`` filters that are not
     yet supported in py42 or programmatically crafting filter groups.
@@ -148,7 +148,7 @@ def create_on_or_before_filter_group(term, value):
 
 
 def create_in_range_filter_group(term, start_value, end_value):
-    """"Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering results
+    """ "Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering results
     where the value with key ``term`` is in the given range. Examples include values describing
     dates. Useful for creating a combination of ``ON_OR_AFTER`` and ``ON_OR_BEFORE`` filters
     that are not yet supported in py42 or programmatically crafting filter groups.

--- a/src/py42/services/detectionlists/departing_employee.py
+++ b/src/py42/services/detectionlists/departing_employee.py
@@ -16,10 +16,10 @@ _DATE_FORMAT = "%Y-%m-%d"
 class DepartingEmployeeFilters(_DetectionListFilters, Choices):
     """Constants available for filtering Departing Employee search results.
 
-        * ``OPEN``
-        * ``EXFILTRATION_30_DAYS``
-        * ``EXFILTRATION_24_HOURS``
-        * ``LEAVING_TODAY``
+    * ``OPEN``
+    * ``EXFILTRATION_30_DAYS``
+    * ``EXFILTRATION_24_HOURS``
+    * ``LEAVING_TODAY``
     """
 
     LEAVING_TODAY = "LEAVING_TODAY"

--- a/src/py42/services/detectionlists/high_risk_employee.py
+++ b/src/py42/services/detectionlists/high_risk_employee.py
@@ -12,9 +12,9 @@ from py42.services.util import get_all_pages
 class HighRiskEmployeeFilters(_DetectionListFilters, Choices):
     """Constants available for filtering High Risk Employee search results.
 
-        * ``OPEN``
-        * ``EXFILTRATION_30_DAYS``
-        * ``EXFILTRATION_24_HOURS``
+    * ``OPEN``
+    * ``EXFILTRATION_30_DAYS``
+    * ``EXFILTRATION_24_HOURS``
     """
 
 

--- a/src/py42/services/devices.py
+++ b/src/py42/services/devices.py
@@ -236,13 +236,13 @@ class DeviceService(BaseService):
     def get_agent_state(self, guid, property_name):
         """Gets the agent state of the device.
 
-            Args:
-                guid (str): The globally unique identifier of the device.
-                property_name (str): The name of the property to retrieve (e.g. `fullDiskAccess`).
+        Args:
+            guid (str): The globally unique identifier of the device.
+            property_name (str): The name of the property to retrieve (e.g. `fullDiskAccess`).
 
-            Returns:
-                :class:`py42.response.Py42Response`: A response containing settings information.
-            """
+        Returns:
+            :class:`py42.response.Py42Response`: A response containing settings information.
+        """
         uri = "/api/v14/agent-state/view-by-device-guid"
         params = {"deviceGuid": guid, "propertyName": property_name}
         return self._connection.get(uri, params=params)
@@ -250,12 +250,12 @@ class DeviceService(BaseService):
     def get_agent_full_disk_access_state(self, guid):
         """Gets the full disk access status of a device.
 
-            Args:
-                guid (str): The globally unique identifier of the device.
+        Args:
+            guid (str): The globally unique identifier of the device.
 
-            Returns:
-                :class:`py42.response.Py42Response`: A response containing settings information.
-            """
+        Returns:
+            :class:`py42.response.Py42Response`: A response containing settings information.
+        """
         return self.get_agent_state(guid, "fullDiskAccess")
 
     def get_settings(self, guid):

--- a/src/py42/services/devices.py
+++ b/src/py42/services/devices.py
@@ -268,7 +268,6 @@ class DeviceService(BaseService):
             :class:`py42.clients.settings.device_settings.DeviceSettings`: A class to help manage device settings.
         """
         settings = self.get_by_guid(guid, incSettings=True)
-        print(settings.data)
         if settings.data["service"].lower() == "crashplan":
             return DeviceSettings(settings.data)
         else:

--- a/src/py42/services/orgs.py
+++ b/src/py42/services/orgs.py
@@ -160,13 +160,13 @@ class OrgService(BaseService):
     def get_agent_state(self, org_id, property_name):
         """Gets the agent state of the devices in the org.
 
-            Args:
-                org_id (str): The org's identifier.
-                property_name (str): The name of the property to retrieve (e.g. `fullDiskAccess`).
+        Args:
+            org_id (str): The org's identifier.
+            property_name (str): The name of the property to retrieve (e.g. `fullDiskAccess`).
 
-            Returns:
-                :class:`py42.response.Py42Response`: A response containing settings information.
-            """
+        Returns:
+            :class:`py42.response.Py42Response`: A response containing settings information.
+        """
         uri = "/api/v14/agent-state/view-by-organization-id"
         params = {"orgId": org_id, "propertyName": property_name}
         return self._connection.get(uri, params=params)
@@ -174,12 +174,12 @@ class OrgService(BaseService):
     def get_agent_full_disk_access_states(self, org_id):
         """Gets the full disk access status for devices in an org.
 
-            Args:
-                org_id (str): The org's identifier.
+        Args:
+            org_id (str): The org's identifier.
 
-            Returns:
-                :class:`py42.response.Py42Response`: A response containing settings information.
-            """
+        Returns:
+            :class:`py42.response.Py42Response`: A response containing settings information.
+        """
         return self.get_agent_state(org_id, "fullDiskAccess")
 
     def get_settings(self, org_id):
@@ -190,7 +190,7 @@ class OrgService(BaseService):
 
         Returns:
             :class:`py42.clients._settings_managers.OrgSettings`: A class to help manage org settings.
-                """
+        """
         org_settings = self.get_by_id(
             org_id, incSettings=True, incDeviceDefaults=True, incInheritedOrgInfo=True
         )

--- a/src/py42/services/storage/archive.py
+++ b/src/py42/services/storage/archive.py
@@ -42,7 +42,11 @@ class StorageArchiveService(RestoreService):
         return self._connection.get(uri, params=params)
 
     def create_file_size_job(
-        self, device_guid, file_id, timestamp=None, show_deleted=None,
+        self,
+        device_guid,
+        file_id,
+        timestamp=None,
+        show_deleted=None,
     ):
         uri = "/api/WebRestoreFileSizePolling"
         json_dict = {

--- a/tests/clients/_archiveaccess/test_accessorfactory.py
+++ b/tests/clients/_archiveaccess/test_accessorfactory.py
@@ -32,7 +32,10 @@ class TestArchiveAccessFactory:
         assert ArchiveAccessorFactory(archive_service, storage_service_factory)
 
     def test_create_archive_accessor_with_device_guid_and_destination_guid_returns(
-        self, archive_service, storage_service_factory, storage_archive_service,
+        self,
+        archive_service,
+        storage_service_factory,
+        storage_archive_service,
     ):
         storage_service_factory.create_archive_service.return_value = (
             storage_archive_service
@@ -45,7 +48,10 @@ class TestArchiveAccessFactory:
         )
 
     def test_create_archive_accessor_calls_storage_service_factory_with_correct_args(
-        self, archive_service, storage_service_factory, storage_archive_service,
+        self,
+        archive_service,
+        storage_service_factory,
+        storage_archive_service,
     ):
         storage_service_factory.create_archive_service.return_value = (
             storage_archive_service
@@ -55,11 +61,15 @@ class TestArchiveAccessFactory:
         )
         accessor_factory.create_archive_accessor(TEST_DEVICE_GUID, ArchiveAccessor)
         storage_service_factory.create_archive_service.assert_called_with(
-            TEST_DEVICE_GUID, TEST_DESTINATION_GUID_1,
+            TEST_DEVICE_GUID,
+            TEST_DESTINATION_GUID_1,
         )
 
     def test_create_archive_accessor_with_opt_dest_guid_calls_storage_service_factory_with_correct_args(
-        self, archive_service, storage_service_factory, storage_archive_service,
+        self,
+        archive_service,
+        storage_service_factory,
+        storage_archive_service,
     ):
         storage_service_factory.create_archive_service.return_value = (
             storage_archive_service
@@ -68,14 +78,19 @@ class TestArchiveAccessFactory:
             archive_service, storage_service_factory
         )
         accessor_factory.create_archive_accessor(
-            TEST_DEVICE_GUID, ArchiveAccessor, TEST_DESTINATION_GUID_1,
+            TEST_DEVICE_GUID,
+            ArchiveAccessor,
+            TEST_DESTINATION_GUID_1,
         )
         storage_service_factory.create_archive_service.assert_called_with(
             TEST_DEVICE_GUID, TEST_DESTINATION_GUID_1
         )
 
     def test_create_archive_accessor_creates_web_restore_session_with_correct_args(
-        self, archive_service, storage_service_factory, storage_archive_service,
+        self,
+        archive_service,
+        storage_service_factory,
+        storage_archive_service,
     ):
         storage_service_factory.create_archive_service.return_value = (
             storage_archive_service
@@ -90,7 +105,10 @@ class TestArchiveAccessFactory:
         )
 
     def test_create_archive_accessor_when_given_private_password_creates_expected_restore_session(
-        self, archive_service, storage_service_factory, storage_archive_service,
+        self,
+        archive_service,
+        storage_service_factory,
+        storage_archive_service,
     ):
         storage_service_factory.create_archive_service.return_value = (
             storage_archive_service
@@ -99,7 +117,9 @@ class TestArchiveAccessFactory:
             archive_service, storage_service_factory
         )
         accessor_factory.create_archive_accessor(
-            TEST_DEVICE_GUID, ArchiveAccessor, private_password=TEST_PASSWORD,
+            TEST_DEVICE_GUID,
+            ArchiveAccessor,
+            private_password=TEST_PASSWORD,
         )
         storage_archive_service.create_restore_session.assert_called_once_with(
             TEST_DEVICE_GUID,
@@ -108,7 +128,10 @@ class TestArchiveAccessFactory:
         )
 
     def test_create_archive_accessor_when_given_encryption_key_creates_expected_restore_session(
-        self, archive_service, storage_service_factory, storage_archive_service,
+        self,
+        archive_service,
+        storage_service_factory,
+        storage_archive_service,
     ):
         storage_service_factory.create_archive_service.return_value = (
             storage_archive_service
@@ -127,7 +150,11 @@ class TestArchiveAccessFactory:
         )
 
     def test_create_archive_accessor_calls_create_restore_job_manager_with_correct_args(
-        self, mocker, archive_service, storage_service_factory, storage_archive_service,
+        self,
+        mocker,
+        archive_service,
+        storage_service_factory,
+        storage_archive_service,
     ):
         spy = mocker.spy(
             py42.clients._archiveaccess.accessorfactory, "create_restore_job_manager"

--- a/tests/clients/_archiveaccess/test_init.py
+++ b/tests/clients/_archiveaccess/test_init.py
@@ -301,8 +301,10 @@ def get_get_file_path_metadata_mock(mocker, session_id, device_guid, responses):
 
 
 def mock_get_file_path_metadata_responses(mocker, storage_archive_service, responses):
-    storage_archive_service.get_file_path_metadata.side_effect = get_get_file_path_metadata_mock(
-        mocker, TEST_SESSION_ID, TEST_DEVICE_GUID, responses
+    storage_archive_service.get_file_path_metadata.side_effect = (
+        get_get_file_path_metadata_mock(
+            mocker, TEST_SESSION_ID, TEST_DEVICE_GUID, responses
+        )
     )
 
 
@@ -339,7 +341,10 @@ class TestArchiveContentStreamer:
             file_size_poller,
         )
         archive_accessor.stream_from_backup(
-            TEST_BACKUP_SET_ID, "/", file_size_calc_timeout=0, show_deleted=True,
+            TEST_BACKUP_SET_ID,
+            "/",
+            file_size_calc_timeout=0,
+            show_deleted=True,
         )
         expected_file_selection = [get_file_selection(FileType.DIRECTORY, "/")]
         restore_job_manager.get_stream.assert_called_once_with(
@@ -367,7 +372,9 @@ class TestArchiveContentStreamer:
         )
         expected_file_selection = [get_file_selection(FileType.DIRECTORY, USERS_DIR)]
         restore_job_manager.get_stream.assert_called_once_with(
-            TEST_BACKUP_SET_ID, expected_file_selection, show_deleted=True,
+            TEST_BACKUP_SET_ID,
+            expected_file_selection,
+            show_deleted=True,
         )
 
     def test_stream_from_backup_with_file_path_calls_get_stream(
@@ -391,11 +398,17 @@ class TestArchiveContentStreamer:
             get_file_selection(FileType.FILE, TEST_PATH_TO_FILE_IN_DOWNLOADS_DIR)
         ]
         restore_job_manager.get_stream.assert_called_once_with(
-            TEST_BACKUP_SET_ID, expected_file_selection, show_deleted=None,
+            TEST_BACKUP_SET_ID,
+            expected_file_selection,
+            show_deleted=None,
         )
 
     def test_stream_from_backup_normalizes_windows_paths(
-        self, mocker, storage_archive_service, restore_job_manager, file_size_poller,
+        self,
+        mocker,
+        storage_archive_service,
+        restore_job_manager,
+        file_size_poller,
     ):
         mock_walking_tree_for_windows_path(mocker, storage_archive_service)
         archive_accessor = ArchiveContentStreamer(
@@ -411,11 +424,17 @@ class TestArchiveContentStreamer:
         )
         expected_file_selection = [get_file_selection(FileType.DIRECTORY, "C:/")]
         restore_job_manager.get_stream.assert_called_once_with(
-            TEST_BACKUP_SET_ID, expected_file_selection, show_deleted=None,
+            TEST_BACKUP_SET_ID,
+            expected_file_selection,
+            show_deleted=None,
         )
 
     def test_stream_from_backup_calls_get_file_size_with_expected_params(
-        self, mocker, storage_archive_service, restore_job_manager, file_size_poller,
+        self,
+        mocker,
+        storage_archive_service,
+        restore_job_manager,
+        file_size_poller,
     ):
         mock_walking_to_downloads_folder(mocker, storage_archive_service)
         archive_accessor = ArchiveContentStreamer(
@@ -461,16 +480,32 @@ class TestArchiveContentStreamer:
         )
         expected_file_selection = [
             get_file_selection(
-                FileType.FILE, TEST_PATH_TO_FILE_IN_DOWNLOADS_DIR, 1, 2, 3,
+                FileType.FILE,
+                TEST_PATH_TO_FILE_IN_DOWNLOADS_DIR,
+                1,
+                2,
+                3,
             ),
-            get_file_selection(FileType.DIRECTORY, TEST_DOWNLOADS_DIR, 4, 5, 6,),
+            get_file_selection(
+                FileType.DIRECTORY,
+                TEST_DOWNLOADS_DIR,
+                4,
+                5,
+                6,
+            ),
         ]
         restore_job_manager.get_stream.assert_called_once_with(
-            TEST_BACKUP_SET_ID, expected_file_selection, show_deleted=None,
+            TEST_BACKUP_SET_ID,
+            expected_file_selection,
+            show_deleted=None,
         )
 
     def test_stream_from_backup_with_file_not_in_archive_raises_exception(
-        self, mocker, storage_archive_service, restore_job_manager, file_size_poller,
+        self,
+        mocker,
+        storage_archive_service,
+        restore_job_manager,
+        file_size_poller,
     ):
         mock_walking_to_downloads_folder(mocker, storage_archive_service)
         archive_accessor = ArchiveContentStreamer(
@@ -491,7 +526,11 @@ class TestArchiveContentStreamer:
         restore_job_manager.get_stream.assert_not_called()
 
     def test_stream_from_backup_with_unicode_file_path_not_in_archive_raises_exception(
-        self, mocker, storage_archive_service, restore_job_manager, file_size_poller,
+        self,
+        mocker,
+        storage_archive_service,
+        restore_job_manager,
+        file_size_poller,
     ):
         mock_walking_to_downloads_folder(mocker, storage_archive_service)
         archive_accessor = ArchiveContentStreamer(
@@ -513,7 +552,11 @@ class TestArchiveContentStreamer:
         restore_job_manager.get_stream.assert_not_called()
 
     def test_stream_from_backup_with_drive_not_in_archive_raises_exception(
-        self, mocker, storage_archive_service, restore_job_manager, file_size_poller,
+        self,
+        mocker,
+        storage_archive_service,
+        restore_job_manager,
+        file_size_poller,
     ):
         mock_walking_to_downloads_folder(mocker, storage_archive_service)
         archive_accessor = ArchiveContentStreamer(
@@ -537,7 +580,11 @@ class TestArchiveContentStreamer:
         restore_job_manager.get_stream.assert_not_called()
 
     def test_stream_from_backup_with_case_sensitive_drive_not_in_archive_raises_exception(
-        self, mocker, storage_archive_service, restore_job_manager, file_size_poller,
+        self,
+        mocker,
+        storage_archive_service,
+        restore_job_manager,
+        file_size_poller,
     ):
         mock_walking_to_downloads_folder(mocker, storage_archive_service)
         archive_accessor = ArchiveContentStreamer(
@@ -561,7 +608,11 @@ class TestArchiveContentStreamer:
         restore_job_manager.get_stream.assert_not_called()
 
     def test_stream_from_backup_uses_show_deleted_param_on_get_file_path_metadata(
-        self, mocker, storage_archive_service, restore_job_manager, file_size_poller,
+        self,
+        mocker,
+        storage_archive_service,
+        restore_job_manager,
+        file_size_poller,
     ):
         mock_walking_to_downloads_folder(mocker, storage_archive_service)
         archive_accessor = ArchiveContentStreamer(

--- a/tests/clients/_archiveaccess/test_restoremanager.py
+++ b/tests/clients/_archiveaccess/test_restoremanager.py
@@ -123,7 +123,8 @@ class TestFileSizePoller:
         return create_job
 
     def get_file_sizes_polling_status_side_effect(
-        self, mocker,
+        self,
+        mocker,
     ):
         def get_status(job_id, device_guid):
             if job_id == self.DOWNLOADS_JOB:
@@ -139,11 +140,11 @@ class TestFileSizePoller:
     def test_get_file_sizes_returns_sizes_for_each_id(
         self, mocker, storage_archive_service
     ):
-        storage_archive_service.create_file_size_job.side_effect = self.get_create_job_side_effect(
-            mocker
+        storage_archive_service.create_file_size_job.side_effect = (
+            self.get_create_job_side_effect(mocker)
         )
-        storage_archive_service.get_file_size_job.side_effect = self.get_file_sizes_polling_status_side_effect(
-            mocker
+        storage_archive_service.get_file_size_job.side_effect = (
+            self.get_file_sizes_polling_status_side_effect(mocker)
         )
         poller = FileSizePoller(storage_archive_service, TEST_DEVICE_GUID)
         actual = poller.get_file_sizes(
@@ -169,8 +170,8 @@ class TestFileSizePoller:
     def test_get_file_sizes_waits_for_size_calculation(
         self, mocker, storage_archive_service
     ):
-        storage_archive_service.create_file_size_job.side_effect = self.get_create_job_side_effect(
-            mocker
+        storage_archive_service.create_file_size_job.side_effect = (
+            self.get_create_job_side_effect(mocker)
         )
 
         desktop_statuses = ["DONE", "WORKING", "WORKING"]
@@ -202,8 +203,8 @@ class TestFileSizePoller:
                 *args, **kwargs
             )
 
-        storage_archive_service.create_file_size_job.side_effect = self.get_create_job_side_effect(
-            mocker
+        storage_archive_service.create_file_size_job.side_effect = (
+            self.get_create_job_side_effect(mocker)
         )
         storage_archive_service.get_file_size_job.side_effect = take_too_long
         poller = FileSizePoller(storage_archive_service, TEST_DEVICE_GUID)

--- a/tests/clients/settings/test_device_settings.py
+++ b/tests/clients/settings/test_device_settings.py
@@ -582,7 +582,8 @@ class TestDeviceSettings:
         ],
     )
     def test_device_settings_setting_mutable_property_updates_dict_correctly_and_registers_changes(
-        self, param,
+        self,
+        param,
     ):
         setattr(self.device_settings, param.name, param.new_val)
         assert (
@@ -617,7 +618,8 @@ class TestDeviceSettings:
         ],
     )
     def test_device_settings_setting_mutable_property_updates_dict_correctly_and_registers_changes_when_setting_locked(
-        self, param,
+        self,
+        param,
     ):
         setattr(self.device_settings, param.name, param.new_val)
         assert (
@@ -633,11 +635,15 @@ class TestDeviceSettings:
 class TestDeviceSettingsBackupSets:
     device_settings = DeviceSettings(deepcopy(DEVICE_DICT_W_SETTINGS))
 
-    def test_backup_set_destinations_property_returns_expected_value(self,):
+    def test_backup_set_destinations_property_returns_expected_value(
+        self,
+    ):
         expected_destinations = {"4200": "Dest42 <LOCKED>", "4300": "Dest43"}
         assert self.device_settings.backup_sets[0].destinations == expected_destinations
 
-    def test_backup_set_add_destination_when_destination_available(self,):
+    def test_backup_set_add_destination_when_destination_available(
+        self,
+    ):
         self.device_settings.backup_sets[0].add_destination(4400)
         expected_destinations_property = {
             "4200": "Dest42 <LOCKED>",
@@ -660,7 +666,9 @@ class TestDeviceSettingsBackupSets:
             == expected_destinations_dict
         )
 
-    def test_backup_set_add_destination_when_destination_not_available_raises(self,):
+    def test_backup_set_add_destination_when_destination_not_available_raises(
+        self,
+    ):
         expected_destinations_property = {
             "4200": "Dest42 <LOCKED>",
             "4300": "Dest43",
@@ -673,7 +681,9 @@ class TestDeviceSettingsBackupSets:
             == expected_destinations_property
         )
 
-    def test_backup_set_remove_destination_when_destination_available(self,):
+    def test_backup_set_remove_destination_when_destination_available(
+        self,
+    ):
         expected_destinations_property = {
             "4200": "Dest42 <LOCKED>",
             "4300": "Dest43",
@@ -694,7 +704,9 @@ class TestDeviceSettingsBackupSets:
             == expected_destinations_dict
         )
 
-    def test_backup_set_remove_destination_when_destination_not_available_raises(self,):
+    def test_backup_set_remove_destination_when_destination_not_available_raises(
+        self,
+    ):
         expected_destinations_property = {
             "4200": "Dest42 <LOCKED>",
             "4300": "Dest43",

--- a/tests/clients/settings/test_incydr_device_settings.py
+++ b/tests/clients/settings/test_incydr_device_settings.py
@@ -1,0 +1,106 @@
+import pytest
+from tests.clients.conftest import param
+
+from py42.clients.settings import get_val
+from py42.clients.settings.device_settings import IncydrDeviceSettings
+
+TEST_USER_ID = 13548744
+TEST_COMPUTER_ID = 4290210
+TEST_COMPUTER_GUID = "42000000"
+TEST_COMPUTER_ORG_ID = 424242
+TEST_DEVICE_VERSION = 4200000000001
+TEST_COMPUTER_NAME = "Incydr Settings Test Device"
+
+INCYDR_DEVICE_DICT_W_SETTINGS = {
+    "computerId": 4290210,
+    "name": "Incydr Settings Test Device",
+    "osHostname": "DESKTOP-I2SKEML",
+    "guid": "42000000",
+    "type": "COMPUTER",
+    "status": "Active",
+    "active": True,
+    "blocked": False,
+    "alertState": 0,
+    "alertStates": ["OK"],
+    "userId": 13548744,
+    "userUid": "1010090007721726158",
+    "orgId": 424242,
+    "orgUid": "985187827481212202",
+    "computerExtRef": None,
+    "notes": None,
+    "parentComputerId": None,
+    "parentComputerGuid": None,
+    "lastConnected": "2021-07-22T12:38:54.854Z",
+    "osName": "Windows",
+    "osVersion": "10.0.19041",
+    "osArch": "x86-64",
+    "address": "192.168.223.128",
+    "remoteAddress": "50.237.14.12",
+    "javaVersion": "",
+    "modelInfo": "",
+    "timeZone": "(UTC-06:00) Central Time (US & Cana",
+    "version": 4200000000001,
+    "productVersion": "0.0.1",
+    "buildVersion": 3531,
+    "creationDate": "2021-06-04T14:30:51.392Z",
+    "modificationDate": "2021-07-22T12:38:54.854Z",
+    "loginDate": "2021-06-04T14:30:51.362Z",
+    "service": "Artemis",
+    "orgSettings": {"securityKeyLocked": False},
+}
+
+
+class TestIncydrDeviceSettings:
+    device_settings = IncydrDeviceSettings(INCYDR_DEVICE_DICT_W_SETTINGS)
+
+    @pytest.mark.parametrize(
+        "param",
+        [
+            ("name", TEST_COMPUTER_NAME),
+            ("computer_id", TEST_COMPUTER_ID),
+            ("device_id", TEST_COMPUTER_ID),
+            ("guid", TEST_COMPUTER_GUID),
+            ("user_id", TEST_USER_ID),
+            ("org_id", TEST_COMPUTER_ORG_ID),
+            ("version", TEST_DEVICE_VERSION),
+        ],
+    )
+    def test_device_settings_properties_return_expected_value_and_cannot_be_changed(
+        self, param
+    ):
+        name, expected_value = param
+        assert getattr(self.device_settings, name) == expected_value
+        with pytest.raises(AttributeError):
+            setattr(self.device_settings, name, expected_value)
+
+    @pytest.mark.parametrize("param", [("notes", None), ("external_reference", None)])
+    def test_device_settings_get_mutable_properties_return_expected_values(self, param):
+        name, expected_value = param
+        assert getattr(self.device_settings, name) == expected_value
+
+    @pytest.mark.parametrize(
+        "param",
+        [
+            param(
+                name="notes",
+                new_val="an Incydr device note.",
+                expected_stored_val="an Incydr device note.",
+                dict_location=["notes"],
+            ),
+            param(
+                name="external_reference",
+                new_val="reference#id",
+                expected_stored_val="reference#id",
+                dict_location=["computerExtRef"],
+            ),
+        ],
+    )
+    def test_device_settings_setting_mutable_property_updates_dict_correctly_and_registers_changes(
+        self, param
+    ):
+        setattr(self.device_settings, param.name, param.new_val)
+        assert (
+            get_val(self.device_settings.data, param.dict_location)
+            == param.expected_stored_val
+        )
+        assert param.name in self.device_settings.changes

--- a/tests/clients/settings/test_incydr_device_settings.py
+++ b/tests/clients/settings/test_incydr_device_settings.py
@@ -26,8 +26,8 @@ INCYDR_DEVICE_DICT_W_SETTINGS = {
     "userUid": "1010090007721726158",
     "orgId": 424242,
     "orgUid": "985187827481212202",
-    "computerExtRef": None,
-    "notes": None,
+    "computerExtRef": "ext ref",
+    "notes": "My device setting note!",
     "parentComputerId": None,
     "parentComputerGuid": None,
     "lastConnected": "2021-07-22T12:38:54.854Z",
@@ -73,7 +73,10 @@ class TestIncydrDeviceSettings:
         with pytest.raises(AttributeError):
             setattr(self.device_settings, name, expected_value)
 
-    @pytest.mark.parametrize("param", [("notes", None), ("external_reference", None)])
+    @pytest.mark.parametrize(
+        "param",
+        [("notes", "My device setting note!"), ("external_reference", "ext ref")],
+    )
     def test_device_settings_get_mutable_properties_return_expected_values(self, param):
         name, expected_value = param
         assert getattr(self.device_settings, name) == expected_value

--- a/tests/clients/test_alerts.py
+++ b/tests/clients/test_alerts.py
@@ -208,7 +208,10 @@ class TestAlertsClient:
         assert alert_client.rules
 
     def test_alerts_client_calls_search_with_expected_value(
-        self, mock_alerts_service, mock_alert_rules_service, mock_alert_query,
+        self,
+        mock_alerts_service,
+        mock_alert_rules_service,
+        mock_alert_query,
     ):
         alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
         alert_client.search(mock_alert_query)
@@ -222,7 +225,9 @@ class TestAlertsClient:
         mock_alerts_service.get_details.assert_called_once_with(self._alert_ids)
 
     def test_alerts_client_calls_update_state_with_resolve_state_and_expected_value(
-        self, mock_alerts_service, mock_alert_rules_service,
+        self,
+        mock_alerts_service,
+        mock_alert_rules_service,
     ):
         alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
         alert_client.resolve(self._alert_ids)
@@ -231,7 +236,9 @@ class TestAlertsClient:
         )
 
     def test_alerts_client_calls_update_state_with_reopen_state_and_expected_value(
-        self, mock_alerts_service, mock_alert_rules_service,
+        self,
+        mock_alerts_service,
+        mock_alert_rules_service,
     ):
         alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
         alert_client.reopen(self._alert_ids)
@@ -240,7 +247,9 @@ class TestAlertsClient:
         )
 
     def test_alerts_client_calls_update_state_with_state_and_expected_value(
-        self, mock_alerts_service, mock_alert_rules_service,
+        self,
+        mock_alerts_service,
+        mock_alert_rules_service,
     ):
         alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
         alert_client.update_state("RESOLVED", self._alert_ids)
@@ -249,14 +258,18 @@ class TestAlertsClient:
         )
 
     def test_alerts_client_calls_update_note_with_expected_value_and_param(
-        self, mock_alerts_service, mock_alert_rules_service,
+        self,
+        mock_alerts_service,
+        mock_alert_rules_service,
     ):
         alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
         alert_client.update_note("alert-id", "a note")
         mock_alerts_service.update_note.assert_called_once_with("alert-id", "a note")
 
     def test_alerts_client_calls_search_all_pages_with_expected_value_and_param(
-        self, mock_alerts_service, mock_alert_rules_service,
+        self,
+        mock_alerts_service,
+        mock_alert_rules_service,
     ):
         alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
         query = AlertQuery()
@@ -264,7 +277,9 @@ class TestAlertsClient:
         mock_alerts_service.search_all_pages.assert_called_once_with(query)
 
     def test_alerts_client_calls_get_aggregate_data_with_expected_value_and_param(
-        self, mock_alerts_service, mock_alert_rules_service,
+        self,
+        mock_alerts_service,
+        mock_alert_rules_service,
     ):
         alert_client = AlertsClient(mock_alerts_service, mock_alert_rules_service)
         alert_client.get_aggregate_data("alert-id")

--- a/tests/clients/test_securitydata.py
+++ b/tests/clients/test_securitydata.py
@@ -230,11 +230,11 @@ class TestSecurityClient:
         file_event_service.search.return_value = create_mock_response(
             mocker, FILE_EVENTS_RESPONSE
         )
-        preservation_data_service.get_file_version_list.return_value = create_mock_response(
-            mocker, PDS_FILE_VERSIONS
+        preservation_data_service.get_file_version_list.return_value = (
+            create_mock_response(mocker, PDS_FILE_VERSIONS)
         )
-        file_event_service.get_file_location_detail_by_sha256.return_value = create_mock_response(
-            mocker, FILE_LOCATION_RESPONSE
+        file_event_service.get_file_location_detail_by_sha256.return_value = (
+            create_mock_response(mocker, FILE_LOCATION_RESPONSE)
         )
         storage_node_client = mocker.MagicMock(spec=StoragePreservationDataService)
         storage_node_client.get_download_token.return_value = file_download
@@ -258,7 +258,8 @@ class TestSecurityClient:
         return mock
 
     def test_stream_file_by_sha256_with_exact_match_response_calls_get_version_list_with_expected_params(
-        self, pds_config,
+        self,
+        pds_config,
     ):
 
         security_client = SecurityDataClient(
@@ -293,7 +294,9 @@ class TestSecurityClient:
         assert response == b"stream"
 
     def test_stream_file_by_sha256_without_exact_match_response_calls_get_version_list_with_expected_params(
-        self, mocker, pds_config,
+        self,
+        mocker,
+        pds_config,
     ):
         pds_config.file_event_service.search.return_value = create_mock_response(
             mocker, FILE_EVENTS_RESPONSE.replace("-2", "-6")
@@ -349,7 +352,9 @@ class TestSecurityClient:
         assert "No files found with SHA256 checksum" in e.value.args[0]
 
     def test_stream_file_by_sha256_when_file_versions_returns_empty_response_gets_version_from_other_location(
-        self, mocker, pds_config,
+        self,
+        mocker,
+        pds_config,
     ):
         available_version = create_mock_response(mocker, AVAILABLE_VERSION_RESPONSE)
         file_version_list = create_mock_response(mocker, '{"preservationVersions": []}')
@@ -382,7 +387,9 @@ class TestSecurityClient:
         )
 
     def test_stream_file_by_sha256_when_get_locations_returns_empty_list_raises_py42_error(
-        self, mocker, pds_config,
+        self,
+        mocker,
+        pds_config,
     ):
         file_version_list = create_mock_response(mocker, '{"preservationVersions": []}')
         file_location = create_mock_response(mocker, '{"locations": []}')
@@ -405,7 +412,9 @@ class TestSecurityClient:
         assert e.value.args[0] == PDS_EXCEPTION_MESSAGE.format("shahash")
 
     def test_stream_file_by_sha256_when_find_file_version_returns_204_status_code_raises_py42_error(
-        self, mocker, pds_config,
+        self,
+        mocker,
+        pds_config,
     ):
         file_version_list = create_mock_response(mocker, '{"preservationVersions": []}')
         pds_config.preservation_data_service.get_file_version_list.return_value = (
@@ -431,7 +440,8 @@ class TestSecurityClient:
         assert e.value.args[0] == PDS_EXCEPTION_MESSAGE.format("shahash")
 
     def test_stream_file_by_md5_with_exact_match_response_calls_get_version_list_with_expected_params(
-        self, pds_config,
+        self,
+        pds_config,
     ):
         security_client = SecurityDataClient(
             pds_config.file_event_service,
@@ -465,7 +475,9 @@ class TestSecurityClient:
         assert response == b"stream"
 
     def test_stream_file_by_md5_without_exact_match_response_calls_get_version_list_with_expected_params(
-        self, mocker, pds_config,
+        self,
+        mocker,
+        pds_config,
     ):
         pds_config.file_event_service.search.return_value = create_mock_response(
             mocker, FILE_EVENTS_RESPONSE.replace("-2", "-6")
@@ -522,7 +534,9 @@ class TestSecurityClient:
         assert "No files found with MD5 checksum" in e.value.args[0]
 
     def test_stream_file_by_md5_when_file_versions_returns_empty_response_gets_version_from_other_location(
-        self, mocker, pds_config,
+        self,
+        mocker,
+        pds_config,
     ):
         file_version_list = create_mock_response(mocker, '{"preservationVersions": []}')
         pds_config.preservation_data_service.get_file_version_list.return_value = (

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -47,7 +47,8 @@ def _get_sdk(host, user, pw):
         return _sdk.from_local_account(host, user, pw)
     except Exception as err:
         pytest.exit(
-            f"Failed to init SDK for integration tests: {err}", returncode=1,
+            f"Failed to init SDK for integration tests: {err}",
+            returncode=1,
         )
 
 

--- a/tests/integration/test_cases.py
+++ b/tests/integration/test_cases.py
@@ -9,7 +9,8 @@ class TestCases:
         return connection.cases.create(f"integration_test_{timestamp}")
 
     def test_get_all_cases(
-        self, connection,
+        self,
+        connection,
     ):
         page_gen = connection.cases.get_all()
         for response in page_gen:

--- a/tests/integration/test_trustedactivites.py
+++ b/tests/integration/test_trustedactivites.py
@@ -9,7 +9,8 @@ class TestTrustedActivities:
         return connection.trustedactivities.create("DOMAIN", "test.com")
 
     def test_get_all_trusted_activities(
-        self, connection,
+        self,
+        connection,
     ):
         page_gen = connection.trustedactivities.get_all()
         for response in page_gen:
@@ -17,7 +18,8 @@ class TestTrustedActivities:
             break
 
     def test_get_all_trusted_activities_with_optional_params(
-        self, connection,
+        self,
+        connection,
     ):
         page_gen = connection.trustedactivities.get_all(type="DOMAIN", page_size=1)
         for response in page_gen:

--- a/tests/sdk/queries/fileevents/filters/test_print_filter.py
+++ b/tests/sdk/queries/fileevents/filters/test_print_filter.py
@@ -9,7 +9,8 @@ from py42.sdk.queries.fileevents.filters.print_filter import PrintJobName
 
 
 @pytest.mark.parametrize(
-    "filter_criteria, test_filter", [(Printer.eq, IS), (Printer.not_eq, IS_NOT)],
+    "filter_criteria, test_filter",
+    [(Printer.eq, IS), (Printer.not_eq, IS_NOT)],
 )
 def test_equality_printer_name_filter_gives_correct_json_representation(
     filter_criteria, test_filter
@@ -20,7 +21,8 @@ def test_equality_printer_name_filter_gives_correct_json_representation(
 
 
 @pytest.mark.parametrize(
-    "filter_criteria, test_filter", [(Printer.is_in, IS_IN), (Printer.not_in, NOT_IN)],
+    "filter_criteria, test_filter",
+    [(Printer.is_in, IS_IN), (Printer.not_in, NOT_IN)],
 )
 def test_multi_value_printer_name_gives_correct_json_representation(
     filter_criteria, test_filter

--- a/tests/services/detectionlists/test_high_risk_employee.py
+++ b/tests/services/detectionlists/test_high_risk_employee.py
@@ -143,7 +143,10 @@ class TestHighRiskEmployeeClient:
         assert posted_data["userId"] == "942897397520289999"
 
     def test_get_posts_expected_data(
-        self, user_context, mock_connection, mock_detection_list_user_client,
+        self,
+        user_context,
+        mock_connection,
+        mock_detection_list_user_client,
     ):
         high_risk_employee_client = HighRiskEmployeeService(
             mock_connection, user_context, mock_detection_list_user_client
@@ -159,7 +162,10 @@ class TestHighRiskEmployeeClient:
         )
 
     def test_get_all_posts_expected_data(
-        self, user_context, mock_connection, mock_detection_list_user_client,
+        self,
+        user_context,
+        mock_connection,
+        mock_detection_list_user_client,
     ):
         high_risk_employee_client = HighRiskEmployeeService(
             mock_connection, user_context, mock_detection_list_user_client

--- a/tests/services/detectionlists/test_user_profile.py
+++ b/tests/services/detectionlists/test_user_profile.py
@@ -36,7 +36,10 @@ class TestDetectionListUserClient:
 
     @pytest.fixture
     def mock_user_client_raises_exception(
-        self, mocker, mock_connection, user_context,
+        self,
+        mocker,
+        mock_connection,
+        user_context,
     ):
         user_client = UserService(mock_connection)
         mock_connection.post.side_effect = create_mock_error(

--- a/tests/services/storage/test_service_factory.py
+++ b/tests/services/storage/test_service_factory.py
@@ -119,7 +119,9 @@ class TestStorageSessionManager:
         with pytest.raises(Py42StorageSessionInitializationError):
             storage_session_manager.get_storage_connection(mock_tmp_auth)
 
-    def test_get_storage_session_get_saved_session_initially_returns_none(self,):
+    def test_get_storage_session_get_saved_session_initially_returns_none(
+        self,
+    ):
         storage_session_manager = ConnectionManager()
         assert (
             storage_session_manager.get_saved_connection_for_url("testhost.com") is None

--- a/tests/services/test_devices.py
+++ b/tests/services/test_devices.py
@@ -5,9 +5,12 @@ from tests.conftest import create_mock_error
 from tests.conftest import create_mock_response
 
 import py42
+from py42.clients.settings.device_settings import DeviceSettings
+from py42.clients.settings.device_settings import IncydrDeviceSettings
 from py42.exceptions import Py42ActiveLegalHoldError
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42OrgNotFoundError
+from py42.response import Py42Response
 from py42.services.devices import DeviceService
 
 COMPUTER_URI = "/api/v1/Computer"
@@ -163,3 +166,70 @@ class TestDeviceService:
 
         assert "The organization with UID 'TestOrgUid' was not found." in str(err.value)
         assert err.value.org_uid == "TestOrgUid"
+
+    def test_get_settings_returns_crashplan_settings_when_crashplan_service(
+        self, mocker, mock_connection
+    ):
+        text = """{"service": "Crashplan", "availableDestinations": "", "settings": {"serviceBackupConfig": {"backupConfig": {"backupSets": ""}}}}"""
+        requests_response = mocker.MagicMock(spec=Response)
+        requests_response.text = text
+        client = DeviceService(mock_connection)
+        mock_connection.get.return_value = Py42Response(requests_response)
+        settings = client.get_settings("42")
+        assert isinstance(settings, DeviceSettings)
+
+    def test_get_settings_returns_incydr_settings_when_artemis_service(
+        self, mocker, mock_connection
+    ):
+        text = """{"service": "Artemis"}"""
+        # response = """{'computerId': 3985, 'name': '994627866755117009', 'osHostname': 'DESKTOP-I2SKEML', 'guid': '994627866755117009', 'type': 'COMPUTER', 'status': 'Active', 'active': True, 'blocked': False, 'alertState': 0, 'alertStates': ['OK'], 'userId': 6340, 'userUid': '994627866352463825', 'orgId': 3332, 'orgUid': '985187827481212202', 'computerExtRef': None, 'notes': None, 'parentComputerId': None, 'parentComputerGuid': None, 'lastConnected': '2021-02-17T20:00:06.959Z', 'osName': 'win', 'osVersion': 'DontKnow', 'osArch': 'DontKnow', 'address': None, 'remoteAddress': None, 'javaVersion': '', 'modelInfo': '', 'timeZone': None, 'version': 0, 'productVersion': '1.1.1970', 'buildVersion': None, 'creationDate': '2021-02-17T20:00:06.994Z', 'modificationDate': '2021-02-17T20:00:06.994Z', 'loginDate': '2021-02-17T20:00:06.959Z', 'service': None, 'orgSettings': {'securityKeyLocked': False}}"""
+        requests_response = mocker.MagicMock(spec=Response)
+        requests_response.text = text
+        client = DeviceService(mock_connection)
+        mock_connection.get.return_value = Py42Response(requests_response)
+        settings = client.get_settings("42")
+        assert isinstance(settings, IncydrDeviceSettings)
+
+    def test_get_settings_returns_incydr_settings_when_unspecified_service(
+        self, mocker, mock_connection
+    ):
+        text = """{"service": ""}"""
+        requests_response = mocker.MagicMock(spec=Response)
+        requests_response.text = text
+        client = DeviceService(mock_connection)
+        mock_connection.get.return_value = Py42Response(requests_response)
+        settings = client.get_settings("42")
+        assert isinstance(settings, IncydrDeviceSettings)
+
+    def test_update_settings_calls_api_with_expected_params_when_crashplan(
+        self, mock_connection
+    ):
+        device_id = "123"
+        device_dict = {
+            "computerId": device_id,
+            "service": "Crashplan",
+            "availableDestinations": "",
+            "settings": {
+                "configDateMs": "123",
+                "serviceBackupConfig": {"backupConfig": {"backupSets": ""}},
+            },
+        }
+        settings = DeviceSettings(device_dict)
+        client = DeviceService(mock_connection)
+        client.update_settings(settings)
+        uri = f"/api/v1/Computer/{device_id}"
+        assert "settings" in settings
+        assert "configDateMs" in settings["settings"]
+        mock_connection.put.assert_called_once_with(uri, json=settings)
+
+    def test_update_settings_calls_api_with_expected_params_when_incydr(
+        self, mock_connection
+    ):
+        device_id = "123"
+        device_dict = {"computerId": device_id, "service": "Artemis"}
+        settings = IncydrDeviceSettings(device_dict)
+        client = DeviceService(mock_connection)
+        client.update_settings(settings)
+        uri = f"/api/v1/Computer/{device_id}"
+        assert "settings" not in settings
+        mock_connection.put.assert_called_once_with(uri, json=settings)

--- a/tests/services/test_devices.py
+++ b/tests/services/test_devices.py
@@ -182,7 +182,6 @@ class TestDeviceService:
         self, mocker, mock_connection
     ):
         text = """{"service": "Artemis"}"""
-        # response = """{'computerId': 3985, 'name': '994627866755117009', 'osHostname': 'DESKTOP-I2SKEML', 'guid': '994627866755117009', 'type': 'COMPUTER', 'status': 'Active', 'active': True, 'blocked': False, 'alertState': 0, 'alertStates': ['OK'], 'userId': 6340, 'userUid': '994627866352463825', 'orgId': 3332, 'orgUid': '985187827481212202', 'computerExtRef': None, 'notes': None, 'parentComputerId': None, 'parentComputerGuid': None, 'lastConnected': '2021-02-17T20:00:06.959Z', 'osName': 'win', 'osVersion': 'DontKnow', 'osArch': 'DontKnow', 'address': None, 'remoteAddress': None, 'javaVersion': '', 'modelInfo': '', 'timeZone': None, 'version': 0, 'productVersion': '1.1.1970', 'buildVersion': None, 'creationDate': '2021-02-17T20:00:06.994Z', 'modificationDate': '2021-02-17T20:00:06.994Z', 'loginDate': '2021-02-17T20:00:06.959Z', 'service': None, 'orgSettings': {'securityKeyLocked': False}}"""
         requests_response = mocker.MagicMock(spec=Response)
         requests_response.text = text
         client = DeviceService(mock_connection)

--- a/tests/services/test_devices.py
+++ b/tests/services/test_devices.py
@@ -218,8 +218,6 @@ class TestDeviceService:
         client = DeviceService(mock_connection)
         client.update_settings(settings)
         uri = f"/api/v1/Computer/{device_id}"
-        assert "settings" in settings
-        assert "configDateMs" in settings["settings"]
         mock_connection.put.assert_called_once_with(uri, json=settings)
 
     def test_update_settings_calls_api_with_expected_params_when_incydr(
@@ -231,5 +229,4 @@ class TestDeviceService:
         client = DeviceService(mock_connection)
         client.update_settings(settings)
         uri = f"/api/v1/Computer/{device_id}"
-        assert "settings" not in settings
         mock_connection.put.assert_called_once_with(uri, json=settings)

--- a/tests/services/test_savedsearch.py
+++ b/tests/services/test_savedsearch.py
@@ -68,7 +68,8 @@ class TestSavedSearchService:
         file_event_service = FileEventService(mock_connection)
         saved_search_client = SavedSearchService(mock_connection, file_event_service)
         saved_search_client.execute(
-            "test-id", page_number=test_custom_page_num,
+            "test-id",
+            page_number=test_custom_page_num,
         )
         assert mock_connection.post.call_count == 1
         posted_data = mock_connection.post.call_args[1]["json"]

--- a/tests/services/test_trustedactivities.py
+++ b/tests/services/test_trustedactivities.py
@@ -90,7 +90,8 @@ class TestTrustedActivitiesService:
     def test_create_called_with_expected_url_and_params(self, mock_connection):
         trusted_activities_service = TrustedActivitiesService(mock_connection)
         trusted_activities_service.create(
-            "DOMAIN", "test.com",
+            "DOMAIN",
+            "test.com",
         )
         assert mock_connection.post.call_args[0][0] == _BASE_URI
         data = {


### PR DESCRIPTION
### Description of Change ###

Adds the `IncydrDeviceSettings` class to manage device settings on Incydr devices, ie. computers without backup settings.  Previously, trying to get the device settings of an Incydr machine threw an error because we assume backup configuration values would be provided.

Created a whole new class instead of trying to reorganize the existing backup-related code to accommodate it.

- upgraded black to v22.3.0 which caused a lot of small changes
- upgraded CLA-assistant to latest version which will take affect on any future PRs 

### Testing Procedure ###

Users should be able to use the `DeviceService` methods `get_settings()` and `update_settings()` to view properties and update the _notes_ and _external_reference_ fields on the device settings of Incydr devices.

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [x] Add docstrings for any new public parameters / methods / classes
