### PR TITLE
Add DeviceSettingsDefaults inherited members to docs

### DIFF
--- a/docs/methoddocs/devicesettings.md
+++ b/docs/methoddocs/devicesettings.md
@@ -10,4 +10,5 @@
 .. autoclass:: py42.clients.settings.device_settings.DeviceSettings
     :members:
     :show-inheritance:
+    :inherited-members: UserDict
 ```


### PR DESCRIPTION
Makes properties like `available_destinations` visible on the DeviceSettings class method docs