### PR TITLE
Bugfix/handle empty archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
     - `add_cloud_aliases()`
     - `delete_cloud_aliases()`
 
+### Fixed
+
+- Bug where attempting to restore from an empty archive would throw a confusing `TypeError`, we now raise appropriate `Py42ArchiveFileNotFoundError`.
+
 ## 1.22.0 - 2022-04-01
 
 ### Added

--- a/src/py42/response.py
+++ b/src/py42/response.py
@@ -111,7 +111,8 @@ class Py42Response:
             if not self._data:
                 response_dict = json.loads(self._response.text)
                 if type(response_dict) == dict:
-                    self._data = response_dict.get("data") or response_dict
+                    data = response_dict.get("data")
+                    self._data = data if data is not None else response_dict
                 else:
                     self._data = response_dict
         except ValueError:

--- a/src/py42/response.py
+++ b/src/py42/response.py
@@ -111,8 +111,10 @@ class Py42Response:
             if not self._data:
                 response_dict = json.loads(self._response.text)
                 if type(response_dict) == dict:
-                    data = response_dict.get("data")
-                    self._data = data if data is not None else response_dict
+                    if "data" in response_dict:
+                        self._data = response_dict["data"]
+                    else:
+                        self._data = response_dict
                 else:
                     self._data = response_dict
         except ValueError:

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -11,6 +11,7 @@ JSON_DICT_WITH_DATA_NODE = '{"data": {"item_list_key": {"foo": "foo_val"}}}'
 
 JSON_LIST_NO_DATA_NODE = '{"item_list_key": [{"foo": "foo_val"}, {"bar": "bar_val"}]}'
 JSON_DICT_NO_DATA_NODE = '{"item_list_key": {"foo": "foo_val", "bar": "bar_val"}}'
+JSON_DICT_EMPTY_DATA_NODE = '{"data": []}'
 
 PLAIN_TEXT = "TEST_PLAIN_TEXT"
 
@@ -45,6 +46,13 @@ class TestPy42Response:
         return mock_response
 
     @pytest.fixture
+    def mock_response_dict_empty_data_node(self, mocker):
+        mock_response = mocker.MagicMock(spec=Response)
+        mock_response.content = JSON_DICT_EMPTY_DATA_NODE.encode("utf-8")
+        mock_response.text = JSON_DICT_EMPTY_DATA_NODE
+        return mock_response
+
+    @pytest.fixture
     def mock_response_not_json(self, mocker):
         mock_response = mocker.MagicMock(spec=Response)
         mock_response.status_code = 200
@@ -76,6 +84,12 @@ class TestPy42Response:
     ):
         response = Py42Response(mock_response_dict_no_data_node)
         assert type(response["item_list_key"]) == dict
+
+    def test_getitem_returns_empty_list_empty_data_node(
+        self, mock_response_dict_empty_data_node
+    ):
+        response = Py42Response(mock_response_dict_empty_data_node)
+        assert response.data == []
 
     def test_setitem_modifies_dict_keys_with_data_node_to_expected_value(
         self, mock_response_dict_data_node


### PR DESCRIPTION
### Description of Change ###

`py42.response.Py42Response`'s handling of the "data" property fails when the key "data" exists, but the value is false-y, like an empty list. If the "data" exists, we want to return it, regardless of its truthiness. 

This came up in the `stream_to_device()` push restore method, when an archive didn't have any files in it, the list of files was empty, but because our processing assumed a list (but actually got a dict, due to this bug), it would throw the following: 

```
line 72, in _get_file_via_walking_tree
  if root["path"].lower() == path_root.lower():
TypeError: string indices must be integers
```

### Issues Resolved ###
INTEG-2160

### PR Checklist ###
Did you remember to do the below?

- [X] Add unit tests to verify this change
- [X] Add an entry to CHANGELOG.md describing this change
- [N/A] Add docstrings for any new public parameters / methods / classes
