### PR TITLE
Bugfix/watchlist errors

### DIFF
--- a/src/py42/services/watchlists.py
+++ b/src/py42/services/watchlists.py
@@ -105,12 +105,7 @@ class WatchlistsService(BaseService):
         except KeyError:
             # if watchlist of specified type not found, create watchlist
             id = (self.create(watchlist_type)).data["watchlistId"]
-        try:
-            self.add_included_users_by_watchlist_id(user_ids, id)
-        except Py42BadRequestError as err:
-            if "User not found" in err.response.text:
-                raise Py42NotFoundError(err, message=err.response.text)
-            raise
+        self.add_included_users_by_watchlist_id(user_ids, id)
 
     def delete_included_users_by_watchlist_id(self, user_ids, watchlist_id):
         if not isinstance(user_ids, (list, tuple)):
@@ -132,12 +127,7 @@ class WatchlistsService(BaseService):
         except KeyError:
             # if specified watchlist type not found, raise error
             raise Py42Error(f"Couldn't find watchlist of type:'{watchlist_type}'.")
-        try:
-            self.delete_included_users_by_watchlist_id(user_ids, id)
-        except Py42BadRequestError as err:
-            if "User not found" in err.response.text:
-                raise Py42NotFoundError(err, message=err.response.text)
-            raise
+        self.delete_included_users_by_watchlist_id(user_ids, id)
 
     def get_page_watchlist_members(self, watchlist_id, page_num=1, page_size=None):
         data = {

--- a/tests/services/test_watchlists.py
+++ b/tests/services/test_watchlists.py
@@ -38,13 +38,16 @@ URI = "/v1/watchlists"
 def mock_not_found_error(mocker):
     return create_mock_error(Py42NotFoundError, mocker, "Not Found Error Msg")
 
+
 @pytest.fixture
 def mock_user_not_found_error(mocker):
     return create_mock_error(Py42BadRequestError, mocker, "User not found")
 
+
 @pytest.fixture
 def mock_watchlist_not_found_error(mocker):
     return create_mock_error(Py42BadRequestError, mocker, "Watchlist not found")
+
 
 @pytest.fixture
 def mock_get_all_included_users_response(mocker):

--- a/tests/services/test_watchlists.py
+++ b/tests/services/test_watchlists.py
@@ -38,6 +38,13 @@ URI = "/v1/watchlists"
 def mock_not_found_error(mocker):
     return create_mock_error(Py42NotFoundError, mocker, "Not Found Error Msg")
 
+@pytest.fixture
+def mock_user_not_found_error(mocker):
+    return create_mock_error(Py42BadRequestError, mocker, "User not found")
+
+@pytest.fixture
+def mock_watchlist_not_found_error(mocker):
+    return create_mock_error(Py42BadRequestError, mocker, "User not found")
 
 @pytest.fixture
 def mock_get_all_included_users_response(mocker):
@@ -253,6 +260,18 @@ class TestWatchlistsService:
 
         assert err.value.args[0] == "Watchlist ID 'invalid-id' not found."
 
+    def test_add_included_users_by_watchlist_id_raises_py42_not_found_when_user_id_not_found(
+        self, mock_connection, mock_user_not_found_error
+    ):
+        watchlists_service = WatchlistsService(mock_connection)
+        mock_connection.post.side_effect = mock_user_not_found_error
+        with pytest.raises(Py42NotFoundError) as err:
+            watchlists_service.add_included_users_by_watchlist_id(
+                watchlist_id="invalid-id", user_ids=["user1", "user2"]
+            )
+
+        assert err.value.args[0] == "User not found"
+
     def test_add_included_users_by_watchlist_type_calls_add_with_expected_params_when_watchlist_exists(
         self, mock_connection
     ):
@@ -296,6 +315,23 @@ class TestWatchlistsService:
             f"{URI}/{WATCHLIST_ID}/included-users/add", json=data
         )
 
+    def test_add_included_users_by_watchlist_type_raises_py42_not_found_when_user_id_not_found(
+        self, mock_connection, mock_user_not_found_error
+    ):
+        watchlists_service = WatchlistsService(mock_connection)
+
+        # set watchlist dict
+        watchlists_service._watchlist_type_id_map = {}
+        watchlists_service.watchlist_type_id_map[WATCHLIST_TYPE] = WATCHLIST_ID
+
+        mock_connection.post.side_effect = mock_user_not_found_error
+        with pytest.raises(Py42NotFoundError) as err:
+            watchlists_service.add_included_users_by_watchlist_type(
+                user_ids=["user1", "user2"], watchlist_type=WATCHLIST_TYPE
+            )
+
+        assert err.value.args[0] == "User not found"
+
     def test_delete_included_users_by_watchlist_id_calls_post_with_expected_params_and_updates_dict(
         self, mock_connection
     ):
@@ -320,6 +356,18 @@ class TestWatchlistsService:
             )
 
         assert err.value.args[0] == "Watchlist ID 'invalid-id' not found."
+
+    def test_delete_included_users_by_watchlist_id_raises_py42_not_found_when_user_id_not_found(
+        self, mock_connection, mock_user_not_found_error
+    ):
+        watchlists_service = WatchlistsService(mock_connection)
+        mock_connection.post.side_effect = mock_user_not_found_error
+        with pytest.raises(Py42NotFoundError) as err:
+            watchlists_service.delete_included_users_by_watchlist_id(
+                watchlist_id="invalid-id", user_ids=["user1", "user2"]
+            )
+
+        assert err.value.args[0] == "User not found"
 
     def test_delete_included_users_by_watchlist_type_calls_post_with_expected_params_when_watchlist_exists(
         self, mock_connection
@@ -354,6 +402,23 @@ class TestWatchlistsService:
         assert (
             err.value.args[0] == f"Couldn't find watchlist of type:'{WATCHLIST_TYPE}'."
         )
+
+    def test_delete_included_users_by_watchlist_type_raises_py42_not_found_when_user_id_not_found(
+        self, mock_connection, mock_user_not_found_error
+    ):
+        watchlists_service = WatchlistsService(mock_connection)
+
+        # set watchlist dict
+        watchlists_service._watchlist_type_id_map = {}
+        watchlists_service.watchlist_type_id_map[WATCHLIST_TYPE] = WATCHLIST_ID
+
+        mock_connection.post.side_effect = mock_user_not_found_error
+        with pytest.raises(Py42NotFoundError) as err:
+            watchlists_service.delete_included_users_by_watchlist_type(
+                user_ids=["user1", "user2"], watchlist_type=WATCHLIST_TYPE
+            )
+
+        assert err.value.args[0] == "User not found"
 
     def test_get_page_members_calls_get_with_expected_params(self, mock_connection):
         watchlists_service = WatchlistsService(mock_connection)

--- a/tests/services/test_watchlists.py
+++ b/tests/services/test_watchlists.py
@@ -252,10 +252,10 @@ class TestWatchlistsService:
         )
 
     def test_add_included_users_by_watchlist_id_raises_py42_not_found_when_id_not_found(
-        self, mock_connection, mock_not_found_error
+        self, mock_connection, mock_watchlist_not_found_error
     ):
         watchlists_service = WatchlistsService(mock_connection)
-        mock_connection.post.side_effect = mock_not_found_error
+        mock_connection.post.side_effect = mock_watchlist_not_found_error
         with pytest.raises(Py42WatchlistNotFound) as err:
             watchlists_service.add_included_users_by_watchlist_id(
                 watchlist_id="invalid-id", user_ids=["user1", "user2"]

--- a/tests/services/test_watchlists.py
+++ b/tests/services/test_watchlists.py
@@ -44,7 +44,7 @@ def mock_user_not_found_error(mocker):
 
 @pytest.fixture
 def mock_watchlist_not_found_error(mocker):
-    return create_mock_error(Py42BadRequestError, mocker, "User not found")
+    return create_mock_error(Py42BadRequestError, mocker, "Watchlist not found")
 
 @pytest.fixture
 def mock_get_all_included_users_response(mocker):
@@ -346,10 +346,10 @@ class TestWatchlistsService:
         )
 
     def test_delete_included_users_by_watchlist_id_raises_py42_not_found_when_id_not_found(
-        self, mock_connection, mock_not_found_error
+        self, mock_connection, mock_watchlist_not_found_error
     ):
         watchlists_service = WatchlistsService(mock_connection)
-        mock_connection.post.side_effect = mock_not_found_error
+        mock_connection.post.side_effect = mock_watchlist_not_found_error
         with pytest.raises(Py42WatchlistNotFound) as err:
             watchlists_service.delete_included_users_by_watchlist_id(
                 watchlist_id="invalid-id", user_ids=["user1", "user2"]


### PR DESCRIPTION
### Description of Change ###

The `included-users/add` & `included-users/delete` endpoints don't actually 404 on bad watchlistId or userId values. They return a 400 instead. Added logic to catch those and raise appropriate "not found" exceptions instead.