### PR TITLE
adjust `userriskprofile.update`'s null date handling

### DIFF
--- a/src/py42/services/userriskprofile.py
+++ b/src/py42/services/userriskprofile.py
@@ -50,7 +50,11 @@ class UserRiskProfileService(BaseService):
                 data["startDate"] = None
             else:
                 start_day, start_month, start_year = _parse_date_string(start_date)
-                data["startDate"] = {"day": start_day, "month": start_month, "year": start_year}
+                data["startDate"] = {
+                    "day": start_day,
+                    "month": start_month,
+                    "year": start_year,
+                }
         if end_date is not None:
             paths += ["endDate"]
             if end_date == "":

--- a/src/py42/services/userriskprofile.py
+++ b/src/py42/services/userriskprofile.py
@@ -40,39 +40,34 @@ class UserRiskProfileService(BaseService):
         except Py42NotFoundError as err:
             raise Py42UserRiskProfileNotFound(err, username, identifier="username")
 
-    def update(self, user_id, start_date=None, end_date=None, notes=None, paths=None):
+    def update(self, user_id, start_date=None, end_date=None, notes=None):
         # Build paths field
-        if not paths:
-            paths = []
-            if start_date is not None:
-                paths += ["startDate"]
-                if start_date == "":
-                    start_date = None
-            if end_date is not None:
-                paths += ["endDate"]
-                if end_date == "":
-                    end_date = None
-            if notes is not None:
-                paths += ["notes"]
-                if notes == "":
-                    notes = None
+        paths = []
+        data = {}
+        if start_date is not None:
+            paths += ["startDate"]
+            if start_date == "":
+                data["startDate"] = None
+            else:
+                start_day, start_month, start_year = _parse_date_string(start_date)
+                data["startDate"] = {"day": start_day, "month": start_month, "year": start_year}
+        if end_date is not None:
+            paths += ["endDate"]
+            if end_date == "":
+                data["endDate"] = None
+            else:
+                end_day, end_month, end_year = _parse_date_string(end_date)
+                data["endDate"] = {"day": end_day, "month": end_month, "year": end_year}
+        if notes is not None:
+            paths += ["notes"]
+            if notes == "":
+                data["notes"] = None
+            else:
+                data["notes"] = notes
         if not paths:
             raise Py42Error("No fields provided. No values will be updated.")
 
-        # parse date strings
-        start_day, start_month, start_year = (
-            _parse_date_string(start_date) if start_date else (None, None, None)
-        )
-        end_day, end_month, end_year = (
-            _parse_date_string(end_date) if end_date else (None, None, None)
-        )
-
         params = {"paths": ", ".join(paths)}
-        data = {
-            "endDate": {"day": end_day, "month": end_month, "year": end_year},
-            "notes": notes,
-            "startDate": {"day": start_day, "month": start_month, "year": start_year},
-        }
         uri = f"{self._uri_prefix}/{user_id}"
         try:
             return self._connection.patch(uri, json=data, params=params)

--- a/tests/services/test_userriskprofile.py
+++ b/tests/services/test_userriskprofile.py
@@ -123,9 +123,9 @@ class TestUserRiskProfileService:
         user_risk_profile_service.update(USER_ID, end_date="", start_date="", notes="")
         params = {"paths": ", ".join(paths)}
         data = {
-            "endDate": {"day": None, "month": None, "year": None},
+            "endDate": None,
             "notes": None,
-            "startDate": {"day": None, "month": None, "year": None},
+            "startDate": None,
         }
         mock_connection.patch.assert_called_once_with(
             f"{URI}/{USER_ID}", json=data, params=params


### PR DESCRIPTION
### Description of Change ###

`sdk.userriskprofile.update()` when getting `None` or `""` for end_date or start_date was sending: 
```
{"startDay": {"day": null, "month": null, "year": null}
``` 
This was causing errors on the backend trying to parse the date values. 

To clear the value (or when not updating at all), we need to send just:
```
{"startDay": null}
```