### PR TITLE
alias filter classes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ per-file-ignores =
     src/py42/sdk/queries/fileevents/v2/filters/__init__.py: F401, F403
     src/py42/sdk/queries/fileevents/v2/__init__.py: F401, F403
     src/py42/sdk/queries/fileevents/v1/__init__.py: F401, F403
+    src/py42/sdk/queries/fileevents/file_event_query.py: F401, F403
     src/py42/sdk/queries/alerts/filters/__init__.py: F401, F403
     src/py42/constants/__init__.py: F401
     docs/conf.py: F401

--- a/src/py42/choices.py
+++ b/src/py42/choices.py
@@ -1,7 +1,7 @@
 from py42.util import get_attribute_values_from_class
 
 
-class _Choices:
+class Choices:
     """Helper class to provide the choices() method to a class."""
 
     @classmethod

--- a/src/py42/clients/cases.py
+++ b/src/py42/clients/cases.py
@@ -1,10 +1,10 @@
 from datetime import datetime
 
-from py42.choices import _Choices
+from py42.choices import Choices
 from py42.util import parse_timestamp_to_milliseconds_precision
 
 
-class CaseStatus(_Choices):
+class CaseStatus(Choices):
     """Constants available for setting the status of a case.
 
     * ``OPEN``

--- a/src/py42/clients/detectionlists.py
+++ b/src/py42/clients/detectionlists.py
@@ -1,9 +1,9 @@
-from py42.choices import _Choices
+from py42.choices import Choices
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42UnableToCreateProfileError
 
 
-class RiskTags(_Choices):
+class RiskTags(Choices):
     """Deprecated. Use :class:`~py42.clients.watchlists.WatchlistsClient` and :class:`~py42.clients.userriskprofile.UserRiskProfileClient` instead. Constants available as risk tags for :meth:`~py42.clients.detectionlists.DetectionListsClient.add_user_risk_tags()`
     and :meth:`~py42.clients.detectionlists.DetectionListsClient.remove_user_risk_tags()`.
 

--- a/src/py42/clients/trustedactivities.py
+++ b/src/py42/clients/trustedactivities.py
@@ -1,7 +1,7 @@
-from py42.choices import _Choices
+from py42.choices import Choices
 
 
-class TrustedActivityType(_Choices):
+class TrustedActivityType(Choices):
     """Constants available for setting the type of a trusted activity.
 
     * ``DOMAIN``

--- a/src/py42/clients/watchlists.py
+++ b/src/py42/clients/watchlists.py
@@ -1,7 +1,7 @@
-from py42.choices import _Choices
+from py42.choices import Choices
 
 
-class WatchlistType(_Choices):
+class WatchlistType(Choices):
     """Constants available for setting the type of watchlist.
 
     * ``CONTRACT_EMPLOYEE``

--- a/src/py42/constants/__init__.py
+++ b/src/py42/constants/__init__.py
@@ -1,4 +1,4 @@
-from py42.choices import _Choices
+from py42.choices import Choices
 from py42.clients.cases import CaseStatus
 from py42.clients.detectionlists import RiskTags
 from py42.clients.trustedactivities import TrustedActivityType
@@ -7,7 +7,7 @@ from py42.services.detectionlists.departing_employee import DepartingEmployeeFil
 from py42.services.detectionlists.high_risk_employee import HighRiskEmployeeFilters
 
 
-class SortDirection(_Choices):
+class SortDirection(Choices):
     """Constants available to set Code42 request `sort_direction` when sorting returned lists in responses.
 
     * ``ASC``

--- a/src/py42/sdk/queries/alerts/filters/alert_filter.py
+++ b/src/py42/sdk/queries/alerts/filters/alert_filter.py
@@ -1,119 +1,41 @@
-from py42.choices import Choices
-from py42.sdk.queries.query_filter import create_filter_group
-from py42.sdk.queries.query_filter import create_query_filter
-from py42.sdk.queries.query_filter import QueryFilterStringField
-from py42.sdk.queries.query_filter import QueryFilterTimestampField
-from py42.util import MICROSECOND_FORMAT
-from py42.util import parse_timestamp_to_microseconds_precision
+from py42.choices import Choices as _Choices
+from py42.sdk.queries.alerts.util import (
+    AlertQueryFilterStringField as _AlertQueryFilterStringField,
+)
+from py42.sdk.queries.alerts.util import (
+    AlertQueryFilterTimestampField as _AlertQueryFilterTimestampField,
+)
+from py42.sdk.queries.query_filter import (
+    QueryFilterStringField as _QueryFilterStringField,
+)
 
 
-def create_contains_filter_group(term, value):
-    """Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering results
-    where the value with key ``term`` contains the given value. Useful for creating ``CONTAINS``
-    filters that are not yet supported in py42 or programmatically crafting filter groups.
-
-    Args:
-        term: (str): The term of the filter, such as ``actor``.
-        value (str): The value used to match on.
-
-    Returns:
-        :class:`~py42.sdk.queries.query_filter.FilterGroup`
-    """
-
-    filter_list = [create_query_filter(term, "CONTAINS", value)]
-    return create_filter_group(filter_list, "AND")
-
-
-def create_not_contains_filter_group(term, value):
-    """Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering results
-    where the value with key ``term`` does not contain the given value. Useful for creating
-    ``DOES_NOT_CONTAIN`` filters that are not yet supported in py42 or programmatically
-    crafting filter groups.
-
-    Args:
-        term: (str): The term of the filter, such as ``actor``.
-        value (str): The value used to exclude on.
-
-    Returns:
-        :class:`~py42.sdk.queries.query_filter.FilterGroup`
-    """
-
-    filter_list = [create_query_filter(term, "DOES_NOT_CONTAIN", value)]
-    return create_filter_group(filter_list, "AND")
-
-
-class AlertQueryFilterStringField(QueryFilterStringField):
-    @classmethod
-    def contains(cls, value):
-        """Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering
-        results where the value with key ``self._term`` contains the given value. Useful
-        for creating ``CONTAINS`` filters that are not yet supported in py42 or programmatically
-        crafting filter groups.
-
-        Args:
-            value (str): The value used to match on.
-
-        Returns:
-            :class:`~py42.sdk.queries.query_filter.FilterGroup`
-        """
-
-        return create_contains_filter_group(cls._term, value)
-
-    @classmethod
-    def not_contains(cls, value):
-        """Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering
-        results where the value with key ``self._term`` does not contain the given value.
-        Useful for creating ``DOES_NOT_CONTAIN`` filters that are not yet supported in py42
-        or programmatically crafting filter groups.
-
-        Args:
-            value (str): The value used to exclude on.
-
-        Returns:
-            :class:`~py42.sdk.queries.query_filter.FilterGroup`
-        """
-
-        return create_not_contains_filter_group(cls._term, value)
-
-
-class AlertQueryFilterTimestampField(QueryFilterTimestampField):
-    """Helper class for creating alert filters where the search value is a timestamp."""
-
-    @staticmethod
-    def _parse_timestamp(value):
-        return parse_timestamp_to_microseconds_precision(value)
-
-    @staticmethod
-    def _convert_datetime_to_timestamp(value):
-        return value.strftime(MICROSECOND_FORMAT)
-
-
-class DateObserved(AlertQueryFilterTimestampField):
+class DateObserved(_AlertQueryFilterTimestampField):
     """Class that filters alerts based on the timestamp the alert was triggered."""
 
     _term = "createdAt"
 
 
-class Actor(AlertQueryFilterStringField):
+class Actor(_AlertQueryFilterStringField):
     """Class that filters alerts based on the username that originated the event(s) that
     triggered the alert."""
 
     _term = "actor"
 
 
-class RuleName(AlertQueryFilterStringField):
+class RuleName(_AlertQueryFilterStringField):
     """Class that filters alerts based on rule name."""
 
     _term = "name"
 
 
-class RuleId(QueryFilterStringField):
+class RuleId(_QueryFilterStringField):
     """Class that filters alerts based on rule identifier."""
 
     _term = "ruleId"
 
 
-class RuleSource(QueryFilterStringField, Choices):
+class RuleSource(_QueryFilterStringField, _Choices):
     """Class that filters alerts based on rule source.
 
     Available options are:
@@ -129,7 +51,7 @@ class RuleSource(QueryFilterStringField, Choices):
     HIGH_RISK_EMPLOYEE = "High Risk Employee"
 
 
-class RuleType(QueryFilterStringField, Choices):
+class RuleType(_QueryFilterStringField, _Choices):
     """Class that filters alerts based on rule type.
 
     Available options are:
@@ -145,13 +67,13 @@ class RuleType(QueryFilterStringField, Choices):
     FILE_TYPE_MISMATCH = "FedFileTypeMismatch"
 
 
-class Description(AlertQueryFilterStringField):
+class Description(_AlertQueryFilterStringField):
     """Class that filters alerts based on rule description text."""
 
     _term = "description"
 
 
-class Severity(QueryFilterStringField, Choices):
+class Severity(_QueryFilterStringField, _Choices):
     """Class that filters alerts based on severity.
 
     Available options are:
@@ -170,7 +92,7 @@ class Severity(QueryFilterStringField, Choices):
     LOW = "LOW"
 
 
-class AlertState(QueryFilterStringField, Choices):
+class AlertState(_QueryFilterStringField, _Choices):
     """Class that filters alerts based on alert state.
 
     Available options are:

--- a/src/py42/sdk/queries/alerts/filters/alert_filter.py
+++ b/src/py42/sdk/queries/alerts/filters/alert_filter.py
@@ -1,8 +1,8 @@
-from py42.choices import _Choices
-from py42.sdk.queries.query_filter import _QueryFilterStringField
-from py42.sdk.queries.query_filter import _QueryFilterTimestampField
+from py42.choices import Choices
 from py42.sdk.queries.query_filter import create_filter_group
 from py42.sdk.queries.query_filter import create_query_filter
+from py42.sdk.queries.query_filter import QueryFilterStringField
+from py42.sdk.queries.query_filter import QueryFilterTimestampField
 from py42.util import MICROSECOND_FORMAT
 from py42.util import parse_timestamp_to_microseconds_precision
 
@@ -42,7 +42,7 @@ def create_not_contains_filter_group(term, value):
     return create_filter_group(filter_list, "AND")
 
 
-class AlertQueryFilterStringField(_QueryFilterStringField):
+class AlertQueryFilterStringField(QueryFilterStringField):
     @classmethod
     def contains(cls, value):
         """Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering
@@ -76,7 +76,7 @@ class AlertQueryFilterStringField(_QueryFilterStringField):
         return create_not_contains_filter_group(cls._term, value)
 
 
-class AlertQueryFilterTimestampField(_QueryFilterTimestampField):
+class AlertQueryFilterTimestampField(QueryFilterTimestampField):
     """Helper class for creating alert filters where the search value is a timestamp."""
 
     @staticmethod
@@ -107,13 +107,13 @@ class RuleName(AlertQueryFilterStringField):
     _term = "name"
 
 
-class RuleId(_QueryFilterStringField):
+class RuleId(QueryFilterStringField):
     """Class that filters alerts based on rule identifier."""
 
     _term = "ruleId"
 
 
-class RuleSource(_QueryFilterStringField, _Choices):
+class RuleSource(QueryFilterStringField, Choices):
     """Class that filters alerts based on rule source.
 
     Available options are:
@@ -129,7 +129,7 @@ class RuleSource(_QueryFilterStringField, _Choices):
     HIGH_RISK_EMPLOYEE = "High Risk Employee"
 
 
-class RuleType(_QueryFilterStringField, _Choices):
+class RuleType(QueryFilterStringField, Choices):
     """Class that filters alerts based on rule type.
 
     Available options are:
@@ -151,7 +151,7 @@ class Description(AlertQueryFilterStringField):
     _term = "description"
 
 
-class Severity(_QueryFilterStringField, _Choices):
+class Severity(QueryFilterStringField, Choices):
     """Class that filters alerts based on severity.
 
     Available options are:
@@ -170,7 +170,7 @@ class Severity(_QueryFilterStringField, _Choices):
     LOW = "LOW"
 
 
-class AlertState(_QueryFilterStringField, _Choices):
+class AlertState(QueryFilterStringField, Choices):
     """Class that filters alerts based on alert state.
 
     Available options are:

--- a/src/py42/sdk/queries/alerts/util.py
+++ b/src/py42/sdk/queries/alerts/util.py
@@ -1,0 +1,87 @@
+from py42.sdk.queries.query_filter import create_filter_group
+from py42.sdk.queries.query_filter import create_query_filter
+from py42.sdk.queries.query_filter import QueryFilterStringField
+from py42.sdk.queries.query_filter import QueryFilterTimestampField
+from py42.util import MICROSECOND_FORMAT
+from py42.util import parse_timestamp_to_microseconds_precision
+
+
+def create_contains_filter_group(term, value):
+    """Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering results
+    where the value with key ``term`` contains the given value. Useful for creating ``CONTAINS``
+    filters that are not yet supported in py42 or programmatically crafting filter groups.
+
+    Args:
+        term: (str): The term of the filter, such as ``actor``.
+        value (str): The value used to match on.
+
+    Returns:
+        :class:`~py42.sdk.queries.query_filter.FilterGroup`
+    """
+
+    filter_list = [create_query_filter(term, "CONTAINS", value)]
+    return create_filter_group(filter_list, "AND")
+
+
+def create_not_contains_filter_group(term, value):
+    """Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering results
+    where the value with key ``term`` does not contain the given value. Useful for creating
+    ``DOES_NOT_CONTAIN`` filters that are not yet supported in py42 or programmatically
+    crafting filter groups.
+
+    Args:
+        term: (str): The term of the filter, such as ``actor``.
+        value (str): The value used to exclude on.
+
+    Returns:
+        :class:`~py42.sdk.queries.query_filter.FilterGroup`
+    """
+
+    filter_list = [create_query_filter(term, "DOES_NOT_CONTAIN", value)]
+    return create_filter_group(filter_list, "AND")
+
+
+class AlertQueryFilterStringField(QueryFilterStringField):
+    @classmethod
+    def contains(cls, value):
+        """Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering
+        results where the value with key ``self._term`` contains the given value. Useful
+        for creating ``CONTAINS`` filters that are not yet supported in py42 or programmatically
+        crafting filter groups.
+
+        Args:
+            value (str): The value used to match on.
+
+        Returns:
+            :class:`~py42.sdk.queries.query_filter.FilterGroup`
+        """
+
+        return create_contains_filter_group(cls._term, value)
+
+    @classmethod
+    def not_contains(cls, value):
+        """Creates a :class:`~py42.sdk.queries.query_filter.FilterGroup` for filtering
+        results where the value with key ``self._term`` does not contain the given value.
+        Useful for creating ``DOES_NOT_CONTAIN`` filters that are not yet supported in py42
+        or programmatically crafting filter groups.
+
+        Args:
+            value (str): The value used to exclude on.
+
+        Returns:
+            :class:`~py42.sdk.queries.query_filter.FilterGroup`
+        """
+
+        return create_not_contains_filter_group(cls._term, value)
+
+
+class AlertQueryFilterTimestampField(QueryFilterTimestampField):
+    """Helper class for creating alert filters where the search value is a timestamp."""
+
+    @staticmethod
+    def _parse_timestamp(value):
+        return parse_timestamp_to_microseconds_precision(value)
+
+    @staticmethod
+    def _convert_datetime_to_timestamp(value):
+        return value.strftime(MICROSECOND_FORMAT)

--- a/src/py42/sdk/queries/fileevents/file_event_query.py
+++ b/src/py42/sdk/queries/fileevents/file_event_query.py
@@ -1,6 +1,11 @@
 from warnings import warn
 
 from py42.sdk.queries import BaseQuery
+from py42.sdk.queries.fileevents.util import FileEventFilterComparableField
+from py42.sdk.queries.fileevents.util import FileEventFilterStringField
+from py42.sdk.queries.fileevents.util import FileEventFilterTimestampField
+
+# import from util for backwards-compatibility
 
 
 class FileEventQuery(BaseQuery):

--- a/src/py42/sdk/queries/fileevents/filters/activity_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/activity_filter.py
@@ -1,4 +1,6 @@
-from py42.sdk.queries.query_filter import _QueryFilterBooleanField
+from py42.sdk.queries.query_filter import (
+    QueryFilterBooleanField as _QueryFilterBooleanField,
+)
 
 
 class TrustedActivity(_QueryFilterBooleanField):

--- a/src/py42/sdk/queries/fileevents/filters/cloud_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/cloud_filter.py
@@ -1,6 +1,8 @@
-from py42.choices import _Choices
-from py42.sdk.queries.fileevents.util import _FileEventFilterStringField
-from py42.sdk.queries.query_filter import _QueryFilterBooleanField
+from py42.choices import Choices as _Choices
+from py42.sdk.queries.fileevents.util import (
+    FileEventFilterStringField as _FileEventFilterStringField,
+)
+from py42.sdk.queries.query_filter import QueryFilterBooleanField
 
 
 class Actor(_FileEventFilterStringField):
@@ -19,7 +21,7 @@ class DirectoryID(_FileEventFilterStringField):
     _term = "directoryId"
 
 
-class Shared(_QueryFilterBooleanField):
+class Shared(QueryFilterBooleanField):
     """V1 filter class that filters events by the shared status of the file at the time the event occurred
     (applies to cloud data source events only).
     """

--- a/src/py42/sdk/queries/fileevents/filters/device_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/device_filter.py
@@ -1,31 +1,31 @@
-from py42.sdk.queries.fileevents.util import _FileEventFilterStringField
+from py42.sdk.queries.fileevents.util import FileEventFilterStringField
 
 
-class DeviceUsername(_FileEventFilterStringField):
+class DeviceUsername(FileEventFilterStringField):
     """V1 filter class that filters events by the Code42 username of the device that observed the event."""
 
     _term = "deviceUserName"
 
 
-class OSHostname(_FileEventFilterStringField):
+class OSHostname(FileEventFilterStringField):
     """V1 filter class that filters events by hostname of the device that observed the event."""
 
     _term = "osHostName"
 
 
-class PrivateIPAddress(_FileEventFilterStringField):
+class PrivateIPAddress(FileEventFilterStringField):
     """V1 filter class that filters events by private (LAN) IP address of the device that observed the event."""
 
     _term = "privateIpAddresses"
 
 
-class PublicIPAddress(_FileEventFilterStringField):
+class PublicIPAddress(FileEventFilterStringField):
     """V1 filter class that filters events by public (WAN) IP address of the device that observed the event."""
 
     _term = "publicIpAddress"
 
 
-class DeviceSignedInUserName(_FileEventFilterStringField):
+class DeviceSignedInUserName(FileEventFilterStringField):
     """V1 filter class that filters events by signed in user of the device that observed the event."""
 
     _term = "operatingSystemUser"

--- a/src/py42/sdk/queries/fileevents/filters/email_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/email_filter.py
@@ -1,4 +1,6 @@
-from py42.sdk.queries.query_filter import _QueryFilterStringField
+from py42.sdk.queries.query_filter import (
+    QueryFilterStringField as _QueryFilterStringField,
+)
 
 
 class EmailPolicyName(_QueryFilterStringField):

--- a/src/py42/sdk/queries/fileevents/filters/event_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/event_filter.py
@@ -1,7 +1,13 @@
-from py42.choices import _Choices
-from py42.sdk.queries.fileevents.util import _FileEventFilterStringField
-from py42.sdk.queries.fileevents.util import _FileEventFilterTimestampField
-from py42.sdk.queries.query_filter import _QueryFilterBooleanField
+from py42.choices import Choices as _Choices
+from py42.sdk.queries.fileevents.util import (
+    FileEventFilterStringField as _FileEventFilterStringField,
+)
+from py42.sdk.queries.fileevents.util import (
+    FileEventFilterTimestampField as _FileEventFilterTimestampField,
+)
+from py42.sdk.queries.query_filter import (
+    QueryFilterBooleanField as _QueryFilterBooleanField,
+)
 
 
 class EventTimestamp(_FileEventFilterTimestampField, _Choices):

--- a/src/py42/sdk/queries/fileevents/filters/exposure_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/exposure_filter.py
@@ -1,5 +1,7 @@
-from py42.choices import _Choices
-from py42.sdk.queries.fileevents.util import _FileEventFilterStringField
+from py42.choices import Choices as _Choices
+from py42.sdk.queries.fileevents.util import (
+    FileEventFilterStringField as _FileEventFilterStringField,
+)
 
 
 class ExposureType(_FileEventFilterStringField, _Choices):

--- a/src/py42/sdk/queries/fileevents/filters/file_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/file_filter.py
@@ -1,6 +1,10 @@
-from py42.choices import _Choices
-from py42.sdk.queries.fileevents.util import _FileEventFilterComparableField
-from py42.sdk.queries.fileevents.util import _FileEventFilterStringField
+from py42.choices import Choices as _Choices
+from py42.sdk.queries.fileevents.util import (
+    FileEventFilterComparableField as _FileEventFilterComparableField,
+)
+from py42.sdk.queries.fileevents.util import (
+    FileEventFilterStringField as _FileEventFilterStringField,
+)
 
 
 class FileCategory(_FileEventFilterStringField, _Choices):

--- a/src/py42/sdk/queries/fileevents/filters/print_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/print_filter.py
@@ -1,4 +1,6 @@
-from py42.sdk.queries.fileevents.util import _FileEventFilterStringField
+from py42.sdk.queries.fileevents.util import (
+    FileEventFilterStringField as _FileEventFilterStringField,
+)
 
 
 class Printer(_FileEventFilterStringField):

--- a/src/py42/sdk/queries/fileevents/filters/risk_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/risk_filter.py
@@ -1,7 +1,13 @@
-from py42.choices import _Choices
-from py42.sdk.queries.fileevents.util import _FileEventFilterComparableField
-from py42.sdk.queries.fileevents.util import _FileEventFilterStringField
-from py42.sdk.queries.query_filter import _QueryFilterStringField
+from py42.choices import Choices as _Choices
+from py42.sdk.queries.fileevents.util import (
+    FileEventFilterComparableField as _FileEventFilterComparableField,
+)
+from py42.sdk.queries.fileevents.util import (
+    FileEventFilterStringField as _FileEventFilterStringField,
+)
+from py42.sdk.queries.query_filter import (
+    QueryFilterStringField as _QueryFilterStringField,
+)
 
 
 class RiskIndicator(_FileEventFilterStringField):

--- a/src/py42/sdk/queries/fileevents/filters/source_filter.py
+++ b/src/py42/sdk/queries/fileevents/filters/source_filter.py
@@ -1,5 +1,7 @@
-from py42.choices import _Choices
-from py42.sdk.queries.fileevents.util import _FileEventFilterStringField
+from py42.choices import Choices as _Choices
+from py42.sdk.queries.fileevents.util import (
+    FileEventFilterStringField as _FileEventFilterStringField,
+)
 
 
 class SourceCategory(_FileEventFilterStringField, _Choices):

--- a/src/py42/sdk/queries/fileevents/util.py
+++ b/src/py42/sdk/queries/fileevents/util.py
@@ -1,8 +1,8 @@
-from py42.sdk.queries.query_filter import _QueryFilterStringField
-from py42.sdk.queries.query_filter import _QueryFilterTimestampField
 from py42.sdk.queries.query_filter import create_filter_group
 from py42.sdk.queries.query_filter import create_query_filter
 from py42.sdk.queries.query_filter import create_within_the_last_filter_group
+from py42.sdk.queries.query_filter import QueryFilterStringField
+from py42.sdk.queries.query_filter import QueryFilterTimestampField
 
 
 def create_exists_filter_group(term):
@@ -69,7 +69,7 @@ def create_less_than_filter_group(term, value):
     return create_filter_group(filter_list, "AND")
 
 
-class _FileEventFilterStringField(_QueryFilterStringField):
+class FileEventFilterStringField(QueryFilterStringField):
     """Helper class for creating filters with the ``EXISTS``/``NOT_EXISTS`` filter clauses."""
 
     @classmethod
@@ -93,7 +93,7 @@ class _FileEventFilterStringField(_QueryFilterStringField):
         return create_not_exists_filter_group(cls._term)
 
 
-class _FileEventFilterComparableField:
+class FileEventFilterComparableField:
     """Helper class for creating filters with the ``GREATER_THAN``/``LESS_THAN`` filter clauses."""
 
     _term = "override_boolean_field_name"
@@ -127,7 +127,7 @@ class _FileEventFilterComparableField:
         return create_less_than_filter_group(cls._term, value)
 
 
-class _FileEventFilterTimestampField(_QueryFilterTimestampField):
+class FileEventFilterTimestampField(QueryFilterTimestampField):
     @classmethod
     def within_the_last(cls, value):
         """Returns a :class:`~py42.sdk.queries.query_filter.FilterGroup` that is useful

--- a/src/py42/sdk/queries/fileevents/v2/filters/destination.py
+++ b/src/py42/sdk/queries/fileevents/v2/filters/destination.py
@@ -1,6 +1,10 @@
-from py42.choices import _Choices
-from py42.sdk.queries.fileevents.util import _FileEventFilterStringField
-from py42.sdk.queries.query_filter import _QueryFilterStringField
+from py42.choices import Choices as _Choices
+from py42.sdk.queries.fileevents.util import (
+    FileEventFilterStringField as _FileEventFilterStringField,
+)
+from py42.sdk.queries.query_filter import (
+    QueryFilterStringField as _QueryFilterStringField,
+)
 
 
 class Name(_QueryFilterStringField):

--- a/src/py42/sdk/queries/fileevents/v2/filters/event.py
+++ b/src/py42/sdk/queries/fileevents/v2/filters/event.py
@@ -1,6 +1,10 @@
-from py42.choices import _Choices
-from py42.sdk.queries.fileevents.util import _FileEventFilterStringField
-from py42.sdk.queries.fileevents.util import _FileEventFilterTimestampField
+from py42.choices import Choices as _Choices
+from py42.sdk.queries.fileevents.util import (
+    FileEventFilterStringField as _FileEventFilterStringField,
+)
+from py42.sdk.queries.fileevents.util import (
+    FileEventFilterTimestampField as _FileEventFilterTimestampField,
+)
 
 
 class Observer(_FileEventFilterStringField, _Choices):

--- a/src/py42/sdk/queries/fileevents/v2/filters/file.py
+++ b/src/py42/sdk/queries/fileevents/v2/filters/file.py
@@ -1,6 +1,10 @@
-from py42.choices import _Choices
-from py42.sdk.queries.fileevents.util import _FileEventFilterComparableField
-from py42.sdk.queries.fileevents.util import _FileEventFilterStringField
+from py42.choices import Choices as _Choices
+from py42.sdk.queries.fileevents.util import (
+    FileEventFilterStringField as _FileEventFilterStringField,
+)
+from py42.sdk.queries.fileevents.util import (
+    FileEventFilterTimestampField as _FileEventFilterTimestampField,
+)
 
 
 class Category(_FileEventFilterStringField, _Choices):
@@ -56,7 +60,7 @@ class Directory(_FileEventFilterStringField):
     _term = "file.directory"
 
 
-class Size(_FileEventFilterComparableField):
+class Size(_FileEventFilterTimestampField):
     """V2 filter class that filters events by size in bytes of the file observed.
 
     Size ``value`` must be bytes.

--- a/src/py42/sdk/queries/fileevents/v2/filters/process.py
+++ b/src/py42/sdk/queries/fileevents/v2/filters/process.py
@@ -1,4 +1,6 @@
-from py42.sdk.queries.fileevents.util import _FileEventFilterStringField
+from py42.sdk.queries.fileevents.util import (
+    FileEventFilterStringField as _FileEventFilterStringField,
+)
 
 
 class Executable(_FileEventFilterStringField):

--- a/src/py42/sdk/queries/fileevents/v2/filters/risk.py
+++ b/src/py42/sdk/queries/fileevents/v2/filters/risk.py
@@ -1,8 +1,16 @@
-from py42.choices import _Choices
-from py42.sdk.queries.fileevents.util import _FileEventFilterComparableField
-from py42.sdk.queries.fileevents.util import _FileEventFilterStringField
-from py42.sdk.queries.query_filter import _QueryFilterBooleanField
-from py42.sdk.queries.query_filter import _QueryFilterStringField
+from py42.choices import Choices as _Choices
+from py42.sdk.queries.fileevents.util import (
+    FileEventFilterComparableField as _FileEventFilterComparableField,
+)
+from py42.sdk.queries.fileevents.util import (
+    FileEventFilterStringField as _FileEventFilterStringField,
+)
+from py42.sdk.queries.query_filter import (
+    QueryFilterBooleanField as _QueryFilterBooleanField,
+)
+from py42.sdk.queries.query_filter import (
+    QueryFilterStringField as _QueryFilterStringField,
+)
 
 
 class Indicators(_FileEventFilterStringField):

--- a/src/py42/sdk/queries/fileevents/v2/filters/source.py
+++ b/src/py42/sdk/queries/fileevents/v2/filters/source.py
@@ -1,6 +1,10 @@
-from py42.choices import _Choices
-from py42.sdk.queries.fileevents.util import _FileEventFilterStringField
-from py42.sdk.queries.query_filter import _QueryFilterStringField
+from py42.choices import Choices as _Choices
+from py42.sdk.queries.fileevents.util import (
+    FileEventFilterStringField as _FileEventFilterStringField,
+)
+from py42.sdk.queries.query_filter import (
+    QueryFilterStringField as _QueryFilterStringField,
+)
 
 
 class EmailSender(_QueryFilterStringField):

--- a/src/py42/sdk/queries/fileevents/v2/filters/timestamp.py
+++ b/src/py42/sdk/queries/fileevents/v2/filters/timestamp.py
@@ -1,5 +1,7 @@
-from py42.choices import _Choices
-from py42.sdk.queries.fileevents.util import _FileEventFilterTimestampField
+from py42.choices import Choices as _Choices
+from py42.sdk.queries.fileevents.util import (
+    FileEventFilterTimestampField as _FileEventFilterTimestampField,
+)
 
 
 class Timestamp(_FileEventFilterTimestampField, _Choices):

--- a/src/py42/sdk/queries/fileevents/v2/filters/user.py
+++ b/src/py42/sdk/queries/fileevents/v2/filters/user.py
@@ -1,4 +1,6 @@
-from py42.sdk.queries.fileevents.util import _FileEventFilterStringField
+from py42.sdk.queries.fileevents.util import (
+    FileEventFilterStringField as _FileEventFilterStringField,
+)
 
 
 class Email(_FileEventFilterStringField):

--- a/src/py42/sdk/queries/query_filter.py
+++ b/src/py42/sdk/queries/query_filter.py
@@ -19,7 +19,7 @@ def create_query_filter(term, operator, value=None):
         :class:`~py42.sdk.queries.query_filter.QueryFilter`
     """
 
-    return _QueryFilter(term, operator, value)
+    return QueryFilter(term, operator, value)
 
 
 def create_filter_group(query_filter_list, filter_clause):
@@ -184,7 +184,7 @@ def create_within_the_last_filter_group(term, value):
     return create_filter_group(filter_list, "AND")
 
 
-class _QueryFilterStringField:
+class QueryFilterStringField:
     """Helper class for creating filters where the search value is a string."""
 
     _term = "override_string_field_name"
@@ -245,7 +245,7 @@ class _QueryFilterStringField:
         return create_not_in_filter_group(cls._term, value_list)
 
 
-class _QueryFilterTimestampField:
+class QueryFilterTimestampField:
     """Helper class for creating filters where the search value is a timestamp."""
 
     _term = "override_timestamp_field_name"
@@ -339,7 +339,7 @@ class _QueryFilterTimestampField:
         )
 
 
-class _QueryFilterBooleanField:
+class QueryFilterBooleanField:
     """Helper class for creating filters where the search value is a boolean."""
 
     _term = "override_boolean_field_name"
@@ -365,7 +365,7 @@ class _QueryFilterBooleanField:
         return create_eq_filter_group(cls._term, "FALSE")
 
 
-class _QueryFilter:
+class QueryFilter:
     """Class for constructing a single filter object for use in a search query.
 
     When :func:`str()` is called on a :class:`~py42.sdk.queries.query_filter.QueryFilter`
@@ -435,7 +435,7 @@ class _QueryFilter:
             yield key, output_dict[key]
 
     def __eq__(self, other):
-        if isinstance(other, (_QueryFilter, tuple, list)):
+        if isinstance(other, (QueryFilter, tuple, list)):
             return tuple(self) == tuple(other)
         elif isinstance(other, str):
             return str(self) == other
@@ -477,7 +477,7 @@ class FilterGroup:
         Returns:
             :class:`~py42.sdk.queries.query_filter.FilterGroup`
         """
-        filter_list = [_QueryFilter.from_dict(item) for item in _dict["filters"]]
+        filter_list = [QueryFilter.from_dict(item) for item in _dict["filters"]]
         return cls(filter_list, filter_clause=_dict["filterClause"])
 
     @property

--- a/src/py42/services/detectionlists/departing_employee.py
+++ b/src/py42/services/detectionlists/departing_employee.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from warnings import warn
 
-from py42.choices import _Choices
+from py42.choices import Choices
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42NotFoundError
 from py42.exceptions import Py42UserNotOnListError
@@ -14,7 +14,7 @@ from py42.services.util import get_all_pages
 _DATE_FORMAT = "%Y-%m-%d"
 
 
-class DepartingEmployeeFilters(_DetectionListFilters, _Choices):
+class DepartingEmployeeFilters(_DetectionListFilters, Choices):
     """Deprecated. Use :class:`~py42.clients.watchlists.WatchlistsClient` and :class:`~py42.clients.userriskprofile.UserRiskProfileClient` instead. Constants available for filtering Departing Employee search results.
 
     * ``OPEN``

--- a/src/py42/services/detectionlists/high_risk_employee.py
+++ b/src/py42/services/detectionlists/high_risk_employee.py
@@ -1,6 +1,6 @@
 from warnings import warn
 
-from py42.choices import _Choices
+from py42.choices import Choices
 from py42.exceptions import Py42BadRequestError
 from py42.exceptions import Py42NotFoundError
 from py42.exceptions import Py42UserNotOnListError
@@ -11,7 +11,7 @@ from py42.services.detectionlists import handle_user_already_added_error
 from py42.services.util import get_all_pages
 
 
-class HighRiskEmployeeFilters(_DetectionListFilters, _Choices):
+class HighRiskEmployeeFilters(_DetectionListFilters, Choices):
     """Deprecated. Use :class:`~py42.clients.watchlists.WatchlistsClient` and :class:`~py42.clients.userriskprofile.UserRiskProfileClient` instead. Constants available for filtering High Risk Employee search results.
 
     * ``OPEN``

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from py42.clients._archiveaccess import FileType
 from py42.exceptions import Py42NotFoundError
 from py42.exceptions import Py42UnauthorizedError
 from py42.response import Py42Response
-from py42.sdk.queries.query_filter import _QueryFilter
+from py42.sdk.queries.query_filter import QueryFilter
 from py42.services._connection import Connection
 from py42.usercontext import UserContext
 
@@ -160,7 +160,7 @@ def exception():
 @pytest.fixture
 def query_filter_list():
     return [
-        _QueryFilter(
+        QueryFilter(
             EVENT_FILTER_FIELD_NAME + str(suffix),
             OPERATOR_STRING + str(suffix),
             VALUE_STRING + str(suffix),
@@ -171,12 +171,12 @@ def query_filter_list():
 
 @pytest.fixture
 def query_filter():
-    return _QueryFilter(EVENT_FILTER_FIELD_NAME, OPERATOR_STRING, VALUE_STRING)
+    return QueryFilter(EVENT_FILTER_FIELD_NAME, OPERATOR_STRING, VALUE_STRING)
 
 
 @pytest.fixture
 def unicode_query_filter():
-    return _QueryFilter(EVENT_FILTER_FIELD_NAME, OPERATOR_STRING, VALUE_UNICODE)
+    return QueryFilter(EVENT_FILTER_FIELD_NAME, OPERATOR_STRING, VALUE_UNICODE)
 
 
 @pytest.fixture

--- a/tests/sdk/queries/alerts/filters/test_alert_filter.py
+++ b/tests/sdk/queries/alerts/filters/test_alert_filter.py
@@ -20,10 +20,8 @@ from py42.sdk.queries.alerts.filters import RuleName
 from py42.sdk.queries.alerts.filters import RuleSource
 from py42.sdk.queries.alerts.filters import RuleType
 from py42.sdk.queries.alerts.filters import Severity
-from py42.sdk.queries.alerts.filters.alert_filter import create_contains_filter_group
-from py42.sdk.queries.alerts.filters.alert_filter import (
-    create_not_contains_filter_group,
-)
+from py42.sdk.queries.alerts.util import create_contains_filter_group
+from py42.sdk.queries.alerts.util import create_not_contains_filter_group
 from py42.util import MICROSECOND_FORMAT
 
 

--- a/tests/sdk/queries/conftest.py
+++ b/tests/sdk/queries/conftest.py
@@ -2,8 +2,8 @@ from datetime import datetime
 
 import pytest
 
-from py42.sdk.queries.query_filter import _QueryFilter
 from py42.sdk.queries.query_filter import FilterGroup
+from py42.sdk.queries.query_filter import QueryFilter
 from py42.util import MICROSECOND_FORMAT
 
 EVENT_FILTER_FIELD_NAME = "filter_field_name"
@@ -47,12 +47,12 @@ def event_filter_group_list(event_filter_group):
 
 @pytest.fixture
 def query_filter():
-    return _QueryFilter(EVENT_FILTER_FIELD_NAME, OPERATOR_STRING, VALUE_STRING)
+    return QueryFilter(EVENT_FILTER_FIELD_NAME, OPERATOR_STRING, VALUE_STRING)
 
 
 @pytest.fixture
 def unicode_query_filter():
-    return _QueryFilter(EVENT_FILTER_FIELD_NAME, OPERATOR_STRING, VALUE_UNICODE)
+    return QueryFilter(EVENT_FILTER_FIELD_NAME, OPERATOR_STRING, VALUE_UNICODE)
 
 
 def format_timestamp(test_time):

--- a/tests/sdk/queries/test_query_filter.py
+++ b/tests/sdk/queries/test_query_filter.py
@@ -2,8 +2,6 @@ from datetime import datetime
 
 import pytest
 
-from py42.sdk.queries.query_filter import _QueryFilter
-from py42.sdk.queries.query_filter import _QueryFilterTimestampField
 from py42.sdk.queries.query_filter import create_eq_filter_group
 from py42.sdk.queries.query_filter import create_filter_group
 from py42.sdk.queries.query_filter import create_in_range_filter_group
@@ -14,6 +12,8 @@ from py42.sdk.queries.query_filter import create_on_or_after_filter_group
 from py42.sdk.queries.query_filter import create_on_or_before_filter_group
 from py42.sdk.queries.query_filter import create_query_filter
 from py42.sdk.queries.query_filter import FilterGroup
+from py42.sdk.queries.query_filter import QueryFilter
+from py42.sdk.queries.query_filter import QueryFilterTimestampField
 
 
 EVENT_FILTER_FIELD_NAME = "filter_field_name"
@@ -34,7 +34,7 @@ def json_query_filter_with_suffix(suffix):
 
 
 def test_query_filter_constructs_successfully():
-    assert _QueryFilter(EVENT_FILTER_FIELD_NAME, OPERATOR_STRING, VALUE_STRING)
+    assert QueryFilter(EVENT_FILTER_FIELD_NAME, OPERATOR_STRING, VALUE_STRING)
 
 
 def test_query_filter_str_outputs_correct_json_representation(query_filter):
@@ -49,12 +49,12 @@ def test_query_filter_unicode_outputs_correct_json_representation(unicode_query_
 def test_query_filter_from_dict_gives_correct_json_representation():
     filter_dict = {"operator": "IS", "term": "testterm", "value": "testval"}
     filter_json = '{"operator":"IS", "term":"testterm", "value":"testval"}'
-    alert_query = _QueryFilter.from_dict(filter_dict)
+    alert_query = QueryFilter.from_dict(filter_dict)
     assert str(alert_query) == filter_json
 
 
 def test_query_filter_dict_gives_expected_dict_representation(event_filter_group):
-    query_filter = _QueryFilter("testterm", "IS", value="testval")
+    query_filter = QueryFilter("testterm", "IS", value="testval")
     alert_query_query_dict = dict(query_filter)
     assert alert_query_query_dict["term"] == "testterm"
     assert alert_query_query_dict["operator"] == "IS"
@@ -62,17 +62,17 @@ def test_query_filter_dict_gives_expected_dict_representation(event_filter_group
 
 
 def test_query_filter_term_returns_expected_value():
-    query_filter = _QueryFilter("testterm", "IS", value="testval")
+    query_filter = QueryFilter("testterm", "IS", value="testval")
     assert query_filter.term == "testterm"
 
 
 def test_query_filter_operator_returns_expected_value():
-    query_filter = _QueryFilter("testterm", "IS", value="testval")
+    query_filter = QueryFilter("testterm", "IS", value="testval")
     assert query_filter.operator == "IS"
 
 
 def test_query_filter_value_returns_expected_value():
-    query_filter = _QueryFilter("testterm", "IS", value="testval")
+    query_filter = QueryFilter("testterm", "IS", value="testval")
     assert query_filter.value == "testval"
 
 
@@ -246,26 +246,26 @@ def test_create_query_filter_returns_obj_with_correct_json_representation():
 
 
 def test_compare_query_filters_with_equivalent_args_returns_true():
-    query_filter1 = _QueryFilter(EVENT_FILTER_FIELD_NAME, OPERATOR_STRING, VALUE_STRING)
-    query_filter2 = _QueryFilter(EVENT_FILTER_FIELD_NAME, OPERATOR_STRING, VALUE_STRING)
+    query_filter1 = QueryFilter(EVENT_FILTER_FIELD_NAME, OPERATOR_STRING, VALUE_STRING)
+    query_filter2 = QueryFilter(EVENT_FILTER_FIELD_NAME, OPERATOR_STRING, VALUE_STRING)
     assert query_filter1 == query_filter2
 
 
 def test_compare_query_filters_with_different_values_returns_false():
-    query_filter1 = _QueryFilter(EVENT_FILTER_FIELD_NAME, OPERATOR_STRING, "TEST")
-    query_filter2 = _QueryFilter(EVENT_FILTER_FIELD_NAME, OPERATOR_STRING, "NOT_TEST")
+    query_filter1 = QueryFilter(EVENT_FILTER_FIELD_NAME, OPERATOR_STRING, "TEST")
+    query_filter2 = QueryFilter(EVENT_FILTER_FIELD_NAME, OPERATOR_STRING, "NOT_TEST")
     assert query_filter1 != query_filter2
 
 
 def test_compare_query_filters_with_different_operators_returns_false():
-    query_filter1 = _QueryFilter(EVENT_FILTER_FIELD_NAME, "IS", VALUE_STRING)
-    query_filter2 = _QueryFilter(EVENT_FILTER_FIELD_NAME, "IS_NOT", VALUE_STRING)
+    query_filter1 = QueryFilter(EVENT_FILTER_FIELD_NAME, "IS", VALUE_STRING)
+    query_filter2 = QueryFilter(EVENT_FILTER_FIELD_NAME, "IS_NOT", VALUE_STRING)
     assert query_filter1 != query_filter2
 
 
 def test_compare_query_filters_with_different_terms_returns_false():
-    query_filter1 = _QueryFilter("TEST", OPERATOR_STRING, VALUE_STRING)
-    query_filter2 = _QueryFilter("NOT_TEST", OPERATOR_STRING, VALUE_STRING)
+    query_filter1 = QueryFilter("TEST", OPERATOR_STRING, VALUE_STRING)
+    query_filter2 = QueryFilter("NOT_TEST", OPERATOR_STRING, VALUE_STRING)
     assert query_filter1 != query_filter2
 
 
@@ -286,7 +286,7 @@ def test_compare_query_filters_with_different_terms_returns_false():
     ],
 )
 def test_compare_query_filter_with_expected_equivalent_returns_true(equivalent):
-    query_filter = _QueryFilter(EVENT_FILTER_FIELD_NAME, OPERATOR_STRING, VALUE_STRING)
+    query_filter = QueryFilter(EVENT_FILTER_FIELD_NAME, OPERATOR_STRING, VALUE_STRING)
     assert query_filter == equivalent
 
 
@@ -329,7 +329,7 @@ def test_compare_query_filter_with_expected_equivalent_returns_true(equivalent):
     ],
 )
 def test_compare_query_filter_with_expected_different_returns_false(different):
-    query_filter = _QueryFilter(EVENT_FILTER_FIELD_NAME, OPERATOR_STRING, VALUE_STRING)
+    query_filter = QueryFilter(EVENT_FILTER_FIELD_NAME, OPERATOR_STRING, VALUE_STRING)
     assert query_filter != different
 
 
@@ -354,9 +354,9 @@ def test_compare_filter_group_with_equivalent_multiple_args_in_different_order_r
 @pytest.mark.parametrize(
     "filter_class",
     [
-        _QueryFilter("term", "IS", "value1"),
-        _QueryFilter("term", "IS", "value2"),
-        _QueryFilter("term", "IS", "value3"),
+        QueryFilter("term", "IS", "value1"),
+        QueryFilter("term", "IS", "value2"),
+        QueryFilter("term", "IS", "value3"),
     ],
 )
 def test_filter_group_contains_expected_query_filter_returns_true(filter_class):
@@ -370,9 +370,9 @@ def test_filter_group_contains_expected_query_filter_returns_true(filter_class):
 @pytest.mark.parametrize(
     "filter_class",
     [
-        _QueryFilter("term", "IS", "value4"),
-        _QueryFilter("different_term", "IS", "value2"),
-        _QueryFilter("term", "DIFFERENT_OPERATOR", "value3"),
+        QueryFilter("term", "IS", "value4"),
+        QueryFilter("different_term", "IS", "value2"),
+        QueryFilter("term", "DIFFERENT_OPERATOR", "value3"),
     ],
 )
 def test_filter_group_when_does_not_contain_expected_query_filter_returns_false(
@@ -424,7 +424,7 @@ class Test_QueryFilterTimestampField:
             ],
         }
 
-        qf = _QueryFilterTimestampField.on_or_after(timestamp)
+        qf = QueryFilterTimestampField.on_or_after(timestamp)
         assert dict(qf) == expected
 
     @pytest.mark.parametrize(
@@ -447,7 +447,7 @@ class Test_QueryFilterTimestampField:
                 }
             ],
         }
-        assert dict(_QueryFilterTimestampField.on_or_before(timestamp)) == expected
+        assert dict(QueryFilterTimestampField.on_or_before(timestamp)) == expected
 
     @pytest.mark.parametrize(
         "start_timestamp, end_timestamp",
@@ -479,7 +479,7 @@ class Test_QueryFilterTimestampField:
         }
 
         assert (
-            dict(_QueryFilterTimestampField.in_range(start_timestamp, end_timestamp))
+            dict(QueryFilterTimestampField.in_range(start_timestamp, end_timestamp))
             == expected
         )
 
@@ -508,7 +508,7 @@ class Test_QueryFilterTimestampField:
                 },
             ],
         }
-        assert dict(_QueryFilterTimestampField.on_same_day(timestamp)) == expected
+        assert dict(QueryFilterTimestampField.on_same_day(timestamp)) == expected
 
     def test_on_or_after_with_decimals(self):
         expected = {
@@ -522,7 +522,7 @@ class Test_QueryFilterTimestampField:
             ],
         }
 
-        qf = _QueryFilterTimestampField.on_or_after(1599736333.123456)
+        qf = QueryFilterTimestampField.on_or_after(1599736333.123456)
         assert dict(qf) == expected
 
     def test_on_or_before_with_decimals(self):
@@ -537,7 +537,7 @@ class Test_QueryFilterTimestampField:
             ],
         }
         assert (
-            dict(_QueryFilterTimestampField.on_or_before(1599736333.123456)) == expected
+            dict(QueryFilterTimestampField.on_or_before(1599736333.123456)) == expected
         )
 
     def test_in_range_with_decimals(self):
@@ -558,8 +558,6 @@ class Test_QueryFilterTimestampField:
         }
 
         assert (
-            dict(
-                _QueryFilterTimestampField.in_range(1599736333.123456, 1599739994.6789)
-            )
+            dict(QueryFilterTimestampField.in_range(1599736333.123456, 1599739994.6789))
             == expected
         )


### PR DESCRIPTION
Undo class renaming in favor of aliasing within the filter modules - for backwards compatibility with imports 