### PR TITLE
Feature/api clients orgs

### DIFF
--- a/docs/userguides/gettingstarted.md
+++ b/docs/userguides/gettingstarted.md
@@ -60,18 +60,36 @@ pip install py42-[VERSION].tar.gz
 
 ## Authentication
 
-TODO: Update before releasing api-clients
-
 ```{eval-rst}
 .. important:: py42 currently only supports token-based authentication.
 ```
 
-To initialize the `py42.sdk.SDKClient`, you must provide your credentials (basic authentication). If you are writing a script,
+To initialize the `py42.sdk.SDKClient`, you must provide your credentials. If you are writing a script,
 we recommend using a secure password storage library, such as `keyring`, for retrieving passwords. However, subsequent
 requests use JWT authentication.
 
 If your account uses [two-factor authentication](https://support.code42.com/Administrator/Cloud/Configuring/Two-factor_authentication_for_local_users), include the time-based one-time password (TOTP) when you initialize the `py42.sdk.SDKClient`.
 You can also provide a callable object that returns a TOTP. If you pass a callable, it will be called whenever a new TOTP is required to renew the authentication token.
+
+### Basic Authentication
+
+Py42 supports basic auth with your Code42 username and password.
+
+```python
+import py42.sdk
+
+sdk = py42.sdk.from_local_account("https://console.code42.com", "username@code42.com", "password")
+```
+
+### Api Clients
+
+Py42 also supports api clients.  You can use the api key and secret generated through the Code42 console to initiate the `SDKClient`.
+
+```python
+import py42.sdk
+
+sdk = py42.sdk.from_api_client("https://console.code42.com", "key-123-42", "my%secret!")
+```
 
 ## Troubleshooting and support
 

--- a/docs/userguides/gettingstarted.md
+++ b/docs/userguides/gettingstarted.md
@@ -83,7 +83,7 @@ sdk = py42.sdk.from_local_account("https://console.code42.com", "username@code42
 
 ### Api Clients
 
-Py42 also supports api clients.  You can use the api key and secret generated through the Code42 console to initiate the `SDKClient`.
+Py42 also supports api clients.  You can use the client ID and secret generated through the Code42 console to initiate the `SDKClient`.
 
 ```python
 import py42.sdk

--- a/src/py42/services/devices.py
+++ b/src/py42/services/devices.py
@@ -293,6 +293,8 @@ class DeviceService(BaseService):
     def upgrade(self, guid):
         """Instructs a device to upgrade to the latest available version.
 
+        WARNING: This method is incompatible with api client authentication.
+
         Args:
             guid (str): The globally unique identifier of the device.
 

--- a/src/py42/services/orgs.py
+++ b/src/py42/services/orgs.py
@@ -209,8 +209,8 @@ class OrgService(BaseService):
         """
         return self.get_agent_state(org_id, "fullDiskAccess")
 
-    # TODO - status of this org settings with api clients
-
+    # TODO - this method won't be supported by API clients.  A plan for how to handle this and similar methods
+    # TODO - will need to be determined prior to a full py42 api-client support release.
     def get_settings(self, org_id):
         """Gets setting data for an org and returns an `OrgSettingsManager` for the target org.
 
@@ -227,6 +227,8 @@ class OrgService(BaseService):
         t_settings = self._connection.get(uri)
         return OrgSettings(org_settings.data, t_settings.data)
 
+    # TODO - this method won't be supported by API clients.  A plan for how to handle this and similar methods
+    # TODO - will need to be determined prior to a full py42 api-client support release.
     def update_settings(self, org_settings):
         """Updates an org's settings based on changes to the passed in `OrgSettings` instance.
 

--- a/src/py42/services/orgs.py
+++ b/src/py42/services/orgs.py
@@ -2,7 +2,8 @@ from collections import namedtuple
 
 from py42 import settings
 from py42.clients.settings.org_settings import OrgSettings
-from py42.exceptions import Py42Error, Py42InternalServerError
+from py42.exceptions import Py42Error
+from py42.exceptions import Py42InternalServerError
 from py42.services import BaseService
 from py42.services.util import get_all_pages
 
@@ -172,7 +173,7 @@ class OrgService(BaseService):
         except Py42InternalServerError as err:
             raise Py42InternalServerError(
                 err,
-                message="Server Error. Please be aware that this method is incompatible with api client authentication."
+                message="Server Error. Please be aware that this method is incompatible with api client authentication.",
             )
 
     def get_agent_state(self, org_id, property_name):
@@ -262,8 +263,6 @@ class OrgService(BaseService):
         # Use additional lookup to prevent breaking changes.
         pages = self.get_all()
         for page in pages:
-            for org in page['orgs']:
+            for org in page["orgs"]:
                 if org[id_key] == org_id:
-                    return org['orgGuid']
-
-
+                    return org["orgGuid"]

--- a/src/py42/services/orgs.py
+++ b/src/py42/services/orgs.py
@@ -34,12 +34,16 @@ class OrgService(BaseService):
         Returns:
             :class:`py42.response.Py42Response`
         """
+
+        # get parent org GUID from UID :)
+        parent_org_guid = self._get_guid_by_id(parent_org_uid, id_key="orgUid")
+
         uri = "/api/v3/orgs"
         data = {
             "orgName": org_name,
             "orgExtRef": org_ext_ref,
             "notes": notes,
-            "parentOrgGuid": parent_org_uid,
+            "parentOrgGuid": parent_org_guid,
         }
         return self._connection.post(uri, json=data)
 

--- a/src/py42/services/orgs.py
+++ b/src/py42/services/orgs.py
@@ -1,6 +1,5 @@
 from collections import namedtuple
 
-from py42 import settings
 from py42.clients.settings.org_settings import OrgSettings
 from py42.exceptions import Py42Error
 from py42.exceptions import Py42InternalServerError
@@ -95,18 +94,14 @@ class OrgService(BaseService):
         """Gets an individual page of organizations.
 
         Args:
-            page_num (int): The page number to request.
-            page_size (int, optional): The number of organizations to return per page.
-                Defaults to `py42.settings.items_per_page`.
-            kwargs (dict, optional): Additional advanced-user arguments. Defaults to None.
+            page_num (int, optional): DEPRECATED.
+            page_size (int, optional): DEPRECATED.
 
         Returns:
             :class:`py42.response.Py42Response`
         """
         uri = "/api/v3/orgs"
-        page_size = page_size or settings.items_per_page
-        params = dict(pgNum=page_num, pgSize=page_size, **kwargs)
-        return self._connection.get(uri, params=params)
+        return self._connection.get(uri)
 
     def get_all(self, **kwargs):
         """Gets all organizations.

--- a/tests/services/test_orgs.py
+++ b/tests/services/test_orgs.py
@@ -61,10 +61,8 @@ class TestOrgService:
 
     def test_get_page_calls_get_with_expected_url_and_params(self, mock_connection):
         service = OrgService(mock_connection)
-        service.get_page(3, 25)
-        mock_connection.get.assert_called_once_with(
-            ORGS_V3_URI, params={"pgNum": 3, "pgSize": 25}
-        )
+        service.get_page()
+        mock_connection.get.assert_called_once_with(ORGS_V3_URI)
 
     def test_get_agent_state_calls_get_with_uri_and_params(
         self, mock_connection, successful_response

--- a/tests/services/test_orgs.py
+++ b/tests/services/test_orgs.py
@@ -1,19 +1,30 @@
+from unittest.mock import patch
+
 import pytest
-from tests.conftest import create_mock_response
+
+from py42.exceptions import Py42InternalServerError
+from tests.conftest import create_mock_response, create_mock_error
 
 import py42.settings
 from py42.services.orgs import OrgService
 
+
+# TODO - update GET/PUT endpoints to be released in 10.5
+
+
 COMPUTER_URI = "/api/v1/Org"
+ORGS_V3_URI = "/api/v3/orgs"
+TEST_ORG_GUID = "12345-org-guid"
 
 MOCK_GET_ORG_RESPONSE = (
-    """{"totalCount": 3000, "orgs": [{"orgName": "foo", "orgUid": "123"}]}"""
+    """{"totalCount": 3000, "orgs": [{"orgName": "foo", "orgId": "12345", "orgUid": "123", "orgGuid":"12345-org-guid"}]}"""
 )
 
 MOCK_EMPTY_GET_ORGS_RESPONSE = """{"totalCount": 3000, "orgs": []}"""
 
 
 class TestOrgService:
+
     @pytest.fixture
     def mock_get_all_response(self, mocker):
         yield create_mock_response(mocker, MOCK_GET_ORG_RESPONSE)
@@ -71,3 +82,84 @@ class TestOrgService:
         service.get_agent_state = mocker.Mock()
         service.get_agent_full_disk_access_states("ORG_ID")
         service.get_agent_state.assert_called_once_with("ORG_ID", "fullDiskAccess")
+
+    def test_create_org_calls_post_with_expected_uri_and_params(self, mock_connection):
+        service = OrgService(mock_connection)
+        service.create_org("My New Org", org_ext_ref="Org Ext Ref", notes="my org notes.", parent_org_uid="parent-123")
+        data = {
+            "orgName": "My New Org",
+            "orgExtRef": "Org Ext Ref",
+            "notes": "my org notes.",
+            "parentOrgGuid": "parent-123",
+        }
+        mock_connection.post.assert_called_once_with(ORGS_V3_URI, json=data)
+
+    def test_get_by_uid_calls_get_with_expected_uri_and_params(self, mock_connection):
+        service = OrgService(mock_connection)
+        service.get_by_uid("12345")
+        uri = f"{COMPUTER_URI}/12345"
+        params = dict(idType="orgUid")
+        mock_connection.get.assert_called_once_with(uri, params=params)
+
+    @patch.object(
+        py42.services.orgs.OrgService,
+        "_get_guid_by_id",
+        return_value=TEST_ORG_GUID,
+    )
+    def test_block_calls_post_with_expected_uri_and_params(self, mock_connection):
+        service = OrgService(mock_connection)
+        service.block(12345)
+        uri = f"{ORGS_V3_URI}/{TEST_ORG_GUID}/block"
+        mock_connection.post.assert_called_once_with(uri)
+
+    @patch.object(
+        py42.services.orgs.OrgService,
+        "_get_guid_by_id",
+        return_value=TEST_ORG_GUID,
+    )
+    def test_unblock_calls_post_with_expected_uri_and_params(self, mock_connection):
+        service = OrgService(mock_connection)
+        service.unblock(12345)
+        uri = f"{ORGS_V3_URI}/{TEST_ORG_GUID}/unblock"
+        mock_connection.post.assert_called_once_with(uri)
+
+    @patch.object(
+        py42.services.orgs.OrgService,
+        "_get_guid_by_id",
+        return_value=TEST_ORG_GUID,
+    )
+    def test_deactivate_calls_post_with_expected_uri_and_params(self, mock_connection):
+        service = OrgService(mock_connection)
+        service.deactivate(12345)
+        uri = f"{ORGS_V3_URI}/{TEST_ORG_GUID}/deactivate"
+        mock_connection.post.assert_called_once_with(uri)
+
+    @patch.object(
+        py42.services.orgs.OrgService,
+        "_get_guid_by_id",
+        return_value=TEST_ORG_GUID,
+    )
+    def test_reactivate_calls_post_with_expected_uri_and_params(self, mock_connection):
+        service = OrgService(mock_connection)
+        service.reactivate(12345)
+        uri = f"{ORGS_V3_URI}/{TEST_ORG_GUID}/activate"
+        mock_connection.post.assert_called_once_with(uri)
+
+    def test_get_current_calls_get_with_expected_uri_and_params(self, mock_connection):
+        service = OrgService(mock_connection)
+        service.get_current()
+        uri = f"{COMPUTER_URI}/my"
+        mock_connection.get.assert_called_once_with(uri, params={})
+
+    def test_get_current_returns_note_about_api_client_support_when_internal_server_error(self, mock_connection, mocker):
+        service = OrgService(mock_connection)
+        mock_connection.get.side_effect = create_mock_error(
+            Py42InternalServerError, mocker, "Server Error"
+        )
+        with pytest.raises(Py42InternalServerError) as err:
+            service.get_current()
+
+        expected = "Please be aware that this method is incompatible with api client authentication."
+        assert expected in err.value.args[0]
+
+

--- a/tests/services/test_orgs.py
+++ b/tests/services/test_orgs.py
@@ -80,6 +80,11 @@ class TestOrgService:
         service.get_agent_full_disk_access_states("ORG_ID")
         service.get_agent_state.assert_called_once_with("ORG_ID", "fullDiskAccess")
 
+    @patch.object(
+        py42.services.orgs.OrgService,
+        "_get_guid_by_id",
+        return_value="parent-guid-123",
+    )
     def test_create_org_calls_post_with_expected_uri_and_params(self, mock_connection):
         service = OrgService(mock_connection)
         service.create_org(
@@ -92,7 +97,7 @@ class TestOrgService:
             "orgName": "My New Org",
             "orgExtRef": "Org Ext Ref",
             "notes": "my org notes.",
-            "parentOrgGuid": "parent-123",
+            "parentOrgGuid": "parent-guid-123",
         }
         mock_connection.post.assert_called_once_with(ORGS_V3_URI, json=data)
 

--- a/tests/services/test_orgs.py
+++ b/tests/services/test_orgs.py
@@ -1,11 +1,11 @@
 from unittest.mock import patch
 
 import pytest
-
-from py42.exceptions import Py42InternalServerError
-from tests.conftest import create_mock_response, create_mock_error
+from tests.conftest import create_mock_error
+from tests.conftest import create_mock_response
 
 import py42.settings
+from py42.exceptions import Py42InternalServerError
 from py42.services.orgs import OrgService
 
 
@@ -16,15 +16,12 @@ COMPUTER_URI = "/api/v1/Org"
 ORGS_V3_URI = "/api/v3/orgs"
 TEST_ORG_GUID = "12345-org-guid"
 
-MOCK_GET_ORG_RESPONSE = (
-    """{"totalCount": 3000, "orgs": [{"orgName": "foo", "orgId": "12345", "orgUid": "123", "orgGuid":"12345-org-guid"}]}"""
-)
+MOCK_GET_ORG_RESPONSE = """{"totalCount": 3000, "orgs": [{"orgName": "foo", "orgId": "12345", "orgUid": "123", "orgGuid":"12345-org-guid"}]}"""
 
 MOCK_EMPTY_GET_ORGS_RESPONSE = """{"totalCount": 3000, "orgs": []}"""
 
 
 class TestOrgService:
-
     @pytest.fixture
     def mock_get_all_response(self, mocker):
         yield create_mock_response(mocker, MOCK_GET_ORG_RESPONSE)
@@ -85,7 +82,12 @@ class TestOrgService:
 
     def test_create_org_calls_post_with_expected_uri_and_params(self, mock_connection):
         service = OrgService(mock_connection)
-        service.create_org("My New Org", org_ext_ref="Org Ext Ref", notes="my org notes.", parent_org_uid="parent-123")
+        service.create_org(
+            "My New Org",
+            org_ext_ref="Org Ext Ref",
+            notes="my org notes.",
+            parent_org_uid="parent-123",
+        )
         data = {
             "orgName": "My New Org",
             "orgExtRef": "Org Ext Ref",
@@ -151,7 +153,9 @@ class TestOrgService:
         uri = f"{COMPUTER_URI}/my"
         mock_connection.get.assert_called_once_with(uri, params={})
 
-    def test_get_current_returns_note_about_api_client_support_when_internal_server_error(self, mock_connection, mocker):
+    def test_get_current_returns_note_about_api_client_support_when_internal_server_error(
+        self, mock_connection, mocker
+    ):
         service = OrgService(mock_connection)
         mock_connection.get.side_effect = create_mock_error(
             Py42InternalServerError, mocker, "Server Error"
@@ -161,5 +165,3 @@ class TestOrgService:
 
         expected = "Please be aware that this method is incompatible with api client authentication."
         assert expected in err.value.args[0]
-
-

--- a/tests/services/test_orgs.py
+++ b/tests/services/test_orgs.py
@@ -8,10 +8,6 @@ import py42.settings
 from py42.exceptions import Py42InternalServerError
 from py42.services.orgs import OrgService
 
-
-# TODO - update GET/PUT endpoints to be released in 10.5
-
-
 COMPUTER_URI = "/api/v1/Org"
 ORGS_V3_URI = "/api/v3/orgs"
 TEST_ORG_GUID = "12345-org-guid"

--- a/tests/services/test_orgs.py
+++ b/tests/services/test_orgs.py
@@ -19,12 +19,8 @@ MOCK_EMPTY_GET_ORGS_RESPONSE = """{"totalCount": 3000, "orgs": []}"""
 
 class TestOrgService:
     @pytest.fixture
-    def mock_get_all_response(self, mocker):
-        yield create_mock_response(mocker, MOCK_GET_ORG_RESPONSE)
-
-    @pytest.fixture
-    def mock_get_all_empty_response(self, mocker):
-        yield create_mock_response(mocker, MOCK_EMPTY_GET_ORGS_RESPONSE)
+    def mock_get_page_response(self, mocker):
+        return create_mock_response(mocker, MOCK_GET_ORG_RESPONSE)
 
     @patch.object(
         py42.services.orgs.OrgService,
@@ -40,20 +36,16 @@ class TestOrgService:
         uri = f"{ORGS_V3_URI}/org-guid-123"
         mock_connection.get.assert_called_once_with(uri, params={})
 
-    def test_get_all_calls_get_expected_number_of_times(
-        self, mock_connection, mock_get_all_response, mock_get_all_empty_response
+    def test_get_all_calls_get_page_and_returns_generator(
+        self, mock_connection, mock_get_page_response
     ):
         py42.settings.items_per_page = 1
         service = OrgService(mock_connection)
-        mock_connection.get.side_effect = [
-            mock_get_all_response,
-            mock_get_all_response,
-            mock_get_all_empty_response,
-        ]
+        mock_connection.get.side_effect = mock_get_page_response
         for _ in service.get_all():
             pass
         py42.settings.items_per_page = 500
-        assert mock_connection.get.call_count == 3
+        assert mock_connection.get.call_count == 1
 
     def test_get_page_calls_get_with_expected_url_and_params(self, mock_connection):
         service = OrgService(mock_connection)


### PR DESCRIPTION
### Description of Change ###

Replaces the APIs for the following methods with the new `v3/orgs` endpoints with api client support.
- create
- block/unblock
- activate/deactivate

The GET and PUT endpoints for v3/orgs are not yet released, but the existing endpoints do support API clients.  TODO's in the code indicate places where those future changes will need to be made.  TBD whether waiting for those is in the scope of this PR.

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [NA] Add an entry to CHANGELOG.md describing this change
- [NA] Add docstrings for any new public parameters / methods / classes
