### PR TITLE
change test method for jwt provider to support api clients

### DIFF
--- a/src/py42/sdk/__init__.py
+++ b/src/py42/sdk/__init__.py
@@ -60,7 +60,7 @@ def from_jwt_provider(host_address, jwt_provider):
     """
 
     client = SDKClient.from_jwt_provider(host_address, jwt_provider)
-    client.users.get_current()
+    client.usercontext.get_current_tenant_id()
     return client
 
 


### PR DESCRIPTION
### Description of Change ###

Use `get_current_tenant_id()` as auth test in `from_jwt_provider()` so api clients can work.
