### PR TITLE
move `sdk.userriskprofile.get_by_username` lookup to use `/v1/User` endpoint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: [3.7, 3.8, 3.9, "3.10", 3.11]
 
     steps:
       - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       rev: 22.3.0
       hooks:
         - id: black
-    - repo: https://gitlab.com/pycqa/flake8
+    - repo: https://github.com/pycqa/flake8
       rev: 3.8.3
       hooks:
         - id: flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 ### Fixed
 
 - Reverted `sdk.orgs.get_page()` method to use `/v1/orgs` endpoint due to paging bug in `/v3/orgs` endpoint. `sdk.orgs.get_all()` has also been reverted accordingly.
+- `sdk.userriskprofile.get_by_username()` now uses a more efficient method to look up the userUid from the username for retrieving the User Risk Profile.
 
 ## 1.26.0 - 2022-09-08
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,8 @@ ignore =
     W503
     # exception chaining
     B904
+    # allow manual quoting
+    B907
 # up to 88 allowed by bugbear B950
 max-line-length = 80
 per-file-ignores =

--- a/src/py42/clients/userriskprofile.py
+++ b/src/py42/clients/userriskprofile.py
@@ -1,4 +1,5 @@
-from py42.exceptions import Py42Error, Py42UserRiskProfileNotFound, Py42NotFoundError
+from py42.exceptions import Py42Error
+from py42.exceptions import Py42NotFoundError
 
 
 class UserRiskProfileClient:

--- a/src/py42/clients/userriskprofile.py
+++ b/src/py42/clients/userriskprofile.py
@@ -1,4 +1,4 @@
-from py42.exceptions import Py42Error
+from py42.exceptions import Py42Error, Py42UserRiskProfileNotFound, Py42NotFoundError
 
 
 class UserRiskProfileClient:
@@ -33,9 +33,9 @@ class UserRiskProfileClient:
         """
         user_response = self._user_service.get_by_username(username)
         if len(user_response.data["users"]) == 0:
-            err = Py42Error(f"Username '{username}' not found.")
+            err = Py42Error()
             err.response = user_response
-            raise err
+            raise Py42NotFoundError(err, message=f"Username '{username}' not found.")
         user_id = user_response.data["users"][0]["userUid"]
         return self.get_by_id(user_id)
 

--- a/src/py42/clients/userriskprofile.py
+++ b/src/py42/clients/userriskprofile.py
@@ -1,11 +1,15 @@
+from py42.exceptions import Py42Error
+
+
 class UserRiskProfileClient:
     """A client to expose the user risk profile API.
 
     `Rest Documentation <https://developer.code42.com/api/#tag/User-Risk-Profiles>`__
     """
 
-    def __init__(self, user_risk_profile_service):
+    def __init__(self, user_risk_profile_service, user_service):
         self._user_risk_profile_service = user_risk_profile_service
+        self._user_service = user_service
 
     def get_by_id(self, user_id):
         """Get a user risk profile by a user UID.
@@ -27,7 +31,13 @@ class UserRiskProfileClient:
         Returns:
                 :class:`py42.response.Py42Response`
         """
-        return self._user_risk_profile_service.get_by_username(username)
+        user_response = self._user_service.get_by_username(username)
+        if len(user_response.data["users"]) == 0:
+            err = Py42Error(f"Username '{username}' not found.")
+            err.response = user_response
+            raise err
+        user_id = user_response.data["users"][0]["userUid"]
+        return self.get_by_id(user_id)
 
     def update(self, user_id, start_date=None, end_date=None, notes=None):
         """Update a user risk profile.

--- a/src/py42/sdk/__init__.py
+++ b/src/py42/sdk/__init__.py
@@ -465,7 +465,7 @@ def _init_clients(services, connection):
     auditlogs = AuditLogsClient(services.auditlogs)
     loginconfig = LoginConfigurationClient(connection)
     trustedactivities = TrustedActivitiesClient(services.trustedactivities)
-    userriskprofile = UserRiskProfileClient(services.userriskprofile)
+    userriskprofile = UserRiskProfileClient(services.userriskprofile, services.users)
     watchlists = WatchlistsClient(services.watchlists)
     clients = Clients(
         authority=authority,

--- a/src/py42/services/storage/_service_factory.py
+++ b/src/py42/services/storage/_service_factory.py
@@ -1,5 +1,6 @@
 from functools import lru_cache
 
+from py42.exceptions import Py42Error
 from py42.services._connection import Connection
 from py42.services.storage.archive import StorageArchiveService
 from py42.services.storage.exfiltrateddata import ExfiltratedDataService
@@ -45,5 +46,5 @@ class StorageServiceFactory:
         # take the first destination guid we find
         destination_list = response["backupUsage"]
         if not destination_list:
-            raise Exception(f"No destinations found for device guid: {device_guid}")
+            raise Py42Error(f"No destinations found for device guid: {device_guid}")
         return destination_list[0]["targetComputerGuid"]

--- a/tests/clients/_archiveaccess/test_accessorfactory.py
+++ b/tests/clients/_archiveaccess/test_accessorfactory.py
@@ -175,13 +175,13 @@ class TestArchiveAccessFactory:
     def test_create_archive_accessor_raises_exception_when_create_backup_client_raises(
         self, archive_service, storage_service_factory
     ):
-        storage_service_factory.create_archive_service.side_effect = Exception(
+        storage_service_factory.create_archive_service.side_effect = ValueError(
             "Exception in create_backup_client"
         )
         accessor_factory = ArchiveAccessorFactory(
             archive_service, storage_service_factory
         )
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             accessor_factory.create_archive_accessor(
                 INVALID_DEVICE_GUID, ArchiveAccessor
             )

--- a/tests/clients/test_userriskprofile.py
+++ b/tests/clients/test_userriskprofile.py
@@ -1,8 +1,11 @@
 import pytest
+from tests.conftest import create_mock_response
 
 from py42.clients.userriskprofile import UserRiskProfileClient
+from py42.exceptions import Py42Error
+from py42.response import Py42Response
 from py42.services.userriskprofile import UserRiskProfileService
-
+from py42.services.users import UserService
 
 USER_ID = "123"
 USERNAME = "risk-user@code42.com"
@@ -13,25 +16,54 @@ def mock_user_risk_profile_service(mocker):
     return mocker.MagicMock(spec=UserRiskProfileService)
 
 
+@pytest.fixture
+def mock_user_service(mocker):
+    return mocker.MagicMock(spec=UserService)
+
+
 class TestUserRiskProfileClient:
     def test_get_by_id_calls_service_with_expected_params(
-        self, mock_user_risk_profile_service
+        self, mock_user_risk_profile_service, mock_user_service
     ):
-        user_risk_profile_client = UserRiskProfileClient(mock_user_risk_profile_service)
+        user_risk_profile_client = UserRiskProfileClient(
+            mock_user_risk_profile_service, mock_user_service
+        )
         user_risk_profile_client.get_by_id(USER_ID)
         mock_user_risk_profile_service.get_by_id.assert_called_once_with(USER_ID)
 
-    def test_get_by_username_calls_service_with_expected_params(
-        self, mock_user_risk_profile_service
+    def test_get_by_username_calls_user_service_with_expected_params(
+        self, mocker, mock_user_risk_profile_service, mock_user_service
     ):
-        user_risk_profile_client = UserRiskProfileClient(mock_user_risk_profile_service)
+        mock_user_service.get_by_username.return_value = create_mock_response(
+            mocker, text='{"data": {"users": [{"userUid": "1234"}]}}'
+        )
+        user_risk_profile_client = UserRiskProfileClient(
+            mock_user_risk_profile_service, mock_user_service
+        )
         user_risk_profile_client.get_by_username(USERNAME)
-        mock_user_risk_profile_service.get_by_username.assert_called_once_with(USERNAME)
+        mock_user_service.get_by_username.assert_called_once_with(USERNAME)
+        mock_user_risk_profile_service.get_by_id.assert_called_once_with("1234")
+
+    def test_get_by_username_raises_py42error_with_response_when_username_not_found(
+        self, mocker, mock_user_risk_profile_service, mock_user_service
+    ):
+        mock_user_service.get_by_username.return_value = create_mock_response(
+            mocker, text='{"data": {"users": []}}'
+        )
+        user_risk_profile_client = UserRiskProfileClient(
+            mock_user_risk_profile_service, mock_user_service
+        )
+        with pytest.raises(Py42Error) as err:
+            user_risk_profile_client.get_by_username(USERNAME)
+
+        assert isinstance(err.value.response, Py42Response)
 
     def test_update_calls_service_with_expected_params(
         self, mock_user_risk_profile_service
     ):
-        user_risk_profile_client = UserRiskProfileClient(mock_user_risk_profile_service)
+        user_risk_profile_client = UserRiskProfileClient(
+            mock_user_risk_profile_service, mock_user_service
+        )
         user_risk_profile_client.update(USER_ID)
         mock_user_risk_profile_service.update.assert_called_once_with(
             USER_ID, None, None, None
@@ -40,7 +72,9 @@ class TestUserRiskProfileClient:
     def test_update_calls_service_with_optional_params(
         self, mock_user_risk_profile_service
     ):
-        user_risk_profile_client = UserRiskProfileClient(mock_user_risk_profile_service)
+        user_risk_profile_client = UserRiskProfileClient(
+            mock_user_risk_profile_service, mock_user_service
+        )
         user_risk_profile_client.update(USER_ID, "2022-1-1", "2022-4-1", "notes")
         mock_user_risk_profile_service.update.assert_called_once_with(
             USER_ID, "2022-1-1", "2022-4-1", "notes"
@@ -49,30 +83,38 @@ class TestUserRiskProfileClient:
     def test_get_page_calls_service_with_expected_params(
         self, mock_user_risk_profile_service
     ):
-        user_risk_profile_client = UserRiskProfileClient(mock_user_risk_profile_service)
+        user_risk_profile_client = UserRiskProfileClient(
+            mock_user_risk_profile_service, mock_user_service
+        )
         user_risk_profile_client.get_page()
         assert mock_user_risk_profile_service.get_page.call_count == 1
 
     def test_get_page_calls_service_with_optional_params(
-        self, mock_user_risk_profile_service
+        self, mock_user_risk_profile_service, mock_user_service
     ):
-        user_risk_profile_client = UserRiskProfileClient(mock_user_risk_profile_service)
+        user_risk_profile_client = UserRiskProfileClient(
+            mock_user_risk_profile_service, mock_user_service
+        )
         user_risk_profile_client.get_page(page_num=1, page_size=10)
         mock_user_risk_profile_service.get_page.assert_called_once_with(
             1, 10, None, None, None, None, None, None, None, None, None, None, None
         )
 
     def test_get_all_calls_service_with_expected_params(
-        self, mock_user_risk_profile_service
+        self, mock_user_risk_profile_service, mock_user_service
     ):
-        user_risk_profile_client = UserRiskProfileClient(mock_user_risk_profile_service)
+        user_risk_profile_client = UserRiskProfileClient(
+            mock_user_risk_profile_service, mock_user_service
+        )
         user_risk_profile_client.get_all()
         assert mock_user_risk_profile_service.get_all.call_count == 1
 
     def test_get_all_calls_service_with_optional_params(
-        self, mock_user_risk_profile_service
+        self, mock_user_risk_profile_service, mock_user_service
     ):
-        user_risk_profile_client = UserRiskProfileClient(mock_user_risk_profile_service)
+        user_risk_profile_client = UserRiskProfileClient(
+            mock_user_risk_profile_service, mock_user_service
+        )
         user_risk_profile_client.get_all(
             manager_id="manager-id",
             title="engineer",
@@ -101,18 +143,22 @@ class TestUserRiskProfileClient:
         )
 
     def test_add_cloud_aliases_calls_service_with_expected_params(
-        self, mock_user_risk_profile_service
+        self, mock_user_risk_profile_service, mock_user_service
     ):
-        user_risk_profile_client = UserRiskProfileClient(mock_user_risk_profile_service)
+        user_risk_profile_client = UserRiskProfileClient(
+            mock_user_risk_profile_service, mock_user_service
+        )
         user_risk_profile_client.add_cloud_aliases(USER_ID, "cloud-alias@email.com")
         mock_user_risk_profile_service.add_cloud_aliases.assert_called_once_with(
             USER_ID, "cloud-alias@email.com"
         )
 
     def test_delete_cloud_aliases_calls_service_with_expected_params(
-        self, mock_user_risk_profile_service
+        self, mock_user_risk_profile_service, mock_user_service
     ):
         aliases = ["cloud-alias@email.com", "default@code42.com"]
-        user_risk_profile_client = UserRiskProfileClient(mock_user_risk_profile_service)
+        user_risk_profile_client = UserRiskProfileClient(
+            mock_user_risk_profile_service, mock_user_service
+        )
         user_risk_profile_client.delete_cloud_aliases(USER_ID, aliases)
         mock_user_risk_profile_service.delete_cloud_aliases(USER_ID, aliases)

--- a/tests/clients/test_userriskprofile.py
+++ b/tests/clients/test_userriskprofile.py
@@ -2,7 +2,7 @@ import pytest
 from tests.conftest import create_mock_response
 
 from py42.clients.userriskprofile import UserRiskProfileClient
-from py42.exceptions import Py42Error
+from py42.exceptions import Py42Error, Py42NotFoundError
 from py42.response import Py42Response
 from py42.services.userriskprofile import UserRiskProfileService
 from py42.services.users import UserService
@@ -44,7 +44,7 @@ class TestUserRiskProfileClient:
         mock_user_service.get_by_username.assert_called_once_with(USERNAME)
         mock_user_risk_profile_service.get_by_id.assert_called_once_with("1234")
 
-    def test_get_by_username_raises_py42error_with_response_when_username_not_found(
+    def test_get_by_username_raises_Py42NotFoundError_with_response_when_username_not_found(
         self, mocker, mock_user_risk_profile_service, mock_user_service
     ):
         mock_user_service.get_by_username.return_value = create_mock_response(
@@ -53,7 +53,7 @@ class TestUserRiskProfileClient:
         user_risk_profile_client = UserRiskProfileClient(
             mock_user_risk_profile_service, mock_user_service
         )
-        with pytest.raises(Py42Error) as err:
+        with pytest.raises(Py42NotFoundError) as err:
             user_risk_profile_client.get_by_username(USERNAME)
 
         assert isinstance(err.value.response, Py42Response)

--- a/tests/clients/test_userriskprofile.py
+++ b/tests/clients/test_userriskprofile.py
@@ -2,7 +2,7 @@ import pytest
 from tests.conftest import create_mock_response
 
 from py42.clients.userriskprofile import UserRiskProfileClient
-from py42.exceptions import Py42Error, Py42NotFoundError
+from py42.exceptions import Py42NotFoundError
 from py42.response import Py42Response
 from py42.services.userriskprofile import UserRiskProfileService
 from py42.services.users import UserService

--- a/tests/services/storage/test_service_factory.py
+++ b/tests/services/storage/test_service_factory.py
@@ -3,6 +3,7 @@ from requests import Session
 from tests.conftest import create_mock_response
 from tests.conftest import TEST_DEVICE_GUID
 
+from py42.exceptions import Py42Error
 from py42.services._connection import Connection
 from py42.services.devices import DeviceService
 from py42.services.storage._service_factory import StorageServiceFactory
@@ -84,7 +85,7 @@ class TestStorageServiceFactory:
         )
         response = create_mock_response(mocker, '{"backupUsage": []}')
         mock_device_service.get_by_guid.return_value = response
-        with pytest.raises(Exception):
+        with pytest.raises(Py42Error):
             factory.auto_select_destination_guid(TEST_DEVICE_GUID)
 
     def test_preservation_data_service(

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39,38,37,36}
+    py{311,310,39,38,37}
     docs
     style
 


### PR DESCRIPTION
### Description of Change ###

`sdk.userriskprofile.get_by_username()` did a full page through all users in the risk profile service until it found the given username, which can be very inefficient in large orgs. This change changes the userId lookup to use the `UserService.get_by_username()` API.


- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [N/A] Add docstrings for any new public parameters / methods / classes
