### PR TITLE
adjust page size to 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+#### Fixed
+
+- An issue where the page size of file event queries was higher than intended.
+
 ## 1.27.1 - 2024-04-25
 
 ### Changed

--- a/src/py42/settings/__init__.py
+++ b/src/py42/settings/__init__.py
@@ -9,7 +9,7 @@ proxies = None
 verify_ssl_certs = True
 
 items_per_page = 500
-security_events_per_page = 10000
+security_events_per_page = 500
 
 _custom_user_suffix = ""
 _python_version = f"{sys.version_info[0]}.{sys.version_info[1]}.{sys.version_info[2]}"


### PR DESCRIPTION
### Description of Change ###

Adjusts the default page size for file event queries to 500 (from 10000)
