### PR TITLE
feat: support urllib3 2.0 range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     zip_safe=False,
     python_requires=">=3.6, <4",
     install_requires=[
-        "urllib3>=1.26.6,<2",
+        "urllib3>=1.26.6",
         "requests>=2.25.0",
     ],
     extras_require={


### PR DESCRIPTION
### Description of Change ###

I am using `code42cli` for some benchmarking tasks, since it does not have a lot of dependencies, I can use it to compare to other CLI packages that do. Anyway, I am in an environment with urllib3 2.2.3 installed, wondering if this can be bumped here.

### Testing Procedure ###

Everything still works as-is; CI should automatically bump `urllib3` in the tests.

### PR Checklist ###
Did you remember to do the below?

- [ ] Add unit tests to verify this change
- [ ] Add an entry to CHANGELOG.md describing this change
- [ ] Add docstrings for any new public parameters / methods / classes
