### PR TITLE
Integ 2834/remove file download by path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ how a consumer would use the library (e.g. adding unit tests, updating documenta
 #### Fixed
 
 - An issue where the page size of file event queries was higher than intended.
+- An issue where streaming file by hash did not use the hash.
 
 ## 1.27.1 - 2024-04-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+#### Fixed
+
+- An issue where the page size of file event queries was higher than intended.
+
 ## 1.27.1 - 2024-04-25
 
 ### Changed

--- a/src/py42/clients/securitydata.py
+++ b/src/py42/clients/securitydata.py
@@ -167,6 +167,7 @@ class SecurityDataClient:
             version["eventId"],
             version["deviceUid"],
             version["filePath"],
+            version["fileSHA256"],
             version["versionTimestamp"],
         )
         return eds.get_file(str(token))

--- a/src/py42/services/storage/exfiltrateddata.py
+++ b/src/py42/services/storage/exfiltrateddata.py
@@ -11,7 +11,9 @@ class ExfiltratedDataService(BaseService):
         super().__init__(main_session)
         self._streaming_session = streaming_session
 
-    def get_download_token(self, event_id, device_id, file_path, timestamp):
+    def get_download_token(
+        self, event_id, device_id, file_path, file_sha256, timestamp
+    ):
         """Get EDS download token for a file.
 
         Args:
@@ -23,8 +25,10 @@ class ExfiltratedDataService(BaseService):
         Returns:
             :class:`py42.response.Py42Response`: A response containing download token for the file.
         """
-        params = "deviceUid={}&eventId={}&filePath={}&versionTimestamp={}"
-        params = params.format(device_id, event_id, quote(file_path), timestamp)
+        params = "deviceUid={}&eventId={}&filePath={}&fileSHA256={}&versionTimestamp={}"
+        params = params.format(
+            device_id, event_id, quote(file_path), file_sha256, timestamp
+        )
         resource = "file-download-token"
         headers = {"Accept": "*/*"}
         uri = f"{self._base_uri}{resource}?{params}"

--- a/src/py42/settings/__init__.py
+++ b/src/py42/settings/__init__.py
@@ -9,7 +9,7 @@ proxies = None
 verify_ssl_certs = True
 
 items_per_page = 500
-security_events_per_page = 10000
+security_events_per_page = 500
 
 _custom_user_suffix = ""
 _python_version = f"{sys.version_info[0]}.{sys.version_info[1]}.{sys.version_info[2]}"

--- a/tests/clients/test_securitydata.py
+++ b/tests/clients/test_securitydata.py
@@ -685,6 +685,7 @@ class TestSecurityClient:
             "eventid-2",
             "deviceuid-2",
             "/test/file/path-2/",
+            "testsha256-2",
             12344,
         ]
         pds_config.exfiltration_client.get_download_token.assert_called_once_with(
@@ -711,6 +712,7 @@ class TestSecurityClient:
             "eventid-2",
             "deviceuid-2",
             "/test/file/path-2/",
+            "testsha256-2",
             12344,
         ]
         pds_config.exfiltration_client.get_download_token.assert_called_once_with(
@@ -737,6 +739,7 @@ class TestSecurityClient:
             "eventid-3",
             "deviceuid-3",
             "/test/file/path-3/",
+            "testsha256-3",
             12346,
         ]
         pds_config.exfiltration_client.get_download_token.assert_called_once_with(
@@ -763,6 +766,7 @@ class TestSecurityClient:
             "eventid-3",
             "deviceuid-3",
             "/test/file/path-3/",
+            "testsha256-3",
             12346,
         ]
         pds_config.exfiltration_client.get_download_token.assert_called_once_with(

--- a/tests/clients/test_securitydata.py
+++ b/tests/clients/test_securitydata.py
@@ -799,7 +799,7 @@ class TestSecurityClient:
             "srtDir": "asc",
             "srtKey": "eventId",
             "pgToken": "",
-            "pgSize": 10000,
+            "pgSize": 500,
         }
         connection.post.assert_called_once_with(FILE_EVENT_URI, json=expected)
         assert response is successful_response
@@ -833,7 +833,7 @@ class TestSecurityClient:
             "srtDir": "asc",
             "srtKey": "eventId",
             "pgToken": "abc",
-            "pgSize": 10000,
+            "pgSize": 500,
         }
         connection.post.assert_called_once_with(FILE_EVENT_URI, json=expected)
         assert response is successful_response
@@ -861,7 +861,7 @@ class TestSecurityClient:
             "srtDir": "asc",
             "srtKey": "eventId",
             "pgToken": escaped_token,
-            "pgSize": 10000,
+            "pgSize": 500,
         }
         connection.post.assert_called_once_with(FILE_EVENT_URI, json=expected)
 
@@ -887,7 +887,7 @@ class TestSecurityClient:
             "srtDir": "asc",
             "srtKey": "eventId",
             "pgToken": escaped_token,
-            "pgSize": 10000,
+            "pgSize": 500,
         }
         connection.post.assert_called_once_with(FILE_EVENT_URI, json=expected)
 


### PR DESCRIPTION
### Description of Change ###

Updates the stream file methods in the securitydata client to use the hash when requesting a download token.

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [n/a] Add docstrings for any new public parameters / methods / classes
