### PR TITLE
add user agent prefix and update default user agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for py42 consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## Unreleased
+
+### Added
+
+- A setting to add a prefix to the user-agent.
+
 ## 1.27.2 - 2024-11-27
 
 ### Fixed

--- a/src/py42/settings/__init__.py
+++ b/src/py42/settings/__init__.py
@@ -11,16 +11,22 @@ verify_ssl_certs = True
 items_per_page = 500
 security_events_per_page = 500
 
+_custom_user_prefix = ""
 _custom_user_suffix = ""
 _python_version = f"{sys.version_info[0]}.{sys.version_info[1]}.{sys.version_info[2]}"
 
 
 def get_user_agent_string():
-    return "py42 {} python {}{}".format(
-        __version__, _python_version, _custom_user_suffix
+    return "{}py42/{} python/{}{}".format(
+        _custom_user_prefix, __version__, _python_version, _custom_user_suffix
     )
 
 
 def set_user_agent_suffix(suffix):
     global _custom_user_suffix
-    _custom_user_suffix = f" {suffix}"
+    _custom_user_suffix = f" {suffix}" if suffix else ""
+
+
+def set_user_agent_prefix(prefix):
+    global _custom_user_prefix
+    _custom_user_prefix = f"{prefix} " if prefix else ""

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -5,7 +5,7 @@ import pytest
 import py42.settings as settings
 from py42.__version__ import __version__
 
-DEFAULT_USER_AGENT_FORMAT = "py42 {0} python {1}"
+DEFAULT_USER_AGENT_FORMAT = "py42/{0} python/{1}"
 
 
 @pytest.fixture
@@ -29,3 +29,10 @@ def test_get_user_agent_returns_correct_value_after_setting_suffix(default_user_
     assert settings.get_user_agent_string() == f"{default_user_agent} example-suffix"
     # reset settings to default
     settings.set_user_agent_suffix("")
+
+
+def test_get_user_agent_returns_correct_value_after_setting_prefix(default_user_agent):
+    settings.set_user_agent_prefix("example-prefix")
+    assert settings.get_user_agent_string() == f"example-prefix {default_user_agent}"
+    # reset settings to default
+    settings.set_user_agent_prefix("")


### PR DESCRIPTION
### Description of Change ###

Updates the default user agent and adds a method to set a user agent prefix.

### PR Checklist ###
Did you remember to do the below?

- [x] Add unit tests to verify this change
- [x] Add an entry to CHANGELOG.md describing this change
- [n/a] Add docstrings for any new public parameters / methods / classes
